### PR TITLE
[Fix/None]: 도커 컨테이너 실행시 DB 초기화 파일 읽기 권한 부여

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,6 +45,20 @@ jobs:
           ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << 'EOF'
             echo ${{ secrets.DOCKERHUB_TOKEN }} | sudo docker login -u ${{ secrets.DOCKERHUB_ID }} --password-stdin
             cd /home/ubuntu/cleopatra
+          
+            # 권한 표준화 (mongo: .sh=755, .js=644 / mysql: .sql=644)
+            sudo find mongo-init -type d -exec chmod 755 {} \; || true
+            sudo find mongo-init -type f -name "*.sh" -exec chmod 755 {} \; || true
+            sudo find mongo-init -type f -name "*.js" -exec chmod 644 {} \; || true
+            sudo find mysql-init -type d -exec chmod 755 {} \; || true
+            sudo find mysql-init -type f -name "*.sql" -exec chmod 644 {} \; || true
+      
+            # CRLF 정리(윈도우 개행 제거) — 없으면 무시
+            sudo sed -i 's/\r$//' mongo-init/*.sh 2>/dev/null || true
+            sudo sed -i 's/\r$//' mongo-init/*.js 2>/dev/null || true
+            sudo sed -i 's/\r$//' mysql-init/*.sql 2>/dev/null || true
+          
+          
             sudo docker compose pull application
             sudo docker compose down
             sudo docker compose up -d


### PR DESCRIPTION
# ✒️ 관련 이슈번호
> #None


   
# 🔑 Key Changes
> CD 로직에서 DB 스크립트 읽기 권한 부여
- 권한 표준화 (mongo: .sh=755, .js=644 / mysql: .sql=644)
- CRLF 정리(윈도우 개행 제거) — 없으면 무시


   
# 📢 To Reviewers
