### PR TITLE
[Hot-fix/5-data-collect]: application 컨테이너가 DB보다 먼저 실행되는 오류 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - "3307:3306"
+      - "3306:3306"
     volumes:
       - mysql_data:/var/lib/mysql
       - ./mysql-init:/docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
       - mysql_data:/var/lib/mysql
       - ./mysql-init:/docker-entrypoint-initdb.d
@@ -62,7 +62,12 @@ services:
     env_file:
       - .env
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
+      mongo:
+        condition: service_healthy
+    restart: on-failure   # 선택(권장): DB 준비되면 자동 재시작
+    # ports, networks 등 기존 그대로
     ports:
       - "8080:8080"
     networks:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,7 +16,8 @@ spring:
 
   data:
     mongodb:
-      uri: mongodb://${MONGO_APP_USERNAME}:${MONGO_APP_PASSWORD}@mongo:27017/${MONGO_DB}?authSource=admin
+      #uri: mongodb://${MONGO_APP_USERNAME}:${MONGO_APP_PASSWORD}@mongo:27017/${MONGO_DB}?authSource=admin
+      uri: mongodb://${MONGO_APP_USERNAME}:${MONGO_APP_PASSWORD}@mongo:27017/${MONGO_DB}?authSource=${MONGO_AUTH_DB:${MONGO_DB}}
       auto-index-creation: false
 
 logging:


### PR DESCRIPTION
- docker-compose.yml에서 mysql, mongodb healthcheck 추가

# ✒️ 관련 이슈번호
> #5 


   
# 🔑 Key Changes
> 도커 컴포즈 실행시 application이 먼저 실행되어 DB의존성 주입 안됨.
- docker-compose.yml파일에서 mysql, mongodb health check 후 시작, 실패시 재실행 설정


   
# 📢 To Reviewers

