### PR TITLE
[Feat/14-data-crawl]: 네이버 블로그 본문 수집 기능 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,32 @@
+# 기존 Java 기반
 FROM openjdk:17-jdk-slim
+
+# 작업 디렉터리 설정
 WORKDIR /app
+
+# JAR 파일 복사
 COPY build/libs/*.jar app.jar
+
+# -------------------------------
+# Playwright 실행에 필요한 최소 Linux 라이브러리 설치
+# Node.js 설치
+# Chromium 설치
+# -------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl gnupg ca-certificates \
+        libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libxkbcommon0 libxcomposite1 \
+        libxdamage1 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2 \
+        libdbus-1-3 libexpat1 libglib2.0-0 \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Playwright Chromium 브라우저 설치
+RUN npx playwright install chromium
+
+# (선택) root가 아닌 사용자로 실행
+RUN adduser --disabled-password --gecos "" appuser && chown -R appuser:appuser /app
+USER appuser
+
+# 기존 Spring Boot 실행
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     // Validatoin
     implementation "org.springframework.boot:spring-boot-starter-validation"
 
+    // Crawling
+    implementation "com.microsoft.playwright:playwright:1.46.0"
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.openApi:junit-openApi-launcher'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - "3307:3306"
+      - "3306:3306"
     volumes:
       - mysql_data:/var/lib/mysql
       - ./mysql-init:/docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
       - mysql_data:/var/lib/mysql
       - ./mysql-init:/docker-entrypoint-initdb.d

--- a/src/main/java/com/likelion/cleopatra/domain/collect/controller/LinkCollectController.java
+++ b/src/main/java/com/likelion/cleopatra/domain/collect/controller/LinkCollectController.java
@@ -45,7 +45,8 @@ public class LinkCollectController {
                         """
                     )
             )
-    )@Valid @RequestBody CollectNaverBlogReq req) {
+    )@Valid @RequestBody CollectNaverBlogReq req)
+    {
         CollectResultRes res = linkCollectorService.collectNaverBlogLinks(req);
         return ApiResponse.success(res);
     }

--- a/src/main/java/com/likelion/cleopatra/domain/collect/document/ContentDoc.java
+++ b/src/main/java/com/likelion/cleopatra/domain/collect/document/ContentDoc.java
@@ -1,0 +1,37 @@
+package com.likelion.cleopatra.domain.collect.document;
+
+import com.likelion.cleopatra.domain.crwal.dto.NaverBlogCrawlRes;
+import com.likelion.cleopatra.global.common.enums.Platform;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Getter @Builder @NoArgsConstructor @AllArgsConstructor
+@Document(collection = "contents")
+@CompoundIndex(name="plat_time_idx", def="{ 'platform':1, 'crawledAt':-1 }")
+public class ContentDoc {
+    @Id private String id;              // LinkDoc.id와 동일(1:1)
+    private Platform platform;
+    private String url;
+    private String canonicalUrl;
+    private String title;
+    private String contentHtml;
+    private String contentText;
+    private Instant crawledAt;
+
+    public static ContentDoc from(LinkDoc link, NaverBlogCrawlRes r) {
+        return ContentDoc.builder()
+                .id(link.getId())
+                .platform(link.getPlatform())
+                .url(link.getUrl())
+                .canonicalUrl(link.getCanonicalUrl())
+                .title(r.title())
+                .contentHtml(r.html())
+                .contentText(r.text())
+                .crawledAt(Instant.now())
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/cleopatra/domain/collect/document/ContentDoc.java
+++ b/src/main/java/com/likelion/cleopatra/domain/collect/document/ContentDoc.java
@@ -9,9 +9,12 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
 
-@Getter @Builder @NoArgsConstructor @AllArgsConstructor
-@Document(collection = "contents")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @CompoundIndex(name="plat_time_idx", def="{ 'platform':1, 'crawledAt':-1 }")
+@Document(collection = "contents")
 public class ContentDoc {
     @Id private String id;              // LinkDoc.id와 동일(1:1)
     private Platform platform;

--- a/src/main/java/com/likelion/cleopatra/domain/collect/document/ContentDoc.java
+++ b/src/main/java/com/likelion/cleopatra/domain/collect/document/ContentDoc.java
@@ -1,6 +1,6 @@
 package com.likelion.cleopatra.domain.collect.document;
 
-import com.likelion.cleopatra.domain.crwal.dto.NaverBlogCrawlRes;
+import com.likelion.cleopatra.domain.crwal.dto.NaverBlogContentRes;
 import com.likelion.cleopatra.global.common.enums.Platform;
 import lombok.*;
 import org.springframework.data.annotation.Id;
@@ -22,7 +22,7 @@ public class ContentDoc {
     private String contentText;
     private Instant crawledAt;
 
-    public static ContentDoc from(LinkDoc link, NaverBlogCrawlRes r) {
+    public static ContentDoc from(LinkDoc link, NaverBlogContentRes r) {
         return ContentDoc.builder()
                 .id(link.getId())
                 .platform(link.getPlatform())

--- a/src/main/java/com/likelion/cleopatra/domain/collect/document/ContentDoc.java
+++ b/src/main/java/com/likelion/cleopatra/domain/collect/document/ContentDoc.java
@@ -28,9 +28,9 @@ public class ContentDoc {
                 .platform(link.getPlatform())
                 .url(link.getUrl())
                 .canonicalUrl(link.getCanonicalUrl())
-                .title(r.title())
-                .contentHtml(r.html())
-                .contentText(r.text())
+                .title(r.getTitle())
+                .contentHtml(r.getHtml())
+                .contentText(r.getText())
                 .crawledAt(Instant.now())
                 .build();
     }

--- a/src/main/java/com/likelion/cleopatra/domain/collect/document/LinkDoc.java
+++ b/src/main/java/com/likelion/cleopatra/domain/collect/document/LinkDoc.java
@@ -18,14 +18,62 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
 
+/**
+ * 정렬 기준과 인덱스 설계 메모
+ *
+ * 1) 크롤 배치 조회(핵심 경로)
+ *    - 쿼리:  platform = ? AND status = ?
+ *    - 정렬:  priority DESC, updatedAt ASC
+ *    - limit: 50
+ *    => 인덱스: { platform:1, status:1, priority:-1, updatedAt:1 }
+ *       - 이유:
+ *         * 동등 매칭 필드(platform, status)는 인덱스의 "앞부분"에 배치(선행키 프리픽스 규칙).
+ *         * 정렬 필드(priority, updatedAt)를 "뒤"에 배치하면 인덱스만으로 소트 커버 가능.
+ *         * priority는 내림차순(-1), updatedAt은 오름차순(1)으로 실제 정렬 방향과 동일하게 둔다.
+ *         * 이렇게 하면 메모리 소트 없이 상위 50건을 바로 읽는다.
+ *
+ * 2) 지역/동 최신 조회(보조 경로)
+ *    - 쿼리:  district = ? AND neighborhood = ?
+ *    - 정렬:  discoveredAt DESC
+ *    => 인덱스: { district:1, neighborhood:1, discoveredAt:-1 }
+ *       - 이유:
+ *         * 지역+동으로 필터링 후 최신순(내림차순) 정렬을 인덱스로 커버.
+ *
+ * 3) 카테고리 최신 조회(보조 경로)
+ *    - 쿼리:  categoryPrimary = ? AND categorySecondary = ?
+ *    - 정렬:  discoveredAt DESC
+ *    => 인덱스: { categoryPrimary:1, categorySecondary:1, discoveredAt:-1 }
+ *
+ * 4) 주의사항
+ *    - 인덱스는 쓰기 비용과 저장 공간을 증가시킨다. 실제 조회 패턴 3가지만 남겼다.
+ *    - 정렬 방향이 바뀌면(ASC/DESC) 인덱스 커버리지가 깨질 수 있다. 정렬을 바꾸지 말 것.
+ *    - 복합 인덱스는 "왼쪽 프리픽스"만 효과적이다.
+ *      예) {A,B,C} 인덱스는 (A), (A,B), (A,B,C) 쿼리엔 효과적이나 (B,C) 단독에겐 비효율.
+ *    - 배치 쿼리는 항상 limit(예: 50)을 걸어 네트워크 전송량과 서버 부하를 줄인다.
+ */
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @CompoundIndexes({
-        @CompoundIndex(name = "status_prio_disc_idx", def = "{'status':1, 'priority':-1, 'discoveredAt':1}"),
-        @CompoundIndex(name = "region_idx", def = "{'district':1, 'neighborhood':1, 'discoveredAt':-1}"),
-        @CompoundIndex(name = "category_idx", def = "{'categoryPrimary':1, 'categorySecondary':1, 'discoveredAt':-1}")
+        // 배치 쿼리용: findByPlatformAndStatus(..., sort = priority desc, updatedAt asc)
+        // 정렬 커버리지 확보를 위해 인덱스의 정렬 방향을 쿼리 정렬과 동일하게 맞춘다.
+        @CompoundIndex(
+                name = "plat_stat_pri_upd",
+                def = "{'platform':1, 'status':1, 'priority':-1, 'updatedAt':1}"
+        ),
+
+        // 지역/동 최신 글 탐색. 최신순(discoveredAt desc) 정렬을 인덱스로 커버.
+        @CompoundIndex(
+                name = "region_idx",
+                def = "{'district':1, 'neighborhood':1, 'discoveredAt':-1}"
+        ),
+
+        // 카테고리 최신 글 탐색. 최신순(discoveredAt desc) 정렬을 인덱스로 커버.
+        @CompoundIndex(
+                name = "category_idx",
+                def = "{'categoryPrimary':1, 'categorySecondary':1, 'discoveredAt':-1}"
+        )
 })
 @Document(collection = "links")
 public class LinkDoc {
@@ -37,25 +85,25 @@ public class LinkDoc {
     private String url;
 
     private String canonicalUrl;           // 정규화 URL
-    private Platform platform;             // NAVER, KAKAO, BAEMIN 등
+    private Platform platform;             // NAVER_BLOG, NAVER_PLACE, KAKAO_...
 
     // 태깅, 필터
     private String query;                  // 수집 검색어
     private String categoryPrimary;        // 요식업/서비스업/도매업
     private String categorySecondary;      // 예: 치킨, 한식, 일식...
 
-    private District district;             // 구 (Enum 쓰던 그대로)
-    private Neighborhood neighborhood;     // 동 (Enum 쓰던 그대로)
+    private District district;             // 구
+    private Neighborhood neighborhood;     // 동
 
     private String postdateHint;           // "yyyyMMdd" (검색 응답값)
 
     // 큐 상태
-    private LinkStatus status;             // NEW/FETCHING/...
-    @Builder.Default private Integer priority = 5; // 큐 우선순위
-    @Builder.Default private Integer tries = 0; // 실패 재시도 횟수
+    private LinkStatus status;             // NEW → FETCHING → FETCHED/PARSED/FAILED
+    @Builder.Default private Integer priority = 5; // 큐 우선순위(높을수록 먼저 처리)
+    @Builder.Default private Integer tries = 0;    // 실패 재시도 횟수
     private String lastError;              // 마지막 에러 메시지
 
-    // 워커 잠금(옵션: 여러 워커 돌릴 때 유용)
+    // 잠금(멀티 워커 대비 선택)
     private String workerId;
     private Instant lockedUntil;
 
@@ -63,13 +111,40 @@ public class LinkDoc {
     private Instant discoveredAt;          // 수집 시각
     private Instant updatedAt;             // 상태 변경 시각
 
+    // 상태 전환 도메인 메서드
+    public void markFetching(Instant now) {
+        this.status = LinkStatus.FETCHING;
+        this.tries = (this.tries == null ? 0 : this.tries) + 1;
+        this.updatedAt = now;
+    }
+
+    public void markFetched(Instant now) {
+        this.status = LinkStatus.FETCHED;
+        this.lastError = null;
+        this.updatedAt = now;
+    }
+
+    public void markFailed(Instant now, String error) {
+        this.status = LinkStatus.FAILED;
+        this.lastError = error;
+        this.updatedAt = now;
+    }
+
+    public void claim(String workerId, Instant until) {
+        this.workerId = workerId;
+        this.lockedUntil = until;
+    }
+
+
     /** 네이버 블로그 검색 아이템 → LinkDoc (id/url/canonical 포함) */
-    public static LinkDoc fromNaver(String url,
-                                    String query,
-                                    Primary primary,
-                                    Secondary secondary,
-                                    District district,
-                                    Neighborhood neighborhood) {
+    public static LinkDoc fromNaver(
+            String url,
+            String query,
+            Primary primary,
+            Secondary secondary,
+            District district,
+            Neighborhood neighborhood
+    ) {
         String canonical = UrlKey.canonicalize(url);
         String id = UrlKey.idOf(Platform.NAVER_BLOG, canonical);
         Instant now = Instant.now();

--- a/src/main/java/com/likelion/cleopatra/domain/collect/repository/ContentRepository.java
+++ b/src/main/java/com/likelion/cleopatra/domain/collect/repository/ContentRepository.java
@@ -1,0 +1,6 @@
+package com.likelion.cleopatra.domain.collect.repository;
+
+import com.likelion.cleopatra.domain.collect.document.ContentDoc;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ContentRepository extends MongoRepository<ContentDoc, String> {}

--- a/src/main/java/com/likelion/cleopatra/domain/collect/repository/LinkDocRepository.java
+++ b/src/main/java/com/likelion/cleopatra/domain/collect/repository/LinkDocRepository.java
@@ -1,0 +1,30 @@
+package com.likelion.cleopatra.domain.collect.repository;
+
+import com.likelion.cleopatra.domain.collect.document.LinkDoc;
+import com.likelion.cleopatra.domain.collect.document.LinkStatus;
+import com.likelion.cleopatra.global.common.enums.Platform;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+/**
+ * 크롤링 처리 성능
+ * - Pageable + Sort는 Mongo 서버측 정렬/제한으로 푸시다운된다.
+ * - 성능 전제: 복합 인덱스 { platform:1, status:1, priority:-1, updatedAt:1 } 필수.
+ * - explain로 확인: SORT 단계가 없어야 한다. (blocking sort 금지)
+ */
+public interface LinkDocRepository extends MongoRepository<LinkDoc, String> {
+    /**
+     * 배치 페치 쿼리
+     * query : platform=?, status=?
+     * sort  : priority DESC, updatedAt ASC
+     * limit : page.size (예: 50)
+     *
+     * 주의:
+     * - 정렬 방향이 인덱스와 다르면 인덱스 커버 정렬이 깨진다.
+     * - page 번호는 항상 0으로 고정. “다음 배치”는 updatedAt/status 변경으로 자연히 분리된다.
+     */
+    Page<LinkDoc> findByPlatformAndStatus(Platform platform, LinkStatus status, Pageable pageable);
+}

--- a/src/main/java/com/likelion/cleopatra/domain/collect/repository/LinksRepository.java
+++ b/src/main/java/com/likelion/cleopatra/domain/collect/repository/LinksRepository.java
@@ -1,8 +1,0 @@
-package com.likelion.cleopatra.domain.collect.repository;
-
-import com.likelion.cleopatra.domain.collect.document.LinkDoc;
-import org.springframework.data.mongodb.repository.MongoRepository;
-
-public interface LinksRepository extends MongoRepository<LinkDoc, String> {
-    // 필요 시 커스텀 finder 추가 가능
-}

--- a/src/main/java/com/likelion/cleopatra/domain/collect/service/LinkCollectorService.java
+++ b/src/main/java/com/likelion/cleopatra/domain/collect/service/LinkCollectorService.java
@@ -95,7 +95,7 @@ public class LinkCollectorService {
                 .setOnInsert("_id", doc.getId())
                 .setOnInsert("url", doc.getUrl())
                 .setOnInsert("canonicalUrl", doc.getCanonicalUrl())
-                .setOnInsert("openApi", doc.getPlatform())
+                .setOnInsert("platform", doc.getPlatform())
                 .setOnInsert("query", doc.getQuery())
                 .setOnInsert("categoryPrimary", doc.getCategoryPrimary())
                 .setOnInsert("categorySecondary", doc.getCategorySecondary())

--- a/src/main/java/com/likelion/cleopatra/domain/collect/service/LinkCollectorService.java
+++ b/src/main/java/com/likelion/cleopatra/domain/collect/service/LinkCollectorService.java
@@ -5,7 +5,7 @@ import com.likelion.cleopatra.domain.collect.dto.requeset.CollectNaverBlogReq;
 import com.likelion.cleopatra.domain.collect.dto.response.CollectResultRes;
 import com.likelion.cleopatra.domain.collect.exception.LinkCollectErrorCode;
 import com.likelion.cleopatra.domain.collect.exception.LinkCollectException;
-import com.likelion.cleopatra.domain.collect.repository.LinksRepository;
+import com.likelion.cleopatra.domain.collect.repository.LinkDocRepository;
 import com.likelion.cleopatra.domain.openApi.naver.dto.blog.NaverBlogSearchRes;
 import com.likelion.cleopatra.domain.openApi.naver.service.NaverApiService;
 import com.mongodb.client.result.UpdateResult;
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
 public class LinkCollectorService {
 
     private final NaverApiService naverApiService;
-    private final LinksRepository linksRepository;
+    private final LinkDocRepository linkDocRepository;
     private final MongoTemplate mongoTemplate;
 
     /**

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/controller/NaverCrawlController.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/controller/NaverCrawlController.java
@@ -1,0 +1,31 @@
+package com.likelion.cleopatra.domain.crwal.controller;
+
+
+import com.likelion.cleopatra.domain.crwal.dto.CrawlRes;
+import com.likelion.cleopatra.domain.crwal.service.NaverCrawlService;
+import com.likelion.cleopatra.global.exception.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/crawl/naver/")
+@RestController
+public class NaverCrawlController {
+
+    private final NaverCrawlService naverCrawlService;
+
+    /**
+     * 서버에서 직접 트리거: 플랫폼 NAVER_BLOG 배치 크롤
+     * 예) POST /api/crawl/naver/blog?size=50
+     */
+    @PostMapping("/blog")
+    public ApiResponse<CrawlRes> crawlBlog(@RequestParam(defaultValue = "50") int size) {
+        return ApiResponse.success(naverCrawlService.naverBlogCrawl(size));
+    }
+
+}

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/controller/NaverCrawlController.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/controller/NaverCrawlController.java
@@ -4,6 +4,9 @@ package com.likelion.cleopatra.domain.crwal.controller;
 import com.likelion.cleopatra.domain.crwal.dto.CrawlRes;
 import com.likelion.cleopatra.domain.crwal.service.NaverCrawlService;
 import com.likelion.cleopatra.global.exception.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Crawl", description = "네이버 본문 크롤링 API")
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/crawl/naver/")
@@ -19,12 +23,20 @@ public class NaverCrawlController {
 
     private final NaverCrawlService naverCrawlService;
 
-    /**
-     * 서버에서 직접 트리거: 플랫폼 NAVER_BLOG 배치 크롤
-     * 예) POST /api/crawl/naver/blog?size=50
-     */
+
     @PostMapping("/blog")
-    public ApiResponse<CrawlRes> crawlBlog(@RequestParam(defaultValue = "50") int size) {
+    @Operation(
+            summary = "네이버 블로그 본문 크롤",
+            description = """
+            큐(links)에서 네이버 블로그 링크를 가져와 본문을 수집합니다.
+            - size: 이번 배치에서 처리할 링크 개수 (기본 10)
+            예) POST /api/crawl/naver/blog?size=10
+            """
+    )
+    public ApiResponse<CrawlRes> crawlBlog(
+            @Parameter(description = "이번 배치에서 처리할 링크 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size)
+    {
         return ApiResponse.success(naverCrawlService.naverBlogCrawl(size));
     }
 

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/dto/CrawlRes.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/dto/CrawlRes.java
@@ -1,0 +1,14 @@
+package com.likelion.cleopatra.domain.crwal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CrawlRes {
+    private int picked;
+    private int success;
+    private int failed;
+}

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/dto/NaverBlogContentRes.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/dto/NaverBlogContentRes.java
@@ -13,7 +13,7 @@ import lombok.ToString;
 @Getter
 @AllArgsConstructor
 @ToString
-public class NaverBlogCrawlRes {
+public class NaverBlogContentRes {
 
     /** 블로그 글 제목 */
     private final String title;

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/dto/NaverBlogCrawlRes.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/dto/NaverBlogCrawlRes.java
@@ -1,0 +1,27 @@
+package com.likelion.cleopatra.domain.crwal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * 네이버 블로그 크롤링 결과 DTO
+ * - 제목
+ * - HTML 원문
+ * - 가공된 텍스트
+ */
+@Getter
+@AllArgsConstructor
+@ToString
+public class NaverBlogCrawlRes {
+
+    /** 블로그 글 제목 */
+    private final String title;
+
+    /** 본문 HTML */
+    private final String html;
+
+    /** HTML에서 추출한 순수 텍스트 */
+    private final String text;
+
+}

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/exception/CrawlErrorCode.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/exception/CrawlErrorCode.java
@@ -1,0 +1,45 @@
+package com.likelion.cleopatra.domain.crwal.exception;
+
+import com.likelion.cleopatra.global.exception.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CrawlErrorCode implements ErrorCode {
+
+    /* 입력/사전 검증 */
+    INVALID_URL(400, "잘못된 URL"),
+    UNSUPPORTED_PLATFORM(400, "지원하지 않는 플랫폼"),
+
+    /* 네트워크/탐색 */
+    NAVIGATION_TIMEOUT(504, "페이지 로딩 제한시간 초과"),
+    NETWORK_IO_ERROR(502, "네트워크/연결 오류"),
+    NOT_FOUND(404, "대상 문서 없음"),
+    ACCESS_FORBIDDEN(403, "접근 권한 없음"),
+    RATE_LIMITED(429, "요청 제한"),
+
+    /* 안티봇/차단 */
+    CAPTCHA_OR_BOT_DETECTED(403, "캡차/봇 탐지 차단"),
+    PAGE_BLOCKED(451, "정책에 의한 접근 차단"),
+
+    /* 추출/파싱 */
+    SELECTOR_MAIN_BODY_NOT_FOUND(422, "본문 컨테이너 선택자 불일치"),
+    EXTRACT_TITLE_FAILED(424, "제목 추출 실패"),
+    CONTENT_EMPTY(422, "본문이 비어 있음"),
+    CONTENT_TOO_SHORT(422, "본문 길이 부족"),
+    SCRIPT_EVAL_ERROR(500, "스크립트 실행 실패"),
+
+    /* 동시성/중복 */
+    CLAIM_LOCKED(423, "작업 잠금 상태"),
+    DUPLICATE_URL(409, "중복 URL"),
+
+    /* 저장 */
+    STORAGE_SAVE_FAILED(500, "콘텐츠 저장 실패"),
+
+    /* 기타 */
+    UNKNOWN(500, "알 수 없는 크롤링 오류");
+
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/exception/CrawlErrorCode.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/exception/CrawlErrorCode.java
@@ -11,6 +11,7 @@ public enum CrawlErrorCode implements ErrorCode {
     /* 입력/사전 검증 */
     INVALID_URL(400, "잘못된 URL"),
     UNSUPPORTED_PLATFORM(400, "지원하지 않는 플랫폼"),
+    NO_LINKS_TO_CRAWL(404, "크롤링할 링크 없음"),
 
     /* 네트워크/탐색 */
     NAVIGATION_TIMEOUT(504, "페이지 로딩 제한시간 초과"),

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/exception/CrawlException.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/exception/CrawlException.java
@@ -1,7 +1,11 @@
 package com.likelion.cleopatra.domain.crwal.exception;
 
-public class CrawlException extends RuntimeException {
-    public CrawlException(String message) {
-        super(message);
-    }
+import com.likelion.cleopatra.global.exception.CleopatraException;
+import lombok.Getter;
+
+public class CrawlException extends CleopatraException {
+    public CrawlException(CrawlErrorCode errorCode) { super(errorCode); }
+
+    public CrawlErrorCode crawlErrorCode() { return (CrawlErrorCode) super.getErrorCode(); }
+
 }

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/exception/CrawlException.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/exception/CrawlException.java
@@ -1,0 +1,7 @@
+package com.likelion.cleopatra.domain.crwal.exception;
+
+public class CrawlException extends RuntimeException {
+    public CrawlException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/exception/failure/CrawlFailure.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/exception/failure/CrawlFailure.java
@@ -1,0 +1,5 @@
+package com.likelion.cleopatra.domain.crwal.exception.failure;
+
+import com.likelion.cleopatra.domain.crwal.exception.CrawlErrorCode;
+
+public record CrawlFailure(CrawlErrorCode code, String message, String cause) {}

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/exception/failure/FailureClassifier.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/exception/failure/FailureClassifier.java
@@ -1,0 +1,50 @@
+package com.likelion.cleopatra.domain.crwal.exception.failure;
+
+import com.likelion.cleopatra.domain.crwal.exception.CrawlErrorCode;
+import com.likelion.cleopatra.domain.crwal.exception.CrawlException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FailureClassifier {
+
+    public CrawlFailure classify(Throwable t) {
+        Throwable r = root(t);
+        String msg = safe(r.getMessage());
+        String low = msg.toLowerCase();
+
+        if (t instanceof CrawlException ce)
+            return new CrawlFailure(ce.crawlErrorCode() , ce.getMessage(), clip(msg, 300));
+
+        if (t instanceof com.microsoft.playwright.TimeoutError)
+            return new CrawlFailure(CrawlErrorCode.NAVIGATION_TIMEOUT, "페이지 로딩 제한시간 초과", clip(msg, 300));
+
+        if (r instanceof java.net.UnknownHostException || low.contains("err_name_not_resolved"))
+            return new CrawlFailure(CrawlErrorCode.NETWORK_IO_ERROR, "DNS 해석 실패", clip(msg, 300));
+        if (r instanceof java.net.SocketTimeoutException || low.contains("err_connection_timed_out"))
+            return new CrawlFailure(CrawlErrorCode.NETWORK_IO_ERROR, "연결 타임아웃", clip(msg, 300));
+        if (r instanceof java.net.ConnectException || low.contains("err_connection_reset"))
+            return new CrawlFailure(CrawlErrorCode.NETWORK_IO_ERROR, "연결 실패", clip(msg, 300));
+
+        if (low.contains("429") || low.contains("rate limit"))
+            return new CrawlFailure(CrawlErrorCode.RATE_LIMITED, "요청 제한", clip(msg, 300));
+        if (low.contains("403") || low.contains("forbidden"))
+            return new CrawlFailure(CrawlErrorCode.ACCESS_FORBIDDEN, "접근 권한 없음", clip(msg, 300));
+        if (low.contains("404") || low.contains("not found"))
+            return new CrawlFailure(CrawlErrorCode.NOT_FOUND, "대상 문서 없음", clip(msg, 300));
+        if (low.contains("captcha") || low.contains("bot"))
+            return new CrawlFailure(CrawlErrorCode.CAPTCHA_OR_BOT_DETECTED, "캡차/봇 탐지 차단", clip(msg, 300));
+
+        if (low.contains("selector") || low.contains("se-main-container"))
+            return new CrawlFailure(CrawlErrorCode.SELECTOR_MAIN_BODY_NOT_FOUND, "본문 컨테이너 선택자 불일치", clip(msg, 300));
+        if (low.contains("empty"))
+            return new CrawlFailure(CrawlErrorCode.CONTENT_EMPTY, "본문이 비어 있음", clip(msg, 300));
+
+        return new CrawlFailure(CrawlErrorCode.UNKNOWN, "알 수 없는 크롤링 오류", clip(msg, 300));
+    }
+
+    private Throwable root(Throwable t){ while(t.getCause()!=null && t.getCause()!=t) t=t.getCause(); return t; }
+    private String safe(String s){ return s==null? "" : s.replaceAll("\\s+"," ").trim(); }
+    private String clip(String s,int n){ return s.length()<=n? s : s.substring(0,n); }
+}

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/impl/NaverBlogCrawler.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/impl/NaverBlogCrawler.java
@@ -1,6 +1,6 @@
 package com.likelion.cleopatra.domain.crwal.impl;
 
-import com.likelion.cleopatra.domain.crwal.dto.NaverBlogCrawlRes;
+import com.likelion.cleopatra.domain.crwal.dto.NaverBlogContentRes;
 import com.likelion.cleopatra.domain.crwal.selector.NaverSelectors;
 import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.Locator;
@@ -19,7 +19,7 @@ public class NaverBlogCrawler {
 
     private final BrowserContext context;
 
-    public NaverBlogCrawlRes crawl(String originalUrl) {
+    public NaverBlogContentRes crawl(String originalUrl) {
         final String url = toMobileUrl(originalUrl);
         final Page page = context.newPage();
         try {
@@ -64,7 +64,7 @@ public class NaverBlogCrawler {
             log.debug("NAVER_BLOG result url={} title='{}' htmlLen={} textLen={} sample=\"{}\"",
                     url, compact(title), html.length(), text.length(), sample(text, 160));
 
-            return new NaverBlogCrawlRes(title, html, text);
+            return new NaverBlogContentRes(title, html, text);
         } finally {
             page.close(); // 자원 정리, 예외는 위로 전파
         }

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/impl/NaverBlogCrawler.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/impl/NaverBlogCrawler.java
@@ -5,11 +5,14 @@ import com.likelion.cleopatra.domain.crwal.selector.NaverSelectors;
 import com.microsoft.playwright.*;
 import com.microsoft.playwright.options.LoadState;
 import com.microsoft.playwright.options.WaitUntilState;
+import com.microsoft.playwright.options.WaitForSelectorState;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function; // [ADD]
+import java.util.List;             // [ADD]
 
 @RequiredArgsConstructor
 @Component
@@ -22,70 +25,67 @@ public class NaverBlogCrawler {
         final String url = toMobileUrl(originalUrl);
         final Page page = context.newPage();
         try {
-
-            // [ADD] 기본 타임아웃 현실화 (팝업/렌더 지연에 대비)
+            // [ADD] 기본 타임아웃 현실화
             page.setDefaultTimeout(10_000);
             page.setDefaultNavigationTimeout(15_000);
 
-            // 리소스 최소 차단: media만
+            // [CHG] 텍스트만 필요 → image/media/font 차단
             page.route("**/*", r -> {
                 String t = r.request().resourceType();
-                if ("media".equals(t)) r.abort(); else r.resume();
+                if ("media".equals(t) || "image".equals(t) || "font".equals(t)) r.abort(); else r.resume();
             });
 
             // 랜덤 뷰포트 + 짧은 지터
             page.setViewportSize(360 + rnd(0, 80), 740 + rnd(0, 180));
             page.navigate(url, new Page.NavigateOptions().setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
-            page.waitForLoadState(LoadState.NETWORKIDLE); // [ADD] 네트워크 안정화까지 대기
+            page.waitForLoadState(LoadState.NETWORKIDLE);
             page.waitForTimeout(rnd(250, 900));
 
-            // [CHG] 선택적 클릭을 “best-effort”로. 실패해도 전파하지 않음
-            clickIfPresent(page, "button:has-text('닫기'), .btn_close, .u_skip", 1200);
-            clickIfPresent(page, "button:has-text('더보기')", 1200);
-            clickIfPresent(page, ".se-more-button, .se-more-text", 1200);
-            clickIfPresent(page, "a:has-text('원문보기')", 1500);
+            // [ADD] 더보기/원문보기 등 모든 토글 시도(페이지/iframe 모두)
+            expandAll(page);
 
-            // [CHG] 본문 컨테이너 필수 확보: 모바일 우선 → 레거시 → iframe(mainFrame) 순
+            // [ADD] 문단 렌더 안정화(문단 노드가 늦게 붙는 케이스)
+            page.waitForSelector("p.se-text-paragraph, " + NaverSelectors.LEGACY_BODY,
+                    new Page.WaitForSelectorOptions().setTimeout(2000).setState(WaitForSelectorState.ATTACHED));
+
+            // [CHG] 본문 컨테이너 확보(모바일 → 레거시 → mainFrame)
             Locator body = requireBody(page);
 
             String title = extractTitle(page).trim();
             String html = body.innerHTML();
-            String text = body.innerText().trim();
+            // [FIX] 전체 텍스트 대신 "텍스트성 문단"만 DOM 순서대로 수집
+            String text = extractFullText(body);
 
-            // 너무 짧으면 경량 스크롤 1회 후 재추출
+            // 너무 짧으면 한 번 더 스크롤 후 재수집
             if (text.length() < 50) {
                 autoScrollLight(page);
                 html = body.innerHTML();
-                text = body.innerText().trim();
+                text = extractFullText(body); // [FIX] 동일 로직 재사용
             }
 
-            if (html.isBlank())
-                throw new IllegalStateException("본문 선택자 미일치");
+            if (html.isBlank() || text.isBlank())
+                throw new IllegalStateException("본문 선택자/텍스트 추출 실패");
 
-            // 배포 최소 로그
             log.info("NAVER_BLOG crawled url={} textLen={}", url, text.length());
-            // 개발 상세 로그
             log.debug("NAVER_BLOG result url={} title='{}' htmlLen={} textLen={} sample=\"{}\"",
                     url, compact(title), html.length(), text.length(), sample(text, 160));
 
             return new NaverBlogContentRes(title, html, text);
         } finally {
-            page.close(); // 자원 정리, 예외는 위로 전파
+            page.close();
         }
     }
 
     // --- helpers ---
 
     private Locator requireBody(Page page) {
-        // 1) 모바일 신형
         Locator se = page.locator(NaverSelectors.SE_MAIN);
         if (se.count() > 0) return se.first();
 
-        // 2) 모바일/데스크톱 레거시
         Locator legacy = page.locator(NaverSelectors.LEGACY_BODY);
         if (legacy.count() > 0) return legacy.first();
 
-        // 3) [ADD] 데스크톱 구형 iframe(mainFrame) 대응
+        // [ADD] 데스크톱 구형 iframe(mainFrame)
         Frame main = null;
         for (Frame f : page.frames()) {
             if ("mainFrame".equals(f.name())) { main = f; break; }
@@ -97,7 +97,6 @@ public class NaverBlogCrawler {
             if (fLegacy.count() > 0) return fLegacy.first();
         }
 
-        // 마지막 짧은 대기 후 재확인
         page.waitForTimeout(300);
         if (se.count() > 0) return se.first();
         if (legacy.count() > 0) return legacy.first();
@@ -107,11 +106,112 @@ public class NaverBlogCrawler {
             Locator fLegacy = main.locator(NaverSelectors.LEGACY_BODY);
             if (fLegacy.count() > 0) return fLegacy.first();
         }
-
         throw new IllegalStateException("본문 컨테이너 없음");
     }
 
-    // [CHG] 클릭 실패는 무시(TimeoutError/PlaywrightException), 보이는 경우만 클릭
+    // [ADD] 본문 토글을 반복적으로 전부 펼침(가능한 한)
+    private void expandAll(Page p) {
+        // 1) 페이지 전역
+        for (int round = 0; round < 4; round++) {
+            int clicked = clickAllOnce(p::locator, NaverSelectors.EXPANDERS); // [FIX] 메서드 레퍼런스 사용
+            if (clicked == 0) break;
+            p.waitForTimeout(180);
+        }
+        // 2) mainFrame 내부도 동일 적용
+        Frame main = null;
+        for (Frame f : p.frames()) {
+            if ("mainFrame".equals(f.name())) { main = f; break; }
+        }
+        if (main != null) {
+            for (int round = 0; round < 4; round++) {
+                int clicked = clickAllOnce(main::locator, NaverSelectors.EXPANDERS); // [FIX]
+                if (clicked == 0) break;
+                p.waitForTimeout(180);
+            }
+        }
+    }
+
+    // [FIX] Page/Frame 공통: locator 펑션을 받아 처리
+    private int clickAllOnce(Function<String, Locator> finder, String[] selectors) {
+        int clicks = 0;
+        for (String sel : selectors) {
+            Locator list = finder.apply(sel);
+            int count = list.count();
+            for (int i = 0; i < count && i < 20; i++) { // 과도한 클릭 방지
+                Locator el = list.nth(i);
+                try {
+                    if (el.isVisible()) {
+                        el.click(new Locator.ClickOptions().setTimeout(1500));
+                        clicks++;
+                    }
+                } catch (PlaywrightException e) {
+                    log.debug("expand ignore sel={} #{} msg={}", sel, i, compact(e.getMessage()));
+                }
+            }
+        }
+        return clicks;
+    }
+
+    // [FIX] "텍스트성 문단"만 DOM 순서대로 수집 + 비텍스트 조상(이미지/갤러리 등) 제외
+    private String extractFullText(Locator body) {
+        String js =
+                "root => {" +
+                        "  const textSel = `" + NaverSelectors.SE_TEXT_NODES + "`;" +             // [ADD]
+                        "  const nonTextAncSel = `" + NaverSelectors.SE_NON_TEXT_COMPONENTS + "`;" + // [ADD]
+                        "  const nodes = Array.from(root.querySelectorAll(textSel));" +
+                        "  const parts = [];" +
+                        "  for (const n of nodes) {" +
+                        "    if (n.closest(nonTextAncSel)) continue;" + // [ADD] 비텍스트 컴포넌트 하위 배제
+                        "    const t = (n.innerText || '').trim();" +
+                        "    if (t) parts.push(t);" +
+                        "  }" +
+                        "  return parts;" +
+                        "}";
+
+        @SuppressWarnings("unchecked")
+        List<String> parts = (List<String>)body.evaluate(js); // [ADD]
+
+        StringBuilder sb = new StringBuilder();
+        for (String part : parts) {
+            String cleaned = cleanParagraph(part);
+            if (isThrowaway(cleaned)) continue; // [ADD]
+            if (sb.length() > 0) sb.append("\n\n");
+            sb.append(cleaned);
+        }
+
+        if (sb.length() > 0) return sb.toString();
+
+        // [CHG] 폴백: 컴포넌트 매칭이 적을 때 컨테이너 전체 텍스트 사용
+        return stripPlaceholders(cleanParagraph(body.innerText()));
+    }
+
+    // [ADD] 이미지/플레이스홀더/제로폭 문자 제거 규칙
+    private static boolean isThrowaway(String s) {
+        if (s == null) return true;
+        String t = s
+                .replace("\u200B", "")
+                .replace("\u200C", "")
+                .replace("\u200D", "")
+                .replace("\uFEFF", "")
+                .trim();
+        if (t.isBlank()) return true;
+        if (t.equals("존재하지 않는 이미지입니다.")) return true;
+        return false;
+    }
+
+    // [ADD] 이미지/광고/공백성 플레이스홀더 제거
+    private static String stripPlaceholders(String s) {
+        if (s == null) return "";
+        String t = s
+                .replace("\u200B", "")
+                .replace("\u200C", "")
+                .replace("\u200D", "")
+                .replace("\uFEFF", "");
+        t = t.replaceAll("(?m)^\\s*존재하지 않는 이미지입니다\\.?\\s*$\\n?", "");
+        return t.trim();
+    }
+
+    // 선택적 클릭(남겨둠)
     private void clickIfPresent(Page p, String sel, int timeoutMs) {
         Locator list = p.locator(sel);
         if (list.count() == 0) return;
@@ -119,12 +219,12 @@ public class NaverBlogCrawler {
         try {
             if (first.isVisible()) {
                 first.click(new Locator.ClickOptions().setTimeout(timeoutMs));
-                p.waitForTimeout(150); // [ADD] 클릭 후 안정화
+                p.waitForTimeout(150);
             } else {
-                log.debug("click skip sel={} reason=not-visible", sel); // [ADD]
+                log.debug("click skip sel={} reason=not-visible", sel);
             }
         } catch (PlaywrightException e) {
-            log.debug("click ignore sel={} msg={}", sel, compact(e.getMessage())); // [ADD]
+            log.debug("click ignore sel={} msg={}", sel, compact(e.getMessage()));
         }
     }
 
@@ -151,18 +251,24 @@ public class NaverBlogCrawler {
         return page.title();
     }
 
-    private static int rnd(int a, int b) {
-        return ThreadLocalRandom.current().nextInt(a, b + 1);
-    }
+    private static int rnd(int a, int b) { return ThreadLocalRandom.current().nextInt(a, b + 1); }
     private static String sample(String s, int n) {
         if (s == null) return "";
         String one = s.replaceAll("\\s+", " ").trim();
         return one.substring(0, Math.min(one.length(), n));
     }
-    private static String compact(String s) {
-        return s == null ? "" : s.replaceAll("\\s+", " ").trim();
-    }
+    private static String compact(String s) { return s == null ? "" : s.replaceAll("\\s+", " ").trim(); }
+
     private String toMobileUrl(String url) {
         return url.replace("://blog.naver.com/", "://m.blog.naver.com/");
+    }
+
+    // [CHG] 문단 클린업 강화
+    private static String cleanParagraph(String s) {
+        if (s == null) return "";
+        String t = s.replace("\u00A0", " ");
+        t = t.replaceAll("[ \\t\\f\\v]+", " ");
+        t = t.replaceAll("\\n{3,}", "\n\n");
+        return t.trim();
     }
 }

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/impl/NaverBlogCrawler.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/impl/NaverBlogCrawler.java
@@ -1,0 +1,106 @@
+package com.likelion.cleopatra.domain.crwal.impl;
+
+import com.likelion.cleopatra.domain.crwal.dto.NaverBlogCrawlRes;
+import com.likelion.cleopatra.domain.crwal.selector.NaverSelectors;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.WaitUntilState;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 네이버는 PC 페이지가 iframe으로 본문을 넣는 경우가 있어 모바일 URL로 변환해 파싱한다.
+ * 도커에서 실행 시 Playwright 런타임 라이브러리(폰트, libnss 등)가 필요할 수 있다. 초기엔 로컬에서 검증 후 컨테이너 의존성 추가.
+ * 크롤링 속도 조절이 필요하면 page.waitForTimeout()을 소폭 삽입하거나 배치 크기를 줄인다.
+ */
+@RequiredArgsConstructor
+@Component
+public class NaverBlogCrawler {
+
+    private final BrowserContext context;
+
+
+    public NaverBlogCrawlRes crawl(String originalUrl) {
+        String url = toMobileUrl(originalUrl);
+
+        Page page = context.newPage(); // crawl exception 생성 후 예외 처리 로직 추가
+
+        page.navigate(url, new Page.NavigateOptions().setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
+
+        // 간헐적 팝업 제거
+        page.locator("button:has-text('닫기'), .btn_close, .u_skip").first().click(new Locator.ClickOptions().setTrial(true).setTimeout(1000));//.catchException(_e -> {});
+
+        // 본문 대기
+        Locator se = page.locator(NaverSelectors.SE_MAIN);
+        Locator legacy = page.locator(NaverSelectors.LEGACY_BODY);
+
+        // 스크롤 유도 후 재시도
+        if (se.count() == 0 && legacy.count() == 0) {
+            // 스크롤 유도 후 재시도
+            page.mouse().wheel(0, 2000);
+            page.waitForTimeout(800);
+        }
+
+        String title = extractTitle(page);
+        String html = extractHtml(page);
+        String text = extractTextFromHtml(page, html);
+        if (html == null || html.isBlank()) {
+            throw new IllegalStateException("본문 선택자 미일치");
+        }
+        return new NaverBlogCrawlRes(title, html, text);
+    }
+
+
+
+
+    private String toMobileUrl(String url) {
+        return url.replace("://blog.naver.com/", "://m.blog.naver.com/");
+    }
+
+    private String extractTitle(Page page) {
+        // 여러 후보 중 우선 매칭
+        for (String sel : NaverSelectors.TITLE.split(",")) {
+            Locator l = page.locator(sel.trim());
+            if (l.count() > 0) {
+                String t = l.first().innerText().trim();
+                if (!t.isBlank()) return t;
+            }
+        }
+        return page.title();
+    }
+
+    private String extractHtml(Page page) {
+        Locator se = page.locator(NaverSelectors.SE_MAIN);
+        if (se.count() > 0) return se.first().innerHTML();
+
+        Locator legacy = page.locator(NaverSelectors.LEGACY_BODY);
+        if (legacy.count() > 0) return legacy.first().innerHTML();
+
+        // 최후 수단: og:description만
+        Locator og = page.locator("meta[property='og:description']");
+        if (og.count() > 0) return "<p>" + og.first().getAttribute("content") + "</p>";
+        return null;
+    }
+
+    private String extractTextFromHtml(Page page, String html) {
+        // 페이지에서 DOM API로 텍스트만 추출
+        // se-text 블록 우선
+        Locator blocks = page.locator(NaverSelectors.SE_TEXT_BLOCKS);
+        if (blocks.count() > 0) {
+            List<String> lines = blocks.allInnerTexts();
+            return String.join("\n\n", lines).trim();
+        }
+        // 그 외는 전체 컨테이너의 innerText
+        Locator se = page.locator(NaverSelectors.SE_MAIN);
+        if (se.count() > 0) return se.first().innerText().trim();
+
+        Locator legacy = page.locator(NaverSelectors.LEGACY_BODY);
+        if (legacy.count() > 0) return legacy.first().innerText().trim();
+
+        return "";
+    }
+
+}

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/selector/NaverSelectors.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/selector/NaverSelectors.java
@@ -1,0 +1,12 @@
+package com.likelion.cleopatra.domain.crwal.selector;
+
+public final class NaverSelectors {
+    private NaverSelectors() {}
+    // 스마트에디터3 모바일 뷰
+    public static final String SE_MAIN = "div.se-main-container";
+    public static final String SE_TEXT_BLOCKS = "div.se-main-container .se-component.se-text";
+    // 구버전 본문
+    public static final String LEGACY_BODY = "#postViewArea, #postContent, #postViewArea > div";
+    // 제목 후보
+    public static final String TITLE = "h3.se_textarea, .pcol1, .se_title, meta[property='og:title']";
+}

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/selector/NaverSelectors.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/selector/NaverSelectors.java
@@ -2,11 +2,41 @@ package com.likelion.cleopatra.domain.crwal.selector;
 
 public final class NaverSelectors {
     private NaverSelectors() {}
-    // 스마트에디터3 모바일 뷰
+
+    // 스마트에디터3 모바일 뷰(본문 컨테이너)
     public static final String SE_MAIN = "div.se-main-container";
-    public static final String SE_TEXT_BLOCKS = "div.se-main-container .se-component.se-text";
+
+    // [ADD] 실제 텍스트 노드들(하이픈 표기, DOM 순서 유지)
+    public static final String SE_TEXT_NODES =
+            "p.se-text-paragraph," +
+                    "h1.se-text-h1, h2.se-text-h2, h3.se-text-h3," +
+                    "li.se-list-item, blockquote.se-text-quote, pre.se-code, figcaption.se-caption";
+
+    // [ADD] 텍스트성 컴포넌트(보조용, 폴백 추출 시 사용 가능)
+    public static final String SE_TEXTUAL_BLOCKS =
+            "div.se-main-container .se-component.se-text," +
+                    "div.se-main-container .se-component.se-quotation," +
+                    "div.se-main-container .se-component.se-heading," +
+                    "div.se-main-container .se-component .se_textarea," +
+                    "div.se-main-container .se-component .se_paragraph";
+
+    // [ADD] 텍스트 제외할 컴포넌트(조상 기준으로 필터링)
+    public static final String SE_NON_TEXT_COMPONENTS =
+            ".se-component.se-image, .se-component.se-gallery, .se-component.se-video," +
+                    ".se-component.se-map, .se-component.se-oglink, .se-component.se-product," +
+                    ".se-component.se-attach, .se-component.se-sticker";
+
     // 구버전 본문
     public static final String LEGACY_BODY = "#postViewArea, #postContent, #postViewArea > div";
+
     // 제목 후보
     public static final String TITLE = "h3.se_textarea, .pcol1, .se_title, meta[property='og:title']";
+
+    // [ADD] 더보기/원문보기/접기해제 등 확장 버튼들
+    public static final String[] EXPANDERS = new String[] {
+            "button:has-text('더보기')",
+            ".se-more-button", ".se-more-text", ".se-module-more", ".se-more-less a",
+            "a:has-text('원문보기')",
+            ".postbtn_more", ".btn_unfold", ".btn_fold"
+    };
 }

--- a/src/main/java/com/likelion/cleopatra/domain/crwal/service/NaverCrawlService.java
+++ b/src/main/java/com/likelion/cleopatra/domain/crwal/service/NaverCrawlService.java
@@ -1,0 +1,89 @@
+package com.likelion.cleopatra.domain.crwal.service;
+
+import com.likelion.cleopatra.domain.collect.document.ContentDoc;
+import com.likelion.cleopatra.domain.collect.document.LinkDoc;
+import com.likelion.cleopatra.domain.collect.document.LinkStatus;
+import com.likelion.cleopatra.domain.collect.repository.ContentRepository;
+import com.likelion.cleopatra.domain.collect.repository.LinkDocRepository;
+import com.likelion.cleopatra.domain.crwal.impl.NaverBlogCrawler;
+import com.likelion.cleopatra.global.common.enums.Platform;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class NaverCrawlService {
+
+    private final LinkDocRepository linkDocRepository;
+    private final ContentRepository contentRepository;
+    private final NaverBlogCrawler naverBlogCrawler;
+    // 필요 시 동시 처리: @Qualifier("crawlerExecutor") ThreadPoolTaskExecutor exec; 현재 순차로 충분
+
+    /**
+     * 실무 메모
+     * - 정렬/제한은 DB가 수행. 애플리케이션 메모리 정렬 없음.
+     * - sort 키와 인덱스(plat_stat_pri_upd) 일치가 핵심.
+     * - 배치 크기(50)는 네트워크/CPU 절충값. QPS에 맞춰 조정.
+     * - 상태머신: NEW → FETCHING → FETCHED|FAILED
+     * - 단일 인스턴스 전제. 멀티 인스턴스면 findAndModify로 “원자적 클레임” 패턴을 쓴다.
+     */
+
+    // @Scheduled(fixedDelay = 60_000)
+    public void naverBlogCrawl() {
+        var sort = Sort.by(Sort.Order.desc("priority"), Sort.Order.asc("updatedAt"));
+        var page = PageRequest.of(0, 50, sort);
+
+        var batch = linkDocRepository.findByPlatformAndStatus(Platform.NAVER_BLOG, LinkStatus.NEW, page).getContent();
+        if (batch.isEmpty()) {
+            log.info("CRAWL skip platform=NAVER_BLOG reason=empty-batch");
+            return;
+        }
+
+        // FETCHING 마킹
+        var now = Instant.now();
+        batch.forEach(d -> d.markFetching(now));
+        linkDocRepository.saveAll(batch);
+
+        // 최소 구현: 순차 처리(해커톤용). 필요하면 exec.submit(processOneSafe)로 교체.
+        for (var doc : batch) processOneSafe(doc);
+    }
+
+    private void processOneSafe(LinkDoc doc) {
+        final String url = doc.getUrl();
+        try {
+            var res = naverBlogCrawler.crawl(url);                 // 실패 시 예외
+            contentRepository.save(ContentDoc.from(doc, res));  // contents 컬렉션 저장
+
+            // 성공 마킹
+            doc.markFetched(Instant.now());
+            linkDocRepository.save(doc);
+
+            // 쿼리 확인
+            log.info("CRAWL ok platform=NAVER_BLOG url={} textLen={}", url, len(res.getText()));
+            log.debug("CRAWL detail url={} title='{}' htmlLen={} textLen={} sample=\"{}\"",
+                    url, compact(res.getTitle()), len(res.getHtml()), len(res.getText()), sample(res.getText(), 160));
+
+        } catch (Exception e) {
+
+            // 실패시 처리
+            doc.markFailed(Instant.now(), e.getClass().getSimpleName() + ":" + e.getMessage());
+            linkDocRepository.save(doc);
+
+            log.info("CRAWL fail platform=NAVER_BLOG url={} reason={}", url, e.getClass().getSimpleName());
+            log.debug("CRAWL fail detail url={} msg={}", url, e.getMessage());
+        }
+    }
+
+    // 유틸
+    private int len(String s){ return s==null?0:s.length(); }
+    private String compact(String s){ return s==null?"":s.replaceAll("\\s+"," ").trim(); }
+    private String sample(String s,int n){ if(s==null)return""; var t=compact(s); return t.substring(0, Math.min(t.length(), n)); }
+}

--- a/src/main/java/com/likelion/cleopatra/global/config/crawler/PlayWrightConfig.java
+++ b/src/main/java/com/likelion/cleopatra/global/config/crawler/PlayWrightConfig.java
@@ -1,0 +1,27 @@
+package com.likelion.cleopatra.global.config.crawler;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Playwright;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PlayWrightConfig {
+
+    @Bean(destroyMethod = "close")
+    public Playwright playwright() {return Playwright.create(); }
+
+    @Bean(destroyMethod = "close")
+    public Browser browser(Playwright playwright) {
+        return playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+    }
+
+    @Bean
+    public BrowserContext browserContext(Browser browser) {
+        return browser.newContext(new Browser.NewContextOptions()
+                .setUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1")
+                .setViewportSize(390, 844));
+    }
+}

--- a/src/main/resources/application-crawler.yml
+++ b/src/main/resources/application-crawler.yml
@@ -1,0 +1,12 @@
+crawler:
+  retry:
+    max-attempts: 3
+    delay-ms: 1000
+  wait:
+    default-time-ms: 2000
+  targets:
+    - site: nate_news
+      url: https://news.nate.com
+
+  schedule:
+    interval: 100000000000  # 10초

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,3 +27,9 @@ logging:
     root: info
     org.springframework.data.mongodb.core.MongoTemplate: INFO
     org.mongodb.driver: WARN
+
+springdoc:
+  packages-to-scan: com.likelion.cleopatra
+  paths-to-match: /api/**
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,4 +2,4 @@ spring:
   config:
     import: optional:file:.env[.properties]
   profiles:
-    active: dev, webclient
+    active: prod, webclient

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,4 +2,4 @@ spring:
   config:
     import: optional:file:.env[.properties]
   profiles:
-    active: pod, webclient
+    active: dev, webclient


### PR DESCRIPTION
# ✒️ 관련 이슈번호
> #14 


   
# 🔑 Key Changes
> 수집된 링크를 바탕으로 본문 내용 수집 후 MongoDB에 저장
- 패키지 구조 수정
- PlayWright 의존성 추가 후 설정
- 블로그 본문 크롤링 기능 구현
- 크롤링 관련 Exception, ErrorCode 설정 후 구성
- 크롤링 시 중간에 오류 발생시 프로그램 중단시키지 않고, lastErrorMessage에 남기도록 구조 설계
- 크롤링 관련 스웨거 설정
- 로컬환경, 로컬 도커환경 테스트 후 배포 준비 완료


   
# 📢 To Reviewers
> 이후 MongoDB 구조 개선 및 코드 리팩터링 예정
