### PR TITLE
[Chore/18-report]: 에러 수정 및 디버그 콘솔 형식 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,3 +65,16 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+/** 파라미터 이름 보존(AOP에서 메서드 파라미터명 로깅용) */
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += ['-parameters']
+    options.encoding = 'UTF-8'
+}
+
+/** Playwright 브라우저 미리 설치 (권장: Docker 빌드 단계에서 실행) */
+tasks.register('playwrightInstall') {
+    doLast {
+        com.microsoft.playwright.CLI.main(['install'] as String[])
+    }
+}

--- a/cleopatra.incomeConsumption.json
+++ b/cleopatra.incomeConsumption.json
@@ -1,0 +1,20825 @@
+[{
+  "_id": {
+    "$oid": "68a85c43287170962935118f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110670",
+  "adstrdName": "창신1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2393308"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2670133000"
+  },
+  "food": {
+    "$numberDecimal": "456883000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "154739000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "5999000"
+  },
+  "medical": {
+    "$numberDecimal": "638566000"
+  },
+  "transport": {
+    "$numberDecimal": "3363000"
+  },
+  "education": {
+    "$numberDecimal": "83347000"
+  },
+  "entertainment": {
+    "$numberDecimal": "88203000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "311938000"
+  },
+  "other": {
+    "$numberDecimal": "130258000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "796837000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351190"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110700",
+  "adstrdName": "숭인1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2868519"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "910727000"
+  },
+  "food": {
+    "$numberDecimal": "475416000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "3608000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "3678000"
+  },
+  "medical": {
+    "$numberDecimal": "168861000"
+  },
+  "transport": {
+    "$numberDecimal": "9599000"
+  },
+  "education": {
+    "$numberDecimal": "18723000"
+  },
+  "entertainment": {
+    "$numberDecimal": "10022000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "8484000"
+  },
+  "other": {
+    "$numberDecimal": "47469000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "164867000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351191"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140570",
+  "adstrdName": "필동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3033044"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5148307000"
+  },
+  "food": {
+    "$numberDecimal": "809804000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "81821000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "65585000"
+  },
+  "medical": {
+    "$numberDecimal": "429581000"
+  },
+  "transport": {
+    "$numberDecimal": "185771000"
+  },
+  "education": {
+    "$numberDecimal": "173685000"
+  },
+  "entertainment": {
+    "$numberDecimal": "314588000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "342130000"
+  },
+  "other": {
+    "$numberDecimal": "68014000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2677328000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351192"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140590",
+  "adstrdName": "광희동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3229604"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "10547836000"
+  },
+  "food": {
+    "$numberDecimal": "1399304000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "3241919000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "78737000"
+  },
+  "medical": {
+    "$numberDecimal": "758841000"
+  },
+  "transport": {
+    "$numberDecimal": "84235000"
+  },
+  "education": {
+    "$numberDecimal": "17326000"
+  },
+  "entertainment": {
+    "$numberDecimal": "171686000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1811690000"
+  },
+  "other": {
+    "$numberDecimal": "580945000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2403153000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351193"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170700",
+  "adstrdName": "보광동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2545653"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1046075000"
+  },
+  "food": {
+    "$numberDecimal": "423456000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "8920000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "15985000"
+  },
+  "medical": {
+    "$numberDecimal": "148394000"
+  },
+  "transport": {
+    "$numberDecimal": "16877000"
+  },
+  "education": {
+    "$numberDecimal": "39916000"
+  },
+  "entertainment": {
+    "$numberDecimal": "26687000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "25704000"
+  },
+  "other": {
+    "$numberDecimal": "53452000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "286684000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351194"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200535",
+  "adstrdName": "왕십리도선동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4015131"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8083563000"
+  },
+  "food": {
+    "$numberDecimal": "1606578000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "203550000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "55836000"
+  },
+  "medical": {
+    "$numberDecimal": "1988218000"
+  },
+  "transport": {
+    "$numberDecimal": "427748000"
+  },
+  "education": {
+    "$numberDecimal": "370387000"
+  },
+  "entertainment": {
+    "$numberDecimal": "260361000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "484098000"
+  },
+  "other": {
+    "$numberDecimal": "466742000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2220045000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351195"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200540",
+  "adstrdName": "마장동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3021967"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4867973000"
+  },
+  "food": {
+    "$numberDecimal": "2588764000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "4382000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "23321000"
+  },
+  "medical": {
+    "$numberDecimal": "163460000"
+  },
+  "transport": {
+    "$numberDecimal": "691647000"
+  },
+  "education": {
+    "$numberDecimal": "73169000"
+  },
+  "entertainment": {
+    "$numberDecimal": "58536000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "137344000"
+  },
+  "other": {
+    "$numberDecimal": "359344000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "768006000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351196"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200590",
+  "adstrdName": "금호1가동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4010011"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1301859000"
+  },
+  "food": {
+    "$numberDecimal": "427842000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "8601000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "3006000"
+  },
+  "medical": {
+    "$numberDecimal": "262581000"
+  },
+  "transport": {
+    "$numberDecimal": "4817000"
+  },
+  "education": {
+    "$numberDecimal": "221704000"
+  },
+  "entertainment": {
+    "$numberDecimal": "28713000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "81226000"
+  },
+  "other": {
+    "$numberDecimal": "44559000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "218810000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351197"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200645",
+  "adstrdName": "옥수동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4836487"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3791155000"
+  },
+  "food": {
+    "$numberDecimal": "1311923000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "66788000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "7944000"
+  },
+  "medical": {
+    "$numberDecimal": "649150000"
+  },
+  "transport": {
+    "$numberDecimal": "45745000"
+  },
+  "education": {
+    "$numberDecimal": "280538000"
+  },
+  "entertainment": {
+    "$numberDecimal": "28747000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "254094000"
+  },
+  "other": {
+    "$numberDecimal": "218480000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "927746000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351198"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200720",
+  "adstrdName": "송정동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2566462"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "824501000"
+  },
+  "food": {
+    "$numberDecimal": "236247000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "19671000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "23040000"
+  },
+  "medical": {
+    "$numberDecimal": "101641000"
+  },
+  "transport": {
+    "$numberDecimal": "246727000"
+  },
+  "education": {
+    "$numberDecimal": "6545000"
+  },
+  "entertainment": {
+    "$numberDecimal": "15111000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "53421000"
+  },
+  "other": {
+    "$numberDecimal": "12297000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "109801000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351199"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200790",
+  "adstrdName": "용답동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2484354"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "15612427000"
+  },
+  "food": {
+    "$numberDecimal": "842055000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "64854000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "7511000"
+  },
+  "medical": {
+    "$numberDecimal": "2878722000"
+  },
+  "transport": {
+    "$numberDecimal": "1869963000"
+  },
+  "education": {
+    "$numberDecimal": "39835000"
+  },
+  "entertainment": {
+    "$numberDecimal": "92405000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "272121000"
+  },
+  "other": {
+    "$numberDecimal": "8470929000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1074032000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935119a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215710",
+  "adstrdName": "화양동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2470026"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "19466000000"
+  },
+  "food": {
+    "$numberDecimal": "2108439000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "592854000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "33763000"
+  },
+  "medical": {
+    "$numberDecimal": "3074143000"
+  },
+  "transport": {
+    "$numberDecimal": "1019044000"
+  },
+  "education": {
+    "$numberDecimal": "247933000"
+  },
+  "entertainment": {
+    "$numberDecimal": "1765686000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1380400000"
+  },
+  "other": {
+    "$numberDecimal": "701378000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "8542360000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935119b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215730",
+  "adstrdName": "군자동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2604535"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5890205000"
+  },
+  "food": {
+    "$numberDecimal": "1443766000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "38214000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "120439000"
+  },
+  "medical": {
+    "$numberDecimal": "1286070000"
+  },
+  "transport": {
+    "$numberDecimal": "185295000"
+  },
+  "education": {
+    "$numberDecimal": "111711000"
+  },
+  "entertainment": {
+    "$numberDecimal": "223236000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "289758000"
+  },
+  "other": {
+    "$numberDecimal": "259797000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1931919000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935119c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215780",
+  "adstrdName": "능동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2846023"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5744545000"
+  },
+  "food": {
+    "$numberDecimal": "698808000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "29659000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "349426000"
+  },
+  "medical": {
+    "$numberDecimal": "1122871000"
+  },
+  "transport": {
+    "$numberDecimal": "1232236000"
+  },
+  "education": {
+    "$numberDecimal": "71030000"
+  },
+  "entertainment": {
+    "$numberDecimal": "169126000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "282519000"
+  },
+  "other": {
+    "$numberDecimal": "58459000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1730411000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935119d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215830",
+  "adstrdName": "자양2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2999213"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3776501000"
+  },
+  "food": {
+    "$numberDecimal": "847945000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "32269000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "53591000"
+  },
+  "medical": {
+    "$numberDecimal": "716951000"
+  },
+  "transport": {
+    "$numberDecimal": "657211000"
+  },
+  "education": {
+    "$numberDecimal": "205754000"
+  },
+  "entertainment": {
+    "$numberDecimal": "131945000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "173540000"
+  },
+  "other": {
+    "$numberDecimal": "222462000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "734833000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935119e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230600",
+  "adstrdName": "답십리1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3538405"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4356263000"
+  },
+  "food": {
+    "$numberDecimal": "1378500000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "69401000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "164366000"
+  },
+  "medical": {
+    "$numberDecimal": "644475000"
+  },
+  "transport": {
+    "$numberDecimal": "39675000"
+  },
+  "education": {
+    "$numberDecimal": "520883000"
+  },
+  "entertainment": {
+    "$numberDecimal": "61735000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "299888000"
+  },
+  "other": {
+    "$numberDecimal": "106434000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1070906000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935119f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260590",
+  "adstrdName": "상봉2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2575432"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9685450000"
+  },
+  "food": {
+    "$numberDecimal": "2084252000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "184360000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "59715000"
+  },
+  "medical": {
+    "$numberDecimal": "1325661000"
+  },
+  "transport": {
+    "$numberDecimal": "627036000"
+  },
+  "education": {
+    "$numberDecimal": "67000000"
+  },
+  "entertainment": {
+    "$numberDecimal": "696124000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "818463000"
+  },
+  "other": {
+    "$numberDecimal": "404795000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3418044000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511a0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260600",
+  "adstrdName": "중화1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2518956"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1679805000"
+  },
+  "food": {
+    "$numberDecimal": "669962000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "41286000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "35170000"
+  },
+  "medical": {
+    "$numberDecimal": "426658000"
+  },
+  "transport": {
+    "$numberDecimal": "51469000"
+  },
+  "education": {
+    "$numberDecimal": "125111000"
+  },
+  "entertainment": {
+    "$numberDecimal": "11646000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "40472000"
+  },
+  "other": {
+    "$numberDecimal": "82820000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "195211000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511a1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290525",
+  "adstrdName": "성북동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3470748"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3504850000"
+  },
+  "food": {
+    "$numberDecimal": "826083000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "112656000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "20611000"
+  },
+  "medical": {
+    "$numberDecimal": "483772000"
+  },
+  "transport": {
+    "$numberDecimal": "15611000"
+  },
+  "education": {
+    "$numberDecimal": "323880000"
+  },
+  "entertainment": {
+    "$numberDecimal": "20416000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "189204000"
+  },
+  "other": {
+    "$numberDecimal": "290770000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1221847000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511a2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290610",
+  "adstrdName": "보문동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3162623"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2996240000"
+  },
+  "food": {
+    "$numberDecimal": "560379000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "44478000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "13718000"
+  },
+  "medical": {
+    "$numberDecimal": "208475000"
+  },
+  "transport": {
+    "$numberDecimal": "1314096000"
+  },
+  "education": {
+    "$numberDecimal": "67962000"
+  },
+  "entertainment": {
+    "$numberDecimal": "33497000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "123653000"
+  },
+  "other": {
+    "$numberDecimal": "60493000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "569489000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511a3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305575",
+  "adstrdName": "삼각산동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3734477"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2560712000"
+  },
+  "food": {
+    "$numberDecimal": "989427000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "24965000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "18509000"
+  },
+  "medical": {
+    "$numberDecimal": "313948000"
+  },
+  "transport": {
+    "$numberDecimal": "1229000"
+  },
+  "education": {
+    "$numberDecimal": "339369000"
+  },
+  "entertainment": {
+    "$numberDecimal": "21749000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "104658000"
+  },
+  "other": {
+    "$numberDecimal": "165810000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "581048000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511a4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320513",
+  "adstrdName": "창3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2229423"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1380581000"
+  },
+  "food": {
+    "$numberDecimal": "494279000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "22908000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "13113000"
+  },
+  "medical": {
+    "$numberDecimal": "157585000"
+  },
+  "transport": {
+    "$numberDecimal": "13242000"
+  },
+  "education": {
+    "$numberDecimal": "48469000"
+  },
+  "entertainment": {
+    "$numberDecimal": "60630000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "58124000"
+  },
+  "other": {
+    "$numberDecimal": "68810000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "443421000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511a5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320515",
+  "adstrdName": "창5동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3298026"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6182039000"
+  },
+  "food": {
+    "$numberDecimal": "1119290000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "154979000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "83499000"
+  },
+  "medical": {
+    "$numberDecimal": "1660681000"
+  },
+  "transport": {
+    "$numberDecimal": "214723000"
+  },
+  "education": {
+    "$numberDecimal": "792413000"
+  },
+  "entertainment": {
+    "$numberDecimal": "141791000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "319013000"
+  },
+  "other": {
+    "$numberDecimal": "255017000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1440633000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511a6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350570",
+  "adstrdName": "월계2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2728093"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1802523000"
+  },
+  "food": {
+    "$numberDecimal": "671437000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "22217000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "3634000"
+  },
+  "medical": {
+    "$numberDecimal": "222210000"
+  },
+  "transport": {
+    "$numberDecimal": "0"
+  },
+  "education": {
+    "$numberDecimal": "461870000"
+  },
+  "entertainment": {
+    "$numberDecimal": "15692000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "47528000"
+  },
+  "other": {
+    "$numberDecimal": "89029000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "268906000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511a7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350595",
+  "adstrdName": "공릉1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2786137"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "13338883000"
+  },
+  "food": {
+    "$numberDecimal": "3477743000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "159258000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "148919000"
+  },
+  "medical": {
+    "$numberDecimal": "2888145000"
+  },
+  "transport": {
+    "$numberDecimal": "1520543000"
+  },
+  "education": {
+    "$numberDecimal": "221434000"
+  },
+  "entertainment": {
+    "$numberDecimal": "230769000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "695365000"
+  },
+  "other": {
+    "$numberDecimal": "452369000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3544338000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511a8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380570",
+  "adstrdName": "대조동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2535013"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7872671000"
+  },
+  "food": {
+    "$numberDecimal": "1794832000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "158210000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "126294000"
+  },
+  "medical": {
+    "$numberDecimal": "2205398000"
+  },
+  "transport": {
+    "$numberDecimal": "58512000"
+  },
+  "education": {
+    "$numberDecimal": "328332000"
+  },
+  "entertainment": {
+    "$numberDecimal": "204129000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "518474000"
+  },
+  "other": {
+    "$numberDecimal": "317084000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2161406000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511a9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380590",
+  "adstrdName": "응암2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3510245"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1812919000"
+  },
+  "food": {
+    "$numberDecimal": "620486000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "17796000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "22185000"
+  },
+  "medical": {
+    "$numberDecimal": "190676000"
+  },
+  "transport": {
+    "$numberDecimal": "216811000"
+  },
+  "education": {
+    "$numberDecimal": "305040000"
+  },
+  "entertainment": {
+    "$numberDecimal": "32043000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "54451000"
+  },
+  "other": {
+    "$numberDecimal": "81551000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "271880000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511aa"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380600",
+  "adstrdName": "응암3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2360910"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8366850000"
+  },
+  "food": {
+    "$numberDecimal": "4052190000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "184334000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "32635000"
+  },
+  "medical": {
+    "$numberDecimal": "796734000"
+  },
+  "transport": {
+    "$numberDecimal": "475498000"
+  },
+  "education": {
+    "$numberDecimal": "178730000"
+  },
+  "entertainment": {
+    "$numberDecimal": "406055000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "189661000"
+  },
+  "other": {
+    "$numberDecimal": "177244000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1873769000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ab"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410700",
+  "adstrdName": "남가좌2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3237719"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5146574000"
+  },
+  "food": {
+    "$numberDecimal": "1846395000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "60546000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "30496000"
+  },
+  "medical": {
+    "$numberDecimal": "605503000"
+  },
+  "transport": {
+    "$numberDecimal": "198163000"
+  },
+  "education": {
+    "$numberDecimal": "416425000"
+  },
+  "entertainment": {
+    "$numberDecimal": "91535000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "326749000"
+  },
+  "other": {
+    "$numberDecimal": "247218000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1323544000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ac"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440555",
+  "adstrdName": "아현동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5237419"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6211264000"
+  },
+  "food": {
+    "$numberDecimal": "2044842000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "75665000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "30527000"
+  },
+  "medical": {
+    "$numberDecimal": "1413548000"
+  },
+  "transport": {
+    "$numberDecimal": "16468000"
+  },
+  "education": {
+    "$numberDecimal": "330592000"
+  },
+  "entertainment": {
+    "$numberDecimal": "43926000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "506969000"
+  },
+  "other": {
+    "$numberDecimal": "419071000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1329656000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ad"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440710",
+  "adstrdName": "연남동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2980162"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8413679000"
+  },
+  "food": {
+    "$numberDecimal": "1665287000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "321637000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "48458000"
+  },
+  "medical": {
+    "$numberDecimal": "156689000"
+  },
+  "transport": {
+    "$numberDecimal": "29970000"
+  },
+  "education": {
+    "$numberDecimal": "78959000"
+  },
+  "entertainment": {
+    "$numberDecimal": "347292000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "266210000"
+  },
+  "other": {
+    "$numberDecimal": "290847000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "5208330000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ae"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470540",
+  "adstrdName": "목4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3426858"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8413679000"
+  },
+  "food": {
+    "$numberDecimal": "2207965000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "52627000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "106859000"
+  },
+  "medical": {
+    "$numberDecimal": "865482000"
+  },
+  "transport": {
+    "$numberDecimal": "13141000"
+  },
+  "education": {
+    "$numberDecimal": "547392000"
+  },
+  "entertainment": {
+    "$numberDecimal": "86002000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "271555000"
+  },
+  "other": {
+    "$numberDecimal": "122225000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "991633000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511af"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470600",
+  "adstrdName": "신월5동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2615553"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3305664000"
+  },
+  "food": {
+    "$numberDecimal": "462286000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "20966000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "84464000"
+  },
+  "medical": {
+    "$numberDecimal": "391662000"
+  },
+  "transport": {
+    "$numberDecimal": "972187000"
+  },
+  "education": {
+    "$numberDecimal": "123890000"
+  },
+  "entertainment": {
+    "$numberDecimal": "93207000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "241316000"
+  },
+  "other": {
+    "$numberDecimal": "208560000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "707126000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511b0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470611",
+  "adstrdName": "신월7동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2343943"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2038196000"
+  },
+  "food": {
+    "$numberDecimal": "1009471000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "29784000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "33939000"
+  },
+  "medical": {
+    "$numberDecimal": "140449000"
+  },
+  "transport": {
+    "$numberDecimal": "81787000"
+  },
+  "education": {
+    "$numberDecimal": "69722000"
+  },
+  "entertainment": {
+    "$numberDecimal": "61840000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "159722000"
+  },
+  "other": {
+    "$numberDecimal": "64425000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "387057000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511b1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470650",
+  "adstrdName": "신정4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2609700"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "10009084000"
+  },
+  "food": {
+    "$numberDecimal": "1905960000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "319365000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "105328000"
+  },
+  "medical": {
+    "$numberDecimal": "2477004000"
+  },
+  "transport": {
+    "$numberDecimal": "361965000"
+  },
+  "education": {
+    "$numberDecimal": "634292000"
+  },
+  "entertainment": {
+    "$numberDecimal": "340628000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "644410000"
+  },
+  "other": {
+    "$numberDecimal": "403409000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2816723000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511b2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470670",
+  "adstrdName": "신정6동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5384412"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2777243000"
+  },
+  "food": {
+    "$numberDecimal": "663444000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "23818000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "0"
+  },
+  "medical": {
+    "$numberDecimal": "175173000"
+  },
+  "transport": {
+    "$numberDecimal": "30555000"
+  },
+  "education": {
+    "$numberDecimal": "1318345000"
+  },
+  "entertainment": {
+    "$numberDecimal": "19367000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "209208000"
+  },
+  "other": {
+    "$numberDecimal": "80063000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "257270000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511b3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500590",
+  "adstrdName": "화곡본동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2398795"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5996784000"
+  },
+  "food": {
+    "$numberDecimal": "1955233000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "62739000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "94162000"
+  },
+  "medical": {
+    "$numberDecimal": "980845000"
+  },
+  "transport": {
+    "$numberDecimal": "906164000"
+  },
+  "education": {
+    "$numberDecimal": "203657000"
+  },
+  "entertainment": {
+    "$numberDecimal": "153805000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "202787000"
+  },
+  "other": {
+    "$numberDecimal": "132577000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1304815000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511b4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500591",
+  "adstrdName": "화곡6동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3040513"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7460895000"
+  },
+  "food": {
+    "$numberDecimal": "1303086000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "77976000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "31216000"
+  },
+  "medical": {
+    "$numberDecimal": "1676890000"
+  },
+  "transport": {
+    "$numberDecimal": "1347018000"
+  },
+  "education": {
+    "$numberDecimal": "50280000"
+  },
+  "entertainment": {
+    "$numberDecimal": "622325000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "492501000"
+  },
+  "other": {
+    "$numberDecimal": "156784000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1702819000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511b5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530540",
+  "adstrdName": "구로3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2888444"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.79E+12"
+  },
+  "food": {
+    "$numberDecimal": "2165246000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "406294000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "222551000"
+  },
+  "medical": {
+    "$numberDecimal": "4435646000"
+  },
+  "transport": {
+    "$numberDecimal": "369062000"
+  },
+  "education": {
+    "$numberDecimal": "377823000"
+  },
+  "entertainment": {
+    "$numberDecimal": "628150000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1.77E+12"
+  },
+  "other": {
+    "$numberDecimal": "539148000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "5492950000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511b6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530550",
+  "adstrdName": "구로4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2617060"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5522567000"
+  },
+  "food": {
+    "$numberDecimal": "2195838000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "220122000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "42807000"
+  },
+  "medical": {
+    "$numberDecimal": "819998000"
+  },
+  "transport": {
+    "$numberDecimal": "89313000"
+  },
+  "education": {
+    "$numberDecimal": "184914000"
+  },
+  "entertainment": {
+    "$numberDecimal": "200032000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "282757000"
+  },
+  "other": {
+    "$numberDecimal": "147353000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1339433000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511b7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530740",
+  "adstrdName": "개봉1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2805757"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4746819000"
+  },
+  "food": {
+    "$numberDecimal": "1877467000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "57716000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "91991000"
+  },
+  "medical": {
+    "$numberDecimal": "552469000"
+  },
+  "transport": {
+    "$numberDecimal": "668290000"
+  },
+  "education": {
+    "$numberDecimal": "114988000"
+  },
+  "entertainment": {
+    "$numberDecimal": "86983000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "202158000"
+  },
+  "other": {
+    "$numberDecimal": "234415000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "860342000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511b8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11545640",
+  "adstrdName": "독산4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2255044"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1931745000"
+  },
+  "food": {
+    "$numberDecimal": "379503000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "20919000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "9444000"
+  },
+  "medical": {
+    "$numberDecimal": "332519000"
+  },
+  "transport": {
+    "$numberDecimal": "167241000"
+  },
+  "education": {
+    "$numberDecimal": "38867000"
+  },
+  "entertainment": {
+    "$numberDecimal": "165259000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "125798000"
+  },
+  "other": {
+    "$numberDecimal": "92221000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "599974000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511b9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560535",
+  "adstrdName": "영등포동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3570107"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "31210974000"
+  },
+  "food": {
+    "$numberDecimal": "4213303000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "1949958000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "945262000"
+  },
+  "medical": {
+    "$numberDecimal": "5884233000"
+  },
+  "transport": {
+    "$numberDecimal": "394809000"
+  },
+  "education": {
+    "$numberDecimal": "321511000"
+  },
+  "entertainment": {
+    "$numberDecimal": "1212239000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "5736342000"
+  },
+  "other": {
+    "$numberDecimal": "1186420000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "9366897000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ba"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560585",
+  "adstrdName": "도림동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3031484"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2434597000"
+  },
+  "food": {
+    "$numberDecimal": "1122883000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "9641000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "35578000"
+  },
+  "medical": {
+    "$numberDecimal": "115961000"
+  },
+  "transport": {
+    "$numberDecimal": "149636000"
+  },
+  "education": {
+    "$numberDecimal": "87839000"
+  },
+  "entertainment": {
+    "$numberDecimal": "50460000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "171345000"
+  },
+  "other": {
+    "$numberDecimal": "98754000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "592500000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511bb"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560660",
+  "adstrdName": "신길4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2717791"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "977052000"
+  },
+  "food": {
+    "$numberDecimal": "367114000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "14249000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "11531000"
+  },
+  "medical": {
+    "$numberDecimal": "217183000"
+  },
+  "transport": {
+    "$numberDecimal": "3184000"
+  },
+  "education": {
+    "$numberDecimal": "77689000"
+  },
+  "entertainment": {
+    "$numberDecimal": "21211000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "19948000"
+  },
+  "other": {
+    "$numberDecimal": "48735000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "196208000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511bc"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650570",
+  "adstrdName": "반포2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "6812331"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1864719000"
+  },
+  "food": {
+    "$numberDecimal": "387626000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "12346000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "48000"
+  },
+  "medical": {
+    "$numberDecimal": "243493000"
+  },
+  "transport": {
+    "$numberDecimal": "11774000"
+  },
+  "education": {
+    "$numberDecimal": "460788000"
+  },
+  "entertainment": {
+    "$numberDecimal": "0"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "75069000"
+  },
+  "other": {
+    "$numberDecimal": "108893000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "564682000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511bd"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650600",
+  "adstrdName": "방배1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4069239"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6131943000"
+  },
+  "food": {
+    "$numberDecimal": "1929068000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "82302000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "86667000"
+  },
+  "medical": {
+    "$numberDecimal": "1466445000"
+  },
+  "transport": {
+    "$numberDecimal": "23223000"
+  },
+  "education": {
+    "$numberDecimal": "336769000"
+  },
+  "entertainment": {
+    "$numberDecimal": "109605000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "272071000"
+  },
+  "other": {
+    "$numberDecimal": "455896000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1369897000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511be"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680750",
+  "adstrdName": "수서동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3847379"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.37E+11"
+  },
+  "food": {
+    "$numberDecimal": "879352000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "88849000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "27860000"
+  },
+  "medical": {
+    "$numberDecimal": "2258788000"
+  },
+  "transport": {
+    "$numberDecimal": "19123838000"
+  },
+  "education": {
+    "$numberDecimal": "53978000"
+  },
+  "entertainment": {
+    "$numberDecimal": "65520000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1.13E+11"
+  },
+  "other": {
+    "$numberDecimal": "135460000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1491486000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511bf"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710510",
+  "adstrdName": "풍납1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3011150"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1462999000"
+  },
+  "food": {
+    "$numberDecimal": "472270000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "5832000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "174454000"
+  },
+  "medical": {
+    "$numberDecimal": "68539000"
+  },
+  "transport": {
+    "$numberDecimal": "15932000"
+  },
+  "education": {
+    "$numberDecimal": "68067000"
+  },
+  "entertainment": {
+    "$numberDecimal": "30109000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "52622000"
+  },
+  "other": {
+    "$numberDecimal": "263136000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "312038000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511c0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710532",
+  "adstrdName": "거여2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3033238"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3306888000"
+  },
+  "food": {
+    "$numberDecimal": "1008725000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "30085000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "21750000"
+  },
+  "medical": {
+    "$numberDecimal": "829210000"
+  },
+  "transport": {
+    "$numberDecimal": "22254000"
+  },
+  "education": {
+    "$numberDecimal": "122896000"
+  },
+  "entertainment": {
+    "$numberDecimal": "61720000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "278241000"
+  },
+  "other": {
+    "$numberDecimal": "149505000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "782502000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511c1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740610",
+  "adstrdName": "천호2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2749741"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "74406137000"
+  },
+  "food": {
+    "$numberDecimal": "1348444000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "144108000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "177294000"
+  },
+  "medical": {
+    "$numberDecimal": "2766867000"
+  },
+  "transport": {
+    "$numberDecimal": "312571000"
+  },
+  "education": {
+    "$numberDecimal": "290744000"
+  },
+  "entertainment": {
+    "$numberDecimal": "607173000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "64735482000"
+  },
+  "other": {
+    "$numberDecimal": "699901000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3323553000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511c2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740640",
+  "adstrdName": "성내1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3438376"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5731700000"
+  },
+  "food": {
+    "$numberDecimal": "911362000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "186839000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "113205000"
+  },
+  "medical": {
+    "$numberDecimal": "1696607000"
+  },
+  "transport": {
+    "$numberDecimal": "508614000"
+  },
+  "education": {
+    "$numberDecimal": "186664000"
+  },
+  "entertainment": {
+    "$numberDecimal": "65065000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "297867000"
+  },
+  "other": {
+    "$numberDecimal": "289442000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1476035000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511c3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110630",
+  "adstrdName": "종로5?6가동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2531450"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "10034245000"
+  },
+  "food": {
+    "$numberDecimal": "724319000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "415608000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "169418000"
+  },
+  "medical": {
+    "$numberDecimal": "3918101000"
+  },
+  "transport": {
+    "$numberDecimal": "18001000"
+  },
+  "education": {
+    "$numberDecimal": "48029000"
+  },
+  "entertainment": {
+    "$numberDecimal": "276481000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1571911000"
+  },
+  "other": {
+    "$numberDecimal": "27008000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2865369000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511c4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110710",
+  "adstrdName": "숭인2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2607311"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2277129000"
+  },
+  "food": {
+    "$numberDecimal": "546402000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "211928000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "27972000"
+  },
+  "medical": {
+    "$numberDecimal": "287582000"
+  },
+  "transport": {
+    "$numberDecimal": "2557000"
+  },
+  "education": {
+    "$numberDecimal": "32781000"
+  },
+  "entertainment": {
+    "$numberDecimal": "77332000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "165081000"
+  },
+  "other": {
+    "$numberDecimal": "111212000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "814282000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511c5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140645",
+  "adstrdName": "청구동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3566241"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1362525000"
+  },
+  "food": {
+    "$numberDecimal": "303842000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "184504000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "32506000"
+  },
+  "medical": {
+    "$numberDecimal": "92215000"
+  },
+  "transport": {
+    "$numberDecimal": "997000"
+  },
+  "education": {
+    "$numberDecimal": "156922000"
+  },
+  "entertainment": {
+    "$numberDecimal": "18193000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "94640000"
+  },
+  "other": {
+    "$numberDecimal": "101769000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "376937000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511c6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140665",
+  "adstrdName": "동화동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3621349"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1564224000"
+  },
+  "food": {
+    "$numberDecimal": "589149000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "68498000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "19667000"
+  },
+  "medical": {
+    "$numberDecimal": "205220000"
+  },
+  "transport": {
+    "$numberDecimal": "9526000"
+  },
+  "education": {
+    "$numberDecimal": "54774000"
+  },
+  "entertainment": {
+    "$numberDecimal": "25142000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "126011000"
+  },
+  "other": {
+    "$numberDecimal": "52570000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "413667000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511c7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200580",
+  "adstrdName": "응봉동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3858472"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "452770000"
+  },
+  "food": {
+    "$numberDecimal": "206296000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "17634000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "0"
+  },
+  "medical": {
+    "$numberDecimal": "46483000"
+  },
+  "transport": {
+    "$numberDecimal": "5288000"
+  },
+  "education": {
+    "$numberDecimal": "40811000"
+  },
+  "entertainment": {
+    "$numberDecimal": "3087000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "10793000"
+  },
+  "other": {
+    "$numberDecimal": "20839000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "101539000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511c8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215840",
+  "adstrdName": "자양3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4353416"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4693056000"
+  },
+  "food": {
+    "$numberDecimal": "1142693000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "318251000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "18699000"
+  },
+  "medical": {
+    "$numberDecimal": "579740000"
+  },
+  "transport": {
+    "$numberDecimal": "243684000"
+  },
+  "education": {
+    "$numberDecimal": "365974000"
+  },
+  "entertainment": {
+    "$numberDecimal": "17189000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "313594000"
+  },
+  "other": {
+    "$numberDecimal": "300929000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1392303000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511c9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215860",
+  "adstrdName": "구의2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2948328"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4774771000"
+  },
+  "food": {
+    "$numberDecimal": "1388792000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "136544000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "47854000"
+  },
+  "medical": {
+    "$numberDecimal": "634119000"
+  },
+  "transport": {
+    "$numberDecimal": "71117000"
+  },
+  "education": {
+    "$numberDecimal": "197082000"
+  },
+  "entertainment": {
+    "$numberDecimal": "104016000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "481504000"
+  },
+  "other": {
+    "$numberDecimal": "206426000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1507317000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ca"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230570",
+  "adstrdName": "전농2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3136080"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1643764000"
+  },
+  "food": {
+    "$numberDecimal": "418349000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "54209000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "8082000"
+  },
+  "medical": {
+    "$numberDecimal": "279166000"
+  },
+  "transport": {
+    "$numberDecimal": "11216000"
+  },
+  "education": {
+    "$numberDecimal": "169022000"
+  },
+  "entertainment": {
+    "$numberDecimal": "16948000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "158586000"
+  },
+  "other": {
+    "$numberDecimal": "56458000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "471728000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511cb"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230610",
+  "adstrdName": "답십리2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3049260"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5154591000"
+  },
+  "food": {
+    "$numberDecimal": "1425554000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "36144000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "68961000"
+  },
+  "medical": {
+    "$numberDecimal": "962002000"
+  },
+  "transport": {
+    "$numberDecimal": "970164000"
+  },
+  "education": {
+    "$numberDecimal": "175266000"
+  },
+  "entertainment": {
+    "$numberDecimal": "120035000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "281345000"
+  },
+  "other": {
+    "$numberDecimal": "224252000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "890868000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511cc"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230705",
+  "adstrdName": "청량리동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2860315"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4701440000"
+  },
+  "food": {
+    "$numberDecimal": "1007305000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "149618000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "69057000"
+  },
+  "medical": {
+    "$numberDecimal": "1070371000"
+  },
+  "transport": {
+    "$numberDecimal": "426120000"
+  },
+  "education": {
+    "$numberDecimal": "74080000"
+  },
+  "entertainment": {
+    "$numberDecimal": "124068000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "232705000"
+  },
+  "other": {
+    "$numberDecimal": "145261000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1402855000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511cd"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230720",
+  "adstrdName": "휘경1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2722774"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3840971000"
+  },
+  "food": {
+    "$numberDecimal": "1187191000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "22813000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "239192000"
+  },
+  "medical": {
+    "$numberDecimal": "556235000"
+  },
+  "transport": {
+    "$numberDecimal": "49057000"
+  },
+  "education": {
+    "$numberDecimal": "161486000"
+  },
+  "entertainment": {
+    "$numberDecimal": "84825000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "313197000"
+  },
+  "other": {
+    "$numberDecimal": "277539000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "949436000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ce"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260575",
+  "adstrdName": "면목3?8동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2354962"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4292725000"
+  },
+  "food": {
+    "$numberDecimal": "1251287000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "95813000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "29195000"
+  },
+  "medical": {
+    "$numberDecimal": "640808000"
+  },
+  "transport": {
+    "$numberDecimal": "20448000"
+  },
+  "education": {
+    "$numberDecimal": "82114000"
+  },
+  "entertainment": {
+    "$numberDecimal": "322880000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "248590000"
+  },
+  "other": {
+    "$numberDecimal": "254571000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1347019000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511cf"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260655",
+  "adstrdName": "망우본동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2443681"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7005430000"
+  },
+  "food": {
+    "$numberDecimal": "1772452000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "383397000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "145137000"
+  },
+  "medical": {
+    "$numberDecimal": "1885849000"
+  },
+  "transport": {
+    "$numberDecimal": "169939000"
+  },
+  "education": {
+    "$numberDecimal": "309695000"
+  },
+  "entertainment": {
+    "$numberDecimal": "268059000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "278673000"
+  },
+  "other": {
+    "$numberDecimal": "245116000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1547113000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511d0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260690",
+  "adstrdName": "신내2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3060535"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3788757000"
+  },
+  "food": {
+    "$numberDecimal": "1733389000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "84122000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "17859000"
+  },
+  "medical": {
+    "$numberDecimal": "456906000"
+  },
+  "transport": {
+    "$numberDecimal": "12498000"
+  },
+  "education": {
+    "$numberDecimal": "484307000"
+  },
+  "entertainment": {
+    "$numberDecimal": "35154000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "248202000"
+  },
+  "other": {
+    "$numberDecimal": "162025000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "554295000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511d1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290555",
+  "adstrdName": "삼선동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3057377"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7123516000"
+  },
+  "food": {
+    "$numberDecimal": "2995387000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "157669000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "60393000"
+  },
+  "medical": {
+    "$numberDecimal": "982744000"
+  },
+  "transport": {
+    "$numberDecimal": "113651000"
+  },
+  "education": {
+    "$numberDecimal": "318769000"
+  },
+  "entertainment": {
+    "$numberDecimal": "222523000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "272082000"
+  },
+  "other": {
+    "$numberDecimal": "196033000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1804265000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511d2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290660",
+  "adstrdName": "길음1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4462339"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4669095000"
+  },
+  "food": {
+    "$numberDecimal": "2090834000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "55667000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "22735000"
+  },
+  "medical": {
+    "$numberDecimal": "586998000"
+  },
+  "transport": {
+    "$numberDecimal": "1251000"
+  },
+  "education": {
+    "$numberDecimal": "647271000"
+  },
+  "entertainment": {
+    "$numberDecimal": "61819000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "185451000"
+  },
+  "other": {
+    "$numberDecimal": "209975000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "807094000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511d3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290685",
+  "adstrdName": "길음2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3736133"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5809124000"
+  },
+  "food": {
+    "$numberDecimal": "383416000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "82704000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "12756000"
+  },
+  "medical": {
+    "$numberDecimal": "921766000"
+  },
+  "transport": {
+    "$numberDecimal": "117993000"
+  },
+  "education": {
+    "$numberDecimal": "355126000"
+  },
+  "entertainment": {
+    "$numberDecimal": "527000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "2852694000"
+  },
+  "other": {
+    "$numberDecimal": "240590000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "841552000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511d4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290705",
+  "adstrdName": "종암동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3381883"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6534231000"
+  },
+  "food": {
+    "$numberDecimal": "2282361000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "43414000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "28974000"
+  },
+  "medical": {
+    "$numberDecimal": "1004016000"
+  },
+  "transport": {
+    "$numberDecimal": "528362000"
+  },
+  "education": {
+    "$numberDecimal": "449037000"
+  },
+  "entertainment": {
+    "$numberDecimal": "92310000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "387937000"
+  },
+  "other": {
+    "$numberDecimal": "210826000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1506994000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511d5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290760",
+  "adstrdName": "장위1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2231978"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1610648000"
+  },
+  "food": {
+    "$numberDecimal": "494219000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "16883000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "19492000"
+  },
+  "medical": {
+    "$numberDecimal": "146888000"
+  },
+  "transport": {
+    "$numberDecimal": "286530000"
+  },
+  "education": {
+    "$numberDecimal": "65137000"
+  },
+  "entertainment": {
+    "$numberDecimal": "59991000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "80413000"
+  },
+  "other": {
+    "$numberDecimal": "50243000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "390852000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511d6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305535",
+  "adstrdName": "미아동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2318870"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5504081000"
+  },
+  "food": {
+    "$numberDecimal": "1004510000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "287576000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "95231000"
+  },
+  "medical": {
+    "$numberDecimal": "1847700000"
+  },
+  "transport": {
+    "$numberDecimal": "230118000"
+  },
+  "education": {
+    "$numberDecimal": "76135000"
+  },
+  "entertainment": {
+    "$numberDecimal": "192460000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "204903000"
+  },
+  "other": {
+    "$numberDecimal": "200431000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1365017000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511d7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305635",
+  "adstrdName": "수유3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2205999"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "10971539000"
+  },
+  "food": {
+    "$numberDecimal": "1486702000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "181301000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "88330000"
+  },
+  "medical": {
+    "$numberDecimal": "1767451000"
+  },
+  "transport": {
+    "$numberDecimal": "500083000"
+  },
+  "education": {
+    "$numberDecimal": "82711000"
+  },
+  "entertainment": {
+    "$numberDecimal": "1131495000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "822212000"
+  },
+  "other": {
+    "$numberDecimal": "567168000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4344086000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511d8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305660",
+  "adstrdName": "인수동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2359990"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2515987000"
+  },
+  "food": {
+    "$numberDecimal": "980257000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "34811000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "51207000"
+  },
+  "medical": {
+    "$numberDecimal": "291623000"
+  },
+  "transport": {
+    "$numberDecimal": "213637000"
+  },
+  "education": {
+    "$numberDecimal": "95239000"
+  },
+  "entertainment": {
+    "$numberDecimal": "70019000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "74438000"
+  },
+  "other": {
+    "$numberDecimal": "73772000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "630984000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511d9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320522",
+  "adstrdName": "도봉2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2811820"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2521932000"
+  },
+  "food": {
+    "$numberDecimal": "902813000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "132658000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "16040000"
+  },
+  "medical": {
+    "$numberDecimal": "183508000"
+  },
+  "transport": {
+    "$numberDecimal": "357250000"
+  },
+  "education": {
+    "$numberDecimal": "127349000"
+  },
+  "entertainment": {
+    "$numberDecimal": "44962000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "164553000"
+  },
+  "other": {
+    "$numberDecimal": "63099000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "529700000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511da"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320660",
+  "adstrdName": "쌍문1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2440535"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1605797000"
+  },
+  "food": {
+    "$numberDecimal": "718674000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "25188000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "36434000"
+  },
+  "medical": {
+    "$numberDecimal": "189952000"
+  },
+  "transport": {
+    "$numberDecimal": "30892000"
+  },
+  "education": {
+    "$numberDecimal": "95967000"
+  },
+  "entertainment": {
+    "$numberDecimal": "15880000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "132048000"
+  },
+  "other": {
+    "$numberDecimal": "17296000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "343466000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511db"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350600",
+  "adstrdName": "공릉2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3394877"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7932212000"
+  },
+  "food": {
+    "$numberDecimal": "2303119000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "47847000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "60876000"
+  },
+  "medical": {
+    "$numberDecimal": "765266000"
+  },
+  "transport": {
+    "$numberDecimal": "642944000"
+  },
+  "education": {
+    "$numberDecimal": "762189000"
+  },
+  "entertainment": {
+    "$numberDecimal": "200596000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "848642000"
+  },
+  "other": {
+    "$numberDecimal": "348546000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1952187000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511dc"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410585",
+  "adstrdName": "신촌동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3331768"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "39342255000"
+  },
+  "food": {
+    "$numberDecimal": "2939300000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "254435000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "182161000"
+  },
+  "medical": {
+    "$numberDecimal": "23166487000"
+  },
+  "transport": {
+    "$numberDecimal": "257117000"
+  },
+  "education": {
+    "$numberDecimal": "1065247000"
+  },
+  "entertainment": {
+    "$numberDecimal": "894857000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1480885000"
+  },
+  "other": {
+    "$numberDecimal": "1404352000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "7697414000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511dd"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410720",
+  "adstrdName": "북가좌2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2590646"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3684372000"
+  },
+  "food": {
+    "$numberDecimal": "1021431000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "31613000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "84015000"
+  },
+  "medical": {
+    "$numberDecimal": "463552000"
+  },
+  "transport": {
+    "$numberDecimal": "48880000"
+  },
+  "education": {
+    "$numberDecimal": "418484000"
+  },
+  "entertainment": {
+    "$numberDecimal": "125537000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "232630000"
+  },
+  "other": {
+    "$numberDecimal": "163650000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1094580000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511de"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440590",
+  "adstrdName": "용강동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4787212"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7481741000"
+  },
+  "food": {
+    "$numberDecimal": "1339854000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "35905000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "86707000"
+  },
+  "medical": {
+    "$numberDecimal": "1563836000"
+  },
+  "transport": {
+    "$numberDecimal": "338456000"
+  },
+  "education": {
+    "$numberDecimal": "602761000"
+  },
+  "entertainment": {
+    "$numberDecimal": "225317000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "615882000"
+  },
+  "other": {
+    "$numberDecimal": "209859000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2463164000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511df"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440680",
+  "adstrdName": "합정동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3195027"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9910705000"
+  },
+  "food": {
+    "$numberDecimal": "1784574000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "271961000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "275427000"
+  },
+  "medical": {
+    "$numberDecimal": "995461000"
+  },
+  "transport": {
+    "$numberDecimal": "112523000"
+  },
+  "education": {
+    "$numberDecimal": "168105000"
+  },
+  "entertainment": {
+    "$numberDecimal": "436157000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "815324000"
+  },
+  "other": {
+    "$numberDecimal": "504313000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4546860000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511e0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470510",
+  "adstrdName": "목1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5667672"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "25908662000"
+  },
+  "food": {
+    "$numberDecimal": "2354289000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "122875000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "124198000"
+  },
+  "medical": {
+    "$numberDecimal": "6066562000"
+  },
+  "transport": {
+    "$numberDecimal": "68065000"
+  },
+  "education": {
+    "$numberDecimal": "3760081000"
+  },
+  "entertainment": {
+    "$numberDecimal": "275548000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "6883058000"
+  },
+  "other": {
+    "$numberDecimal": "1456788000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4797198000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511e1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500593",
+  "adstrdName": "화곡8동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2473381"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4454543000"
+  },
+  "food": {
+    "$numberDecimal": "1845858000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "140939000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "47017000"
+  },
+  "medical": {
+    "$numberDecimal": "434745000"
+  },
+  "transport": {
+    "$numberDecimal": "13427000"
+  },
+  "education": {
+    "$numberDecimal": "197024000"
+  },
+  "entertainment": {
+    "$numberDecimal": "144609000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "238611000"
+  },
+  "other": {
+    "$numberDecimal": "190428000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1201885000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511e2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11545610",
+  "adstrdName": "독산1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3000453"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9573172000"
+  },
+  "food": {
+    "$numberDecimal": "2617311000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "94966000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "261527000"
+  },
+  "medical": {
+    "$numberDecimal": "2522676000"
+  },
+  "transport": {
+    "$numberDecimal": "890941000"
+  },
+  "education": {
+    "$numberDecimal": "347406000"
+  },
+  "entertainment": {
+    "$numberDecimal": "227955000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "486994000"
+  },
+  "other": {
+    "$numberDecimal": "347104000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1776292000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511e3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11545690",
+  "adstrdName": "시흥3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2516251"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1387223000"
+  },
+  "food": {
+    "$numberDecimal": "362154000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "4856000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "55155000"
+  },
+  "medical": {
+    "$numberDecimal": "60581000"
+  },
+  "transport": {
+    "$numberDecimal": "516737000"
+  },
+  "education": {
+    "$numberDecimal": "18532000"
+  },
+  "entertainment": {
+    "$numberDecimal": "45705000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "24239000"
+  },
+  "other": {
+    "$numberDecimal": "41642000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "257622000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511e4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560560",
+  "adstrdName": "당산2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4130932"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8141109000"
+  },
+  "food": {
+    "$numberDecimal": "1737294000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "97396000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "27496000"
+  },
+  "medical": {
+    "$numberDecimal": "1452523000"
+  },
+  "transport": {
+    "$numberDecimal": "83658000"
+  },
+  "education": {
+    "$numberDecimal": "431853000"
+  },
+  "entertainment": {
+    "$numberDecimal": "296069000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "443317000"
+  },
+  "other": {
+    "$numberDecimal": "512416000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3059087000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511e5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590540",
+  "adstrdName": "상도2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3826699"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4321858000"
+  },
+  "food": {
+    "$numberDecimal": "1341591000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "98187000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "50965000"
+  },
+  "medical": {
+    "$numberDecimal": "942490000"
+  },
+  "transport": {
+    "$numberDecimal": "90440000"
+  },
+  "education": {
+    "$numberDecimal": "390721000"
+  },
+  "entertainment": {
+    "$numberDecimal": "95984000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "190167000"
+  },
+  "other": {
+    "$numberDecimal": "191613000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "929700000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511e6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590660",
+  "adstrdName": "대방동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3524765"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6365173000"
+  },
+  "food": {
+    "$numberDecimal": "1729378000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "102123000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "25748000"
+  },
+  "medical": {
+    "$numberDecimal": "1035505000"
+  },
+  "transport": {
+    "$numberDecimal": "377672000"
+  },
+  "education": {
+    "$numberDecimal": "654985000"
+  },
+  "entertainment": {
+    "$numberDecimal": "141756000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "592544000"
+  },
+  "other": {
+    "$numberDecimal": "303270000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1402192000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511e7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620685",
+  "adstrdName": "신사동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2430662"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3665864000"
+  },
+  "food": {
+    "$numberDecimal": "1404746000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "67495000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "84022000"
+  },
+  "medical": {
+    "$numberDecimal": "670437000"
+  },
+  "transport": {
+    "$numberDecimal": "86915000"
+  },
+  "education": {
+    "$numberDecimal": "86848000"
+  },
+  "entertainment": {
+    "$numberDecimal": "176429000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "161038000"
+  },
+  "other": {
+    "$numberDecimal": "135456000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "792478000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511e8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620695",
+  "adstrdName": "신림동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2434279"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8866716000"
+  },
+  "food": {
+    "$numberDecimal": "1634607000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "132108000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "23325000"
+  },
+  "medical": {
+    "$numberDecimal": "1983903000"
+  },
+  "transport": {
+    "$numberDecimal": "82373000"
+  },
+  "education": {
+    "$numberDecimal": "63840000"
+  },
+  "entertainment": {
+    "$numberDecimal": "790095000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "854626000"
+  },
+  "other": {
+    "$numberDecimal": "463687000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2838152000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511e9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620725",
+  "adstrdName": "조원동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2523192"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6666390000"
+  },
+  "food": {
+    "$numberDecimal": "1964681000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "49228000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "104918000"
+  },
+  "medical": {
+    "$numberDecimal": "1317919000"
+  },
+  "transport": {
+    "$numberDecimal": "59417000"
+  },
+  "education": {
+    "$numberDecimal": "85331000"
+  },
+  "entertainment": {
+    "$numberDecimal": "545839000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "391267000"
+  },
+  "other": {
+    "$numberDecimal": "435662000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1712128000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ea"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620775",
+  "adstrdName": "난곡동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2268676"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2737512000"
+  },
+  "food": {
+    "$numberDecimal": "1225642000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "26250000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "15571000"
+  },
+  "medical": {
+    "$numberDecimal": "703265000"
+  },
+  "transport": {
+    "$numberDecimal": "39477000"
+  },
+  "education": {
+    "$numberDecimal": "135885000"
+  },
+  "entertainment": {
+    "$numberDecimal": "16726000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "86005000"
+  },
+  "other": {
+    "$numberDecimal": "74209000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "414482000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511eb"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650520",
+  "adstrdName": "서초2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5196131"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.80E+11"
+  },
+  "food": {
+    "$numberDecimal": "1342957000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "18967000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "1637679000"
+  },
+  "medical": {
+    "$numberDecimal": "6750681000"
+  },
+  "transport": {
+    "$numberDecimal": "115852000"
+  },
+  "education": {
+    "$numberDecimal": "1025440000"
+  },
+  "entertainment": {
+    "$numberDecimal": "209463000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1463546000"
+  },
+  "other": {
+    "$numberDecimal": "1.64E+11"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3960881000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ec"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650610",
+  "adstrdName": "방배2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3864301"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "81401143000"
+  },
+  "food": {
+    "$numberDecimal": "1189346000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "57429000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "35001000"
+  },
+  "medical": {
+    "$numberDecimal": "922112000"
+  },
+  "transport": {
+    "$numberDecimal": "221050000"
+  },
+  "education": {
+    "$numberDecimal": "499675000"
+  },
+  "entertainment": {
+    "$numberDecimal": "367606000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "73189680000"
+  },
+  "other": {
+    "$numberDecimal": "249142000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4670102000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ed"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650651",
+  "adstrdName": "양재1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4173236"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "10602660000"
+  },
+  "food": {
+    "$numberDecimal": "1623954000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "206001000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "149705000"
+  },
+  "medical": {
+    "$numberDecimal": "2575944000"
+  },
+  "transport": {
+    "$numberDecimal": "559603000"
+  },
+  "education": {
+    "$numberDecimal": "940544000"
+  },
+  "entertainment": {
+    "$numberDecimal": "240288000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "643633000"
+  },
+  "other": {
+    "$numberDecimal": "757174000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2905814000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ee"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650652",
+  "adstrdName": "양재2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3222382"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9664577000"
+  },
+  "food": {
+    "$numberDecimal": "2385057000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "91438000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "94492000"
+  },
+  "medical": {
+    "$numberDecimal": "1628852000"
+  },
+  "transport": {
+    "$numberDecimal": "705825000"
+  },
+  "education": {
+    "$numberDecimal": "254827000"
+  },
+  "entertainment": {
+    "$numberDecimal": "189661000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "725220000"
+  },
+  "other": {
+    "$numberDecimal": "274630000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3314575000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ef"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680740",
+  "adstrdName": "일원2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4553185"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1253926000"
+  },
+  "food": {
+    "$numberDecimal": "483396000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "15008000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "14307000"
+  },
+  "medical": {
+    "$numberDecimal": "214516000"
+  },
+  "transport": {
+    "$numberDecimal": "78449000"
+  },
+  "education": {
+    "$numberDecimal": "82648000"
+  },
+  "entertainment": {
+    "$numberDecimal": "5821000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "97771000"
+  },
+  "other": {
+    "$numberDecimal": "42220000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "219790000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511f0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710610",
+  "adstrdName": "삼전동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2779980"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7249528000"
+  },
+  "food": {
+    "$numberDecimal": "1651481000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "82603000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "192731000"
+  },
+  "medical": {
+    "$numberDecimal": "1405067000"
+  },
+  "transport": {
+    "$numberDecimal": "176211000"
+  },
+  "education": {
+    "$numberDecimal": "772950000"
+  },
+  "entertainment": {
+    "$numberDecimal": "100463000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "652347000"
+  },
+  "other": {
+    "$numberDecimal": "548828000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1666847000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511f1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710632",
+  "adstrdName": "가락2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3910198"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5915456000"
+  },
+  "food": {
+    "$numberDecimal": "1631874000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "47114000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "43816000"
+  },
+  "medical": {
+    "$numberDecimal": "1297076000"
+  },
+  "transport": {
+    "$numberDecimal": "362522000"
+  },
+  "education": {
+    "$numberDecimal": "511086000"
+  },
+  "entertainment": {
+    "$numberDecimal": "65189000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "285542000"
+  },
+  "other": {
+    "$numberDecimal": "300113000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1371124000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511f2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710646",
+  "adstrdName": "장지동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3263464"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3475234000"
+  },
+  "food": {
+    "$numberDecimal": "1301281000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "45364000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "28599000"
+  },
+  "medical": {
+    "$numberDecimal": "362513000"
+  },
+  "transport": {
+    "$numberDecimal": "309071000"
+  },
+  "education": {
+    "$numberDecimal": "424479000"
+  },
+  "entertainment": {
+    "$numberDecimal": "51917000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "173728000"
+  },
+  "other": {
+    "$numberDecimal": "88123000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "690159000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511f3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710670",
+  "adstrdName": "잠실2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "6352641"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3220268000"
+  },
+  "food": {
+    "$numberDecimal": "474057000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "106758000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "5357000"
+  },
+  "medical": {
+    "$numberDecimal": "1306628000"
+  },
+  "transport": {
+    "$numberDecimal": "8250000"
+  },
+  "education": {
+    "$numberDecimal": "474445000"
+  },
+  "entertainment": {
+    "$numberDecimal": "0"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "255694000"
+  },
+  "other": {
+    "$numberDecimal": "209869000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "379210000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511f4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710690",
+  "adstrdName": "잠실4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "6007987"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1738125000"
+  },
+  "food": {
+    "$numberDecimal": "543730000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "23366000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "1905000"
+  },
+  "medical": {
+    "$numberDecimal": "538587000"
+  },
+  "transport": {
+    "$numberDecimal": "1357000"
+  },
+  "education": {
+    "$numberDecimal": "179112000"
+  },
+  "entertainment": {
+    "$numberDecimal": "2687000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "75012000"
+  },
+  "other": {
+    "$numberDecimal": "159547000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "212822000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511f5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710710",
+  "adstrdName": "잠실6동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5237775"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "36182062000"
+  },
+  "food": {
+    "$numberDecimal": "2803344000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "284809000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "46838000"
+  },
+  "medical": {
+    "$numberDecimal": "6687758000"
+  },
+  "transport": {
+    "$numberDecimal": "309604000"
+  },
+  "education": {
+    "$numberDecimal": "178485000"
+  },
+  "entertainment": {
+    "$numberDecimal": "18331000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "20975426000"
+  },
+  "other": {
+    "$numberDecimal": "805222000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4072245000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511f6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710720",
+  "adstrdName": "잠실7동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "6014516"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "383632000"
+  },
+  "food": {
+    "$numberDecimal": "141291000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "11334000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "72073000"
+  },
+  "medical": {
+    "$numberDecimal": "15086000"
+  },
+  "transport": {
+    "$numberDecimal": "213000"
+  },
+  "education": {
+    "$numberDecimal": "31539000"
+  },
+  "entertainment": {
+    "$numberDecimal": "0"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "57285000"
+  },
+  "other": {
+    "$numberDecimal": "6904000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "47907000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511f7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740690",
+  "adstrdName": "둔촌1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3596734"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "17286000"
+  },
+  "food": {
+    "$numberDecimal": "0"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "0"
+  },
+  "livingGoods": {
+    "$numberDecimal": "0"
+  },
+  "medical": {
+    "$numberDecimal": "0"
+  },
+  "transport": {
+    "$numberDecimal": "0"
+  },
+  "education": {
+    "$numberDecimal": "2175000"
+  },
+  "entertainment": {
+    "$numberDecimal": "0"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "7173000"
+  },
+  "other": {
+    "$numberDecimal": "1703000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "6235000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511f8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140520",
+  "adstrdName": "소공동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5380521"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2.23E+12"
+  },
+  "food": {
+    "$numberDecimal": "1322343000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "193551000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "318707000"
+  },
+  "medical": {
+    "$numberDecimal": "1490110000"
+  },
+  "transport": {
+    "$numberDecimal": "36408185000"
+  },
+  "education": {
+    "$numberDecimal": "123615000"
+  },
+  "entertainment": {
+    "$numberDecimal": "299487000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "2.18E+12"
+  },
+  "other": {
+    "$numberDecimal": "12128429000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4251503000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511f9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140680",
+  "adstrdName": "중림동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4435938"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2844592000"
+  },
+  "food": {
+    "$numberDecimal": "537734000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "8218000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "14864000"
+  },
+  "medical": {
+    "$numberDecimal": "443737000"
+  },
+  "transport": {
+    "$numberDecimal": "16377000"
+  },
+  "education": {
+    "$numberDecimal": "79838000"
+  },
+  "entertainment": {
+    "$numberDecimal": "40777000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "609232000"
+  },
+  "other": {
+    "$numberDecimal": "55048000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1038767000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511fa"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170510",
+  "adstrdName": "후암동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3013677"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2196724000"
+  },
+  "food": {
+    "$numberDecimal": "903810000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "47443000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "46663000"
+  },
+  "medical": {
+    "$numberDecimal": "131454000"
+  },
+  "transport": {
+    "$numberDecimal": "52897000"
+  },
+  "education": {
+    "$numberDecimal": "100473000"
+  },
+  "entertainment": {
+    "$numberDecimal": "22061000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "81634000"
+  },
+  "other": {
+    "$numberDecimal": "83168000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "727121000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511fb"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170660",
+  "adstrdName": "이태원2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3261019"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1717968000"
+  },
+  "food": {
+    "$numberDecimal": "409152000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "95020000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "73368000"
+  },
+  "medical": {
+    "$numberDecimal": "62168000"
+  },
+  "transport": {
+    "$numberDecimal": "63934000"
+  },
+  "education": {
+    "$numberDecimal": "13600000"
+  },
+  "entertainment": {
+    "$numberDecimal": "145855000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "80780000"
+  },
+  "other": {
+    "$numberDecimal": "95459000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "678632000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511fc"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170690",
+  "adstrdName": "서빙고동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4208562"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1630838000"
+  },
+  "food": {
+    "$numberDecimal": "380601000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "20477000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "16083000"
+  },
+  "medical": {
+    "$numberDecimal": "37024000"
+  },
+  "transport": {
+    "$numberDecimal": "102596000"
+  },
+  "education": {
+    "$numberDecimal": "168410000"
+  },
+  "entertainment": {
+    "$numberDecimal": "0"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "375724000"
+  },
+  "other": {
+    "$numberDecimal": "30565000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "499358000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511fd"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215750",
+  "adstrdName": "중곡2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2555101"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3850986000"
+  },
+  "food": {
+    "$numberDecimal": "899060000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "78033000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "81305000"
+  },
+  "medical": {
+    "$numberDecimal": "736859000"
+  },
+  "transport": {
+    "$numberDecimal": "99062000"
+  },
+  "education": {
+    "$numberDecimal": "192305000"
+  },
+  "entertainment": {
+    "$numberDecimal": "105853000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "276881000"
+  },
+  "other": {
+    "$numberDecimal": "148745000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1232883000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511fe"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260520",
+  "adstrdName": "면목2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2322173"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3247922000"
+  },
+  "food": {
+    "$numberDecimal": "781593000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "63006000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "176658000"
+  },
+  "medical": {
+    "$numberDecimal": "688246000"
+  },
+  "transport": {
+    "$numberDecimal": "751024000"
+  },
+  "education": {
+    "$numberDecimal": "59457000"
+  },
+  "entertainment": {
+    "$numberDecimal": "64034000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "59347000"
+  },
+  "other": {
+    "$numberDecimal": "97623000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "506934000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293511ff"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260565",
+  "adstrdName": "면목본동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2336892"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4687874000"
+  },
+  "food": {
+    "$numberDecimal": "1515013000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "87458000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "111311000"
+  },
+  "medical": {
+    "$numberDecimal": "786795000"
+  },
+  "transport": {
+    "$numberDecimal": "42081000"
+  },
+  "education": {
+    "$numberDecimal": "107417000"
+  },
+  "entertainment": {
+    "$numberDecimal": "192511000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "211563000"
+  },
+  "other": {
+    "$numberDecimal": "133018000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1500707000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351200"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260570",
+  "adstrdName": "면목7동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2655671"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4321814000"
+  },
+  "food": {
+    "$numberDecimal": "1770510000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "64196000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "62219000"
+  },
+  "medical": {
+    "$numberDecimal": "759420000"
+  },
+  "transport": {
+    "$numberDecimal": "47628000"
+  },
+  "education": {
+    "$numberDecimal": "162361000"
+  },
+  "entertainment": {
+    "$numberDecimal": "115570000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "193463000"
+  },
+  "other": {
+    "$numberDecimal": "254295000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "892152000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351201"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260680",
+  "adstrdName": "신내1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2780491"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5199835000"
+  },
+  "food": {
+    "$numberDecimal": "1591271000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "42912000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "54984000"
+  },
+  "medical": {
+    "$numberDecimal": "787158000"
+  },
+  "transport": {
+    "$numberDecimal": "389674000"
+  },
+  "education": {
+    "$numberDecimal": "477764000"
+  },
+  "entertainment": {
+    "$numberDecimal": "99545000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "283250000"
+  },
+  "other": {
+    "$numberDecimal": "189901000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1283376000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351202"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290620",
+  "adstrdName": "정릉1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3341356"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1571874000"
+  },
+  "food": {
+    "$numberDecimal": "525683000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "4190000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "10988000"
+  },
+  "medical": {
+    "$numberDecimal": "161326000"
+  },
+  "transport": {
+    "$numberDecimal": "152847000"
+  },
+  "education": {
+    "$numberDecimal": "155971000"
+  },
+  "entertainment": {
+    "$numberDecimal": "14333000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "126264000"
+  },
+  "other": {
+    "$numberDecimal": "46814000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "373458000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351203"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290715",
+  "adstrdName": "월곡1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3294213"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2736879000"
+  },
+  "food": {
+    "$numberDecimal": "668484000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "20792000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "297113000"
+  },
+  "medical": {
+    "$numberDecimal": "354179000"
+  },
+  "transport": {
+    "$numberDecimal": "421275000"
+  },
+  "education": {
+    "$numberDecimal": "241761000"
+  },
+  "entertainment": {
+    "$numberDecimal": "37962000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "97544000"
+  },
+  "other": {
+    "$numberDecimal": "78376000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "519393000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351204"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290725",
+  "adstrdName": "월곡2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3138026"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5537256000"
+  },
+  "food": {
+    "$numberDecimal": "1585014000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "200596000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "14275000"
+  },
+  "medical": {
+    "$numberDecimal": "835276000"
+  },
+  "transport": {
+    "$numberDecimal": "470558000"
+  },
+  "education": {
+    "$numberDecimal": "148581000"
+  },
+  "entertainment": {
+    "$numberDecimal": "132341000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "321299000"
+  },
+  "other": {
+    "$numberDecimal": "193430000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1635886000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351205"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290780",
+  "adstrdName": "장위3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3113825"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1440413000"
+  },
+  "food": {
+    "$numberDecimal": "515722000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "14522000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "11851000"
+  },
+  "medical": {
+    "$numberDecimal": "147978000"
+  },
+  "transport": {
+    "$numberDecimal": "275300000"
+  },
+  "education": {
+    "$numberDecimal": "95550000"
+  },
+  "entertainment": {
+    "$numberDecimal": "5945000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "55334000"
+  },
+  "other": {
+    "$numberDecimal": "30359000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "287852000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351206"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305603",
+  "adstrdName": "번2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2308539"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "990561000"
+  },
+  "food": {
+    "$numberDecimal": "234926000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "472000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "12764000"
+  },
+  "medical": {
+    "$numberDecimal": "110343000"
+  },
+  "transport": {
+    "$numberDecimal": "336573000"
+  },
+  "education": {
+    "$numberDecimal": "31266000"
+  },
+  "entertainment": {
+    "$numberDecimal": "6430000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "109461000"
+  },
+  "other": {
+    "$numberDecimal": "31615000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "116711000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351207"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305608",
+  "adstrdName": "번3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2548326"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1795925000"
+  },
+  "food": {
+    "$numberDecimal": "944473000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "55211000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "6071000"
+  },
+  "medical": {
+    "$numberDecimal": "154696000"
+  },
+  "transport": {
+    "$numberDecimal": "57904000"
+  },
+  "education": {
+    "$numberDecimal": "73385000"
+  },
+  "entertainment": {
+    "$numberDecimal": "12802000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "96880000"
+  },
+  "other": {
+    "$numberDecimal": "15331000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "379172000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351208"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320670",
+  "adstrdName": "쌍문2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2430154"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4272247000"
+  },
+  "food": {
+    "$numberDecimal": "799706000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "97793000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "266454000"
+  },
+  "medical": {
+    "$numberDecimal": "535094000"
+  },
+  "transport": {
+    "$numberDecimal": "666963000"
+  },
+  "education": {
+    "$numberDecimal": "203302000"
+  },
+  "entertainment": {
+    "$numberDecimal": "86064000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "284398000"
+  },
+  "other": {
+    "$numberDecimal": "269978000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1062495000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351209"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320710",
+  "adstrdName": "방학3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2962092"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1718616000"
+  },
+  "food": {
+    "$numberDecimal": "361914000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "15376000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "1037000"
+  },
+  "medical": {
+    "$numberDecimal": "290265000"
+  },
+  "transport": {
+    "$numberDecimal": "17027000"
+  },
+  "education": {
+    "$numberDecimal": "138711000"
+  },
+  "entertainment": {
+    "$numberDecimal": "23843000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "139194000"
+  },
+  "other": {
+    "$numberDecimal": "88822000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "642427000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935120a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350560",
+  "adstrdName": "월계1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2777397"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5361503000"
+  },
+  "food": {
+    "$numberDecimal": "1132505000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "32235000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "11810000"
+  },
+  "medical": {
+    "$numberDecimal": "1008857000"
+  },
+  "transport": {
+    "$numberDecimal": "242087000"
+  },
+  "education": {
+    "$numberDecimal": "153952000"
+  },
+  "entertainment": {
+    "$numberDecimal": "216783000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "427616000"
+  },
+  "other": {
+    "$numberDecimal": "220264000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1915394000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935120b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380510",
+  "adstrdName": "녹번동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3055864"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5119710000"
+  },
+  "food": {
+    "$numberDecimal": "1336334000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "36375000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "84870000"
+  },
+  "medical": {
+    "$numberDecimal": "896519000"
+  },
+  "transport": {
+    "$numberDecimal": "473538000"
+  },
+  "education": {
+    "$numberDecimal": "223808000"
+  },
+  "entertainment": {
+    "$numberDecimal": "108704000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "232863000"
+  },
+  "other": {
+    "$numberDecimal": "129716000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1596983000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935120c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380520",
+  "adstrdName": "불광1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3182963"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7130157000"
+  },
+  "food": {
+    "$numberDecimal": "1662053000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "110557000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "383038000"
+  },
+  "medical": {
+    "$numberDecimal": "2329387000"
+  },
+  "transport": {
+    "$numberDecimal": "18731000"
+  },
+  "education": {
+    "$numberDecimal": "304358000"
+  },
+  "entertainment": {
+    "$numberDecimal": "259418000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "430178000"
+  },
+  "other": {
+    "$numberDecimal": "317986000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1314451000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935120d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380530",
+  "adstrdName": "불광2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2396457"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4728336000"
+  },
+  "food": {
+    "$numberDecimal": "1741791000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "62829000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "69501000"
+  },
+  "medical": {
+    "$numberDecimal": "814875000"
+  },
+  "transport": {
+    "$numberDecimal": "476178000"
+  },
+  "education": {
+    "$numberDecimal": "162206000"
+  },
+  "entertainment": {
+    "$numberDecimal": "77523000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "105535000"
+  },
+  "other": {
+    "$numberDecimal": "130814000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1087084000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935120e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380632",
+  "adstrdName": "신사2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2635300"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1307709000"
+  },
+  "food": {
+    "$numberDecimal": "692967000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "19425000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "14203000"
+  },
+  "medical": {
+    "$numberDecimal": "113457000"
+  },
+  "transport": {
+    "$numberDecimal": "7234000"
+  },
+  "education": {
+    "$numberDecimal": "142965000"
+  },
+  "entertainment": {
+    "$numberDecimal": "9158000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "29741000"
+  },
+  "other": {
+    "$numberDecimal": "27105000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "251454000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935120f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410685",
+  "adstrdName": "홍은2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2874442"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3429648000"
+  },
+  "food": {
+    "$numberDecimal": "796447000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "41696000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "19691000"
+  },
+  "medical": {
+    "$numberDecimal": "505588000"
+  },
+  "transport": {
+    "$numberDecimal": "364279000"
+  },
+  "education": {
+    "$numberDecimal": "574890000"
+  },
+  "entertainment": {
+    "$numberDecimal": "53648000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "215819000"
+  },
+  "other": {
+    "$numberDecimal": "78486000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "779104000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351210"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440690",
+  "adstrdName": "망원1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2802536"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7768358000"
+  },
+  "food": {
+    "$numberDecimal": "2406606000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "263291000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "156258000"
+  },
+  "medical": {
+    "$numberDecimal": "755561000"
+  },
+  "transport": {
+    "$numberDecimal": "44450000"
+  },
+  "education": {
+    "$numberDecimal": "97336000"
+  },
+  "entertainment": {
+    "$numberDecimal": "241903000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "354958000"
+  },
+  "other": {
+    "$numberDecimal": "273783000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3174212000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351211"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440720",
+  "adstrdName": "성산1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2814646"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3658154000"
+  },
+  "food": {
+    "$numberDecimal": "855046000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "52880000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "51705000"
+  },
+  "medical": {
+    "$numberDecimal": "402915000"
+  },
+  "transport": {
+    "$numberDecimal": "588692000"
+  },
+  "education": {
+    "$numberDecimal": "224166000"
+  },
+  "entertainment": {
+    "$numberDecimal": "42128000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "306585000"
+  },
+  "other": {
+    "$numberDecimal": "112835000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1021202000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351212"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440730",
+  "adstrdName": "성산2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3521472"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7779603000"
+  },
+  "food": {
+    "$numberDecimal": "4643044000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "62231000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "30993000"
+  },
+  "medical": {
+    "$numberDecimal": "392322000"
+  },
+  "transport": {
+    "$numberDecimal": "411977000"
+  },
+  "education": {
+    "$numberDecimal": "402284000"
+  },
+  "entertainment": {
+    "$numberDecimal": "58438000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "348702000"
+  },
+  "other": {
+    "$numberDecimal": "560059000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "869553000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351213"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440740",
+  "adstrdName": "상암동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4158486"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "13757673000"
+  },
+  "food": {
+    "$numberDecimal": "1577561000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "55891000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "13108000"
+  },
+  "medical": {
+    "$numberDecimal": "1237615000"
+  },
+  "transport": {
+    "$numberDecimal": "76145000"
+  },
+  "education": {
+    "$numberDecimal": "2212579000"
+  },
+  "entertainment": {
+    "$numberDecimal": "171152000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "4490746000"
+  },
+  "other": {
+    "$numberDecimal": "679271000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3243605000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351214"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500560",
+  "adstrdName": "화곡3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3132782"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4439817000"
+  },
+  "food": {
+    "$numberDecimal": "826849000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "36601000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "28434000"
+  },
+  "medical": {
+    "$numberDecimal": "1038989000"
+  },
+  "transport": {
+    "$numberDecimal": "18417000"
+  },
+  "education": {
+    "$numberDecimal": "342547000"
+  },
+  "entertainment": {
+    "$numberDecimal": "166522000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "356444000"
+  },
+  "other": {
+    "$numberDecimal": "177740000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1447274000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351215"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500570",
+  "adstrdName": "화곡4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2423768"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4648210000"
+  },
+  "food": {
+    "$numberDecimal": "1165650000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "105427000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "167081000"
+  },
+  "medical": {
+    "$numberDecimal": "523893000"
+  },
+  "transport": {
+    "$numberDecimal": "987504000"
+  },
+  "education": {
+    "$numberDecimal": "109304000"
+  },
+  "entertainment": {
+    "$numberDecimal": "122829000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "342210000"
+  },
+  "other": {
+    "$numberDecimal": "228442000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "895870000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351216"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500603",
+  "adstrdName": "가양1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3560388"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.05E+11"
+  },
+  "food": {
+    "$numberDecimal": "2986417000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "163112000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "181037000"
+  },
+  "medical": {
+    "$numberDecimal": "5940900000"
+  },
+  "transport": {
+    "$numberDecimal": "21430684000"
+  },
+  "education": {
+    "$numberDecimal": "402225000"
+  },
+  "entertainment": {
+    "$numberDecimal": "1066544000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "52062985000"
+  },
+  "other": {
+    "$numberDecimal": "9843078000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "10439294000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351217"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500620",
+  "adstrdName": "공항동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2896818"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7346038000"
+  },
+  "food": {
+    "$numberDecimal": "1582997000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "83710000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "173476000"
+  },
+  "medical": {
+    "$numberDecimal": "1410931000"
+  },
+  "transport": {
+    "$numberDecimal": "1076899000"
+  },
+  "education": {
+    "$numberDecimal": "197090000"
+  },
+  "entertainment": {
+    "$numberDecimal": "134717000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "707932000"
+  },
+  "other": {
+    "$numberDecimal": "192515000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1785771000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351218"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500630",
+  "adstrdName": "방화1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3407916"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7119946000"
+  },
+  "food": {
+    "$numberDecimal": "2142599000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "88902000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "115008000"
+  },
+  "medical": {
+    "$numberDecimal": "1161571000"
+  },
+  "transport": {
+    "$numberDecimal": "445590000"
+  },
+  "education": {
+    "$numberDecimal": "740301000"
+  },
+  "entertainment": {
+    "$numberDecimal": "132273000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "452490000"
+  },
+  "other": {
+    "$numberDecimal": "226606000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1614606000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351219"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500641",
+  "adstrdName": "방화3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3044446"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1608159000"
+  },
+  "food": {
+    "$numberDecimal": "729199000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "2363000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "5354000"
+  },
+  "medical": {
+    "$numberDecimal": "195606000"
+  },
+  "transport": {
+    "$numberDecimal": "2057000"
+  },
+  "education": {
+    "$numberDecimal": "55450000"
+  },
+  "entertainment": {
+    "$numberDecimal": "22914000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "179884000"
+  },
+  "other": {
+    "$numberDecimal": "60715000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "354617000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935121a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530560",
+  "adstrdName": "구로5동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3213284"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "18253870000"
+  },
+  "food": {
+    "$numberDecimal": "5305861000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "79271000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "574555000"
+  },
+  "medical": {
+    "$numberDecimal": "2505150000"
+  },
+  "transport": {
+    "$numberDecimal": "187499000"
+  },
+  "education": {
+    "$numberDecimal": "170494000"
+  },
+  "entertainment": {
+    "$numberDecimal": "380880000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "4823716000"
+  },
+  "other": {
+    "$numberDecimal": "875069000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3351375000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935121b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530720",
+  "adstrdName": "고척1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2972418"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6857932000"
+  },
+  "food": {
+    "$numberDecimal": "1695830000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "121445000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "103496000"
+  },
+  "medical": {
+    "$numberDecimal": "1589247000"
+  },
+  "transport": {
+    "$numberDecimal": "138670000"
+  },
+  "education": {
+    "$numberDecimal": "264593000"
+  },
+  "entertainment": {
+    "$numberDecimal": "155426000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "742329000"
+  },
+  "other": {
+    "$numberDecimal": "146460000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1900436000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935121c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530760",
+  "adstrdName": "개봉3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2512790"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2801887000"
+  },
+  "food": {
+    "$numberDecimal": "1444286000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "36867000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "68894000"
+  },
+  "medical": {
+    "$numberDecimal": "234499000"
+  },
+  "transport": {
+    "$numberDecimal": "158556000"
+  },
+  "education": {
+    "$numberDecimal": "76177000"
+  },
+  "entertainment": {
+    "$numberDecimal": "42008000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "116382000"
+  },
+  "other": {
+    "$numberDecimal": "80698000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "543520000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935121d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530770",
+  "adstrdName": "오류1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2574851"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3741719000"
+  },
+  "food": {
+    "$numberDecimal": "999783000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "94956000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "4348000"
+  },
+  "medical": {
+    "$numberDecimal": "695806000"
+  },
+  "transport": {
+    "$numberDecimal": "485524000"
+  },
+  "education": {
+    "$numberDecimal": "101747000"
+  },
+  "entertainment": {
+    "$numberDecimal": "199582000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "212608000"
+  },
+  "other": {
+    "$numberDecimal": "61298000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "886067000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935121e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560605",
+  "adstrdName": "문래동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4019445"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.37E+12"
+  },
+  "food": {
+    "$numberDecimal": "2921595000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "71300000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "266822000"
+  },
+  "medical": {
+    "$numberDecimal": "1397259000"
+  },
+  "transport": {
+    "$numberDecimal": "499650000"
+  },
+  "education": {
+    "$numberDecimal": "441479000"
+  },
+  "entertainment": {
+    "$numberDecimal": "325391000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1.36E+12"
+  },
+  "other": {
+    "$numberDecimal": "783285000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4385794000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935121f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560610",
+  "adstrdName": "양평1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3508250"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3911921000"
+  },
+  "food": {
+    "$numberDecimal": "583740000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "15501000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "35866000"
+  },
+  "medical": {
+    "$numberDecimal": "379023000"
+  },
+  "transport": {
+    "$numberDecimal": "986415000"
+  },
+  "education": {
+    "$numberDecimal": "93158000"
+  },
+  "entertainment": {
+    "$numberDecimal": "28810000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "421328000"
+  },
+  "other": {
+    "$numberDecimal": "170177000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1197903000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351220"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560650",
+  "adstrdName": "신길3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3085442"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3453375000"
+  },
+  "food": {
+    "$numberDecimal": "1011142000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "66499000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "113533000"
+  },
+  "medical": {
+    "$numberDecimal": "766447000"
+  },
+  "transport": {
+    "$numberDecimal": "438376000"
+  },
+  "education": {
+    "$numberDecimal": "150444000"
+  },
+  "entertainment": {
+    "$numberDecimal": "54321000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "158755000"
+  },
+  "other": {
+    "$numberDecimal": "71750000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "622108000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351221"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560670",
+  "adstrdName": "신길5동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2656511"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1823306000"
+  },
+  "food": {
+    "$numberDecimal": "200172000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "23025000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "77658000"
+  },
+  "medical": {
+    "$numberDecimal": "262441000"
+  },
+  "transport": {
+    "$numberDecimal": "617375000"
+  },
+  "education": {
+    "$numberDecimal": "88547000"
+  },
+  "entertainment": {
+    "$numberDecimal": "21706000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "40846000"
+  },
+  "other": {
+    "$numberDecimal": "69288000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "422248000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351222"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560680",
+  "adstrdName": "신길6동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2954616"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4773262000"
+  },
+  "food": {
+    "$numberDecimal": "1156261000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "41817000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "158962000"
+  },
+  "medical": {
+    "$numberDecimal": "1131044000"
+  },
+  "transport": {
+    "$numberDecimal": "387912000"
+  },
+  "education": {
+    "$numberDecimal": "344327000"
+  },
+  "entertainment": {
+    "$numberDecimal": "106281000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "213090000"
+  },
+  "other": {
+    "$numberDecimal": "146375000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1087193000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351223"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590605",
+  "adstrdName": "흑석동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4224946"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9834560000"
+  },
+  "food": {
+    "$numberDecimal": "1506852000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "54451000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "43148000"
+  },
+  "medical": {
+    "$numberDecimal": "5256779000"
+  },
+  "transport": {
+    "$numberDecimal": "232413000"
+  },
+  "education": {
+    "$numberDecimal": "240817000"
+  },
+  "entertainment": {
+    "$numberDecimal": "141083000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "284115000"
+  },
+  "other": {
+    "$numberDecimal": "219550000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1855352000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351224"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590640",
+  "adstrdName": "사당3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3890035"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2974853000"
+  },
+  "food": {
+    "$numberDecimal": "1131817000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "49702000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "55601000"
+  },
+  "medical": {
+    "$numberDecimal": "341416000"
+  },
+  "transport": {
+    "$numberDecimal": "19126000"
+  },
+  "education": {
+    "$numberDecimal": "202521000"
+  },
+  "entertainment": {
+    "$numberDecimal": "57722000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "197712000"
+  },
+  "other": {
+    "$numberDecimal": "116638000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "802598000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351225"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620665",
+  "adstrdName": "서림동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2530625"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2447098000"
+  },
+  "food": {
+    "$numberDecimal": "783552000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "25316000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "10026000"
+  },
+  "medical": {
+    "$numberDecimal": "93607000"
+  },
+  "transport": {
+    "$numberDecimal": "297155000"
+  },
+  "education": {
+    "$numberDecimal": "344892000"
+  },
+  "entertainment": {
+    "$numberDecimal": "15726000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "322414000"
+  },
+  "other": {
+    "$numberDecimal": "25376000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "529034000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351226"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650531",
+  "adstrdName": "서초4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "6475383"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "36588336000"
+  },
+  "food": {
+    "$numberDecimal": "1704802000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "1127185000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "111094000"
+  },
+  "medical": {
+    "$numberDecimal": "21853904000"
+  },
+  "transport": {
+    "$numberDecimal": "369715000"
+  },
+  "education": {
+    "$numberDecimal": "1437687000"
+  },
+  "entertainment": {
+    "$numberDecimal": "1488135000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1473724000"
+  },
+  "other": {
+    "$numberDecimal": "1007903000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "6014187000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351227"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650550",
+  "adstrdName": "반포본동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5583021"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "433333000"
+  },
+  "food": {
+    "$numberDecimal": "31639000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "29400000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "0"
+  },
+  "medical": {
+    "$numberDecimal": "21631000"
+  },
+  "transport": {
+    "$numberDecimal": "9887000"
+  },
+  "education": {
+    "$numberDecimal": "214541000"
+  },
+  "entertainment": {
+    "$numberDecimal": "0"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "46614000"
+  },
+  "other": {
+    "$numberDecimal": "7198000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "72423000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351228"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650560",
+  "adstrdName": "반포1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5338302"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8643595000"
+  },
+  "food": {
+    "$numberDecimal": "1053847000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "35081000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "41516000"
+  },
+  "medical": {
+    "$numberDecimal": "3800079000"
+  },
+  "transport": {
+    "$numberDecimal": "553545000"
+  },
+  "education": {
+    "$numberDecimal": "561951000"
+  },
+  "entertainment": {
+    "$numberDecimal": "141522000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "658846000"
+  },
+  "other": {
+    "$numberDecimal": "411745000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1385463000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351229"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650581",
+  "adstrdName": "반포4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5280483"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "29115333000"
+  },
+  "food": {
+    "$numberDecimal": "2309151000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "1327053000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "151507000"
+  },
+  "medical": {
+    "$numberDecimal": "12627572000"
+  },
+  "transport": {
+    "$numberDecimal": "899716000"
+  },
+  "education": {
+    "$numberDecimal": "2630560000"
+  },
+  "entertainment": {
+    "$numberDecimal": "130572000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1336860000"
+  },
+  "other": {
+    "$numberDecimal": "1529142000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "6173200000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935122a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650590",
+  "adstrdName": "방배본동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4856162"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "18763334000"
+  },
+  "food": {
+    "$numberDecimal": "864728000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "95793000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "73979000"
+  },
+  "medical": {
+    "$numberDecimal": "969427000"
+  },
+  "transport": {
+    "$numberDecimal": "520192000"
+  },
+  "education": {
+    "$numberDecimal": "549403000"
+  },
+  "entertainment": {
+    "$numberDecimal": "51052000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "306817000"
+  },
+  "other": {
+    "$numberDecimal": "14222879000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1109064000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935122b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680521",
+  "adstrdName": "논현1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3277066"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "38814874000"
+  },
+  "food": {
+    "$numberDecimal": "2328492000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "331862000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "484793000"
+  },
+  "medical": {
+    "$numberDecimal": "19076541000"
+  },
+  "transport": {
+    "$numberDecimal": "178309000"
+  },
+  "education": {
+    "$numberDecimal": "1969050000"
+  },
+  "entertainment": {
+    "$numberDecimal": "1034055000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "6073054000"
+  },
+  "other": {
+    "$numberDecimal": "1401149000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "5937569000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935122c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680545",
+  "adstrdName": "압구정동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5808537"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "39903438000"
+  },
+  "food": {
+    "$numberDecimal": "2151009000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "2450615000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "269541000"
+  },
+  "medical": {
+    "$numberDecimal": "14702376000"
+  },
+  "transport": {
+    "$numberDecimal": "241510000"
+  },
+  "education": {
+    "$numberDecimal": "2129904000"
+  },
+  "entertainment": {
+    "$numberDecimal": "992789000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "6844367000"
+  },
+  "other": {
+    "$numberDecimal": "2560340000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "7560987000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935122d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680600",
+  "adstrdName": "대치1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "7421305"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "10"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "12584123000"
+  },
+  "food": {
+    "$numberDecimal": "1178109000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "24160000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "1686000"
+  },
+  "medical": {
+    "$numberDecimal": "2043369000"
+  },
+  "transport": {
+    "$numberDecimal": "13138000"
+  },
+  "education": {
+    "$numberDecimal": "6621256000"
+  },
+  "entertainment": {
+    "$numberDecimal": "55453000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1030729000"
+  },
+  "other": {
+    "$numberDecimal": "430419000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1185804000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935122e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710520",
+  "adstrdName": "풍납2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3891704"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4891630000"
+  },
+  "food": {
+    "$numberDecimal": "937830000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "15631000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "14685000"
+  },
+  "medical": {
+    "$numberDecimal": "2763653000"
+  },
+  "transport": {
+    "$numberDecimal": "162618000"
+  },
+  "education": {
+    "$numberDecimal": "189104000"
+  },
+  "entertainment": {
+    "$numberDecimal": "34501000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "354659000"
+  },
+  "other": {
+    "$numberDecimal": "74420000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "344529000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935122f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710631",
+  "adstrdName": "가락1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4973588"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6486759000"
+  },
+  "food": {
+    "$numberDecimal": "3657684000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "64356000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "154854000"
+  },
+  "medical": {
+    "$numberDecimal": "729690000"
+  },
+  "transport": {
+    "$numberDecimal": "5940000"
+  },
+  "education": {
+    "$numberDecimal": "231878000"
+  },
+  "entertainment": {
+    "$numberDecimal": "14407000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "193886000"
+  },
+  "other": {
+    "$numberDecimal": "477177000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "956887000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351230"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710641",
+  "adstrdName": "문정1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3568357"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3561807000"
+  },
+  "food": {
+    "$numberDecimal": "945430000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "122942000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "50402000"
+  },
+  "medical": {
+    "$numberDecimal": "416248000"
+  },
+  "transport": {
+    "$numberDecimal": "89053000"
+  },
+  "education": {
+    "$numberDecimal": "176063000"
+  },
+  "entertainment": {
+    "$numberDecimal": "91991000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "528413000"
+  },
+  "other": {
+    "$numberDecimal": "79376000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1061889000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351231"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710680",
+  "adstrdName": "잠실3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5452682"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9568042000"
+  },
+  "food": {
+    "$numberDecimal": "981732000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "240682000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "107021000"
+  },
+  "medical": {
+    "$numberDecimal": "1406379000"
+  },
+  "transport": {
+    "$numberDecimal": "1576000"
+  },
+  "education": {
+    "$numberDecimal": "315764000"
+  },
+  "entertainment": {
+    "$numberDecimal": "117673000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "5419616000"
+  },
+  "other": {
+    "$numberDecimal": "389170000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "588429000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351232"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740520",
+  "adstrdName": "상일동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3690212"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3365167000"
+  },
+  "food": {
+    "$numberDecimal": "1230323000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "23799000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "55037000"
+  },
+  "medical": {
+    "$numberDecimal": "350485000"
+  },
+  "transport": {
+    "$numberDecimal": "54310000"
+  },
+  "education": {
+    "$numberDecimal": "236547000"
+  },
+  "entertainment": {
+    "$numberDecimal": "55914000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "549488000"
+  },
+  "other": {
+    "$numberDecimal": "66077000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "743187000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351233"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740700",
+  "adstrdName": "둔촌2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3414406"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4145223000"
+  },
+  "food": {
+    "$numberDecimal": "751386000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "43445000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "238604000"
+  },
+  "medical": {
+    "$numberDecimal": "515508000"
+  },
+  "transport": {
+    "$numberDecimal": "716357000"
+  },
+  "education": {
+    "$numberDecimal": "151143000"
+  },
+  "entertainment": {
+    "$numberDecimal": "20286000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "316682000"
+  },
+  "other": {
+    "$numberDecimal": "227728000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1164084000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351234"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110690",
+  "adstrdName": "창신3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3006052"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "351495000"
+  },
+  "food": {
+    "$numberDecimal": "229628000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "1737000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "1527000"
+  },
+  "medical": {
+    "$numberDecimal": "3403000"
+  },
+  "transport": {
+    "$numberDecimal": "250000"
+  },
+  "education": {
+    "$numberDecimal": "8839000"
+  },
+  "entertainment": {
+    "$numberDecimal": "4012000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "42549000"
+  },
+  "other": {
+    "$numberDecimal": "12486000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "47064000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351235"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170560",
+  "adstrdName": "원효로1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4450695"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2854134000"
+  },
+  "food": {
+    "$numberDecimal": "460772000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "25838000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "281267000"
+  },
+  "medical": {
+    "$numberDecimal": "356642000"
+  },
+  "transport": {
+    "$numberDecimal": "40289000"
+  },
+  "education": {
+    "$numberDecimal": "114472000"
+  },
+  "entertainment": {
+    "$numberDecimal": "70476000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "233073000"
+  },
+  "other": {
+    "$numberDecimal": "123224000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1148081000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351236"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170630",
+  "adstrdName": "이촌1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5974291"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2768261000"
+  },
+  "food": {
+    "$numberDecimal": "774740000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "92435000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "29569000"
+  },
+  "medical": {
+    "$numberDecimal": "447879000"
+  },
+  "transport": {
+    "$numberDecimal": "1234000"
+  },
+  "education": {
+    "$numberDecimal": "241731000"
+  },
+  "entertainment": {
+    "$numberDecimal": "61618000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "184816000"
+  },
+  "other": {
+    "$numberDecimal": "185864000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "748375000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351237"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200560",
+  "adstrdName": "행당1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3900841"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7711445000"
+  },
+  "food": {
+    "$numberDecimal": "910635000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "185148000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "193337000"
+  },
+  "medical": {
+    "$numberDecimal": "1426502000"
+  },
+  "transport": {
+    "$numberDecimal": "142903000"
+  },
+  "education": {
+    "$numberDecimal": "538940000"
+  },
+  "entertainment": {
+    "$numberDecimal": "68389000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "539947000"
+  },
+  "other": {
+    "$numberDecimal": "725092000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2980552000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351238"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230660",
+  "adstrdName": "장안2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2920490"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9616093000"
+  },
+  "food": {
+    "$numberDecimal": "3003197000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "152448000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "154178000"
+  },
+  "medical": {
+    "$numberDecimal": "1387616000"
+  },
+  "transport": {
+    "$numberDecimal": "160987000"
+  },
+  "education": {
+    "$numberDecimal": "1097780000"
+  },
+  "entertainment": {
+    "$numberDecimal": "346322000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "423453000"
+  },
+  "other": {
+    "$numberDecimal": "177166000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2712946000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351239"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230710",
+  "adstrdName": "회기동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3217279"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9677389000"
+  },
+  "food": {
+    "$numberDecimal": "731701000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "63318000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "4568000"
+  },
+  "medical": {
+    "$numberDecimal": "6054520000"
+  },
+  "transport": {
+    "$numberDecimal": "1796000"
+  },
+  "education": {
+    "$numberDecimal": "95495000"
+  },
+  "entertainment": {
+    "$numberDecimal": "226176000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "424218000"
+  },
+  "other": {
+    "$numberDecimal": "160361000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1915236000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935123a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305555",
+  "adstrdName": "송천동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2444557"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4457462000"
+  },
+  "food": {
+    "$numberDecimal": "1332231000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "86332000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "25477000"
+  },
+  "medical": {
+    "$numberDecimal": "881622000"
+  },
+  "transport": {
+    "$numberDecimal": "162211000"
+  },
+  "education": {
+    "$numberDecimal": "209216000"
+  },
+  "entertainment": {
+    "$numberDecimal": "88424000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "230600000"
+  },
+  "other": {
+    "$numberDecimal": "252170000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1189179000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935123b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320512",
+  "adstrdName": "창2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2551630"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3286142000"
+  },
+  "food": {
+    "$numberDecimal": "1123579000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "38793000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "7825000"
+  },
+  "medical": {
+    "$numberDecimal": "806585000"
+  },
+  "transport": {
+    "$numberDecimal": "135972000"
+  },
+  "education": {
+    "$numberDecimal": "117553000"
+  },
+  "entertainment": {
+    "$numberDecimal": "91652000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "227489000"
+  },
+  "other": {
+    "$numberDecimal": "151790000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "584904000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935123c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320680",
+  "adstrdName": "쌍문3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2438072"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3049395000"
+  },
+  "food": {
+    "$numberDecimal": "814264000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "117150000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "108047000"
+  },
+  "medical": {
+    "$numberDecimal": "539837000"
+  },
+  "transport": {
+    "$numberDecimal": "31994000"
+  },
+  "education": {
+    "$numberDecimal": "31865000"
+  },
+  "entertainment": {
+    "$numberDecimal": "109180000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "175598000"
+  },
+  "other": {
+    "$numberDecimal": "187572000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "933888000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935123d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350624",
+  "adstrdName": "중계4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3196660"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6282887000"
+  },
+  "food": {
+    "$numberDecimal": "2431255000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "23323000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "89787000"
+  },
+  "medical": {
+    "$numberDecimal": "1036786000"
+  },
+  "transport": {
+    "$numberDecimal": "5097000"
+  },
+  "education": {
+    "$numberDecimal": "277119000"
+  },
+  "entertainment": {
+    "$numberDecimal": "163443000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "268663000"
+  },
+  "other": {
+    "$numberDecimal": "203641000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1783773000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935123e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380551",
+  "adstrdName": "갈현1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2481200"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5540293000"
+  },
+  "food": {
+    "$numberDecimal": "816973000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "52012000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "8052000"
+  },
+  "medical": {
+    "$numberDecimal": "1024411000"
+  },
+  "transport": {
+    "$numberDecimal": "12765000"
+  },
+  "education": {
+    "$numberDecimal": "158833000"
+  },
+  "entertainment": {
+    "$numberDecimal": "726440000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "354353000"
+  },
+  "other": {
+    "$numberDecimal": "222904000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2163550000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935123f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380631",
+  "adstrdName": "신사1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2637581"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4456779000"
+  },
+  "food": {
+    "$numberDecimal": "1242956000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "52962000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "44741000"
+  },
+  "medical": {
+    "$numberDecimal": "458928000"
+  },
+  "transport": {
+    "$numberDecimal": "714006000"
+  },
+  "education": {
+    "$numberDecimal": "124390000"
+  },
+  "entertainment": {
+    "$numberDecimal": "156647000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "272200000"
+  },
+  "other": {
+    "$numberDecimal": "234879000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1155070000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351240"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410640",
+  "adstrdName": "홍제3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2807766"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4165995000"
+  },
+  "food": {
+    "$numberDecimal": "1528334000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "84310000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "33700000"
+  },
+  "medical": {
+    "$numberDecimal": "939089000"
+  },
+  "transport": {
+    "$numberDecimal": "117784000"
+  },
+  "education": {
+    "$numberDecimal": "150431000"
+  },
+  "entertainment": {
+    "$numberDecimal": "50717000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "158899000"
+  },
+  "other": {
+    "$numberDecimal": "152148000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "950583000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351241"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440585",
+  "adstrdName": "도화동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4217433"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8170201000"
+  },
+  "food": {
+    "$numberDecimal": "738512000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "40959000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "82204000"
+  },
+  "medical": {
+    "$numberDecimal": "1809395000"
+  },
+  "transport": {
+    "$numberDecimal": "520997000"
+  },
+  "education": {
+    "$numberDecimal": "119987000"
+  },
+  "entertainment": {
+    "$numberDecimal": "361539000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "817085000"
+  },
+  "other": {
+    "$numberDecimal": "729016000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2950507000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351242"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440610",
+  "adstrdName": "염리동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4051438"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "63572385000"
+  },
+  "food": {
+    "$numberDecimal": "297481000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "30152000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "87014000"
+  },
+  "medical": {
+    "$numberDecimal": "158736000"
+  },
+  "transport": {
+    "$numberDecimal": "396002000"
+  },
+  "education": {
+    "$numberDecimal": "289572000"
+  },
+  "entertainment": {
+    "$numberDecimal": "24344000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "61029777000"
+  },
+  "other": {
+    "$numberDecimal": "40313000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1218994000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351243"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440655",
+  "adstrdName": "서강동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4339738"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5586515000"
+  },
+  "food": {
+    "$numberDecimal": "1341149000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "277230000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "22331000"
+  },
+  "medical": {
+    "$numberDecimal": "153538000"
+  },
+  "transport": {
+    "$numberDecimal": "285207000"
+  },
+  "education": {
+    "$numberDecimal": "478604000"
+  },
+  "entertainment": {
+    "$numberDecimal": "224467000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "664934000"
+  },
+  "other": {
+    "$numberDecimal": "272922000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1866133000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351244"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440700",
+  "adstrdName": "망원2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2912810"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3611508000"
+  },
+  "food": {
+    "$numberDecimal": "1337880000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "66992000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "79276000"
+  },
+  "medical": {
+    "$numberDecimal": "181576000"
+  },
+  "transport": {
+    "$numberDecimal": "125365000"
+  },
+  "education": {
+    "$numberDecimal": "113953000"
+  },
+  "entertainment": {
+    "$numberDecimal": "76242000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "400050000"
+  },
+  "other": {
+    "$numberDecimal": "125900000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1104274000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351245"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470520",
+  "adstrdName": "목2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3244963"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4713432000"
+  },
+  "food": {
+    "$numberDecimal": "1168809000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "72438000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "68452000"
+  },
+  "medical": {
+    "$numberDecimal": "817184000"
+  },
+  "transport": {
+    "$numberDecimal": "648754000"
+  },
+  "education": {
+    "$numberDecimal": "307292000"
+  },
+  "entertainment": {
+    "$numberDecimal": "56749000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "231025000"
+  },
+  "other": {
+    "$numberDecimal": "87707000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1255022000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351246"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470610",
+  "adstrdName": "신월6동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2857257"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2402718000"
+  },
+  "food": {
+    "$numberDecimal": "835273000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "73090000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "36638000"
+  },
+  "medical": {
+    "$numberDecimal": "441148000"
+  },
+  "transport": {
+    "$numberDecimal": "4128000"
+  },
+  "education": {
+    "$numberDecimal": "163042000"
+  },
+  "entertainment": {
+    "$numberDecimal": "27683000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "161850000"
+  },
+  "other": {
+    "$numberDecimal": "84569000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "575297000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351247"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470620",
+  "adstrdName": "신정1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5046256"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4030359000"
+  },
+  "food": {
+    "$numberDecimal": "973265000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "95724000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "166882000"
+  },
+  "medical": {
+    "$numberDecimal": "499090000"
+  },
+  "transport": {
+    "$numberDecimal": "403512000"
+  },
+  "education": {
+    "$numberDecimal": "299712000"
+  },
+  "entertainment": {
+    "$numberDecimal": "171629000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "223774000"
+  },
+  "other": {
+    "$numberDecimal": "152440000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1044331000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351248"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470630",
+  "adstrdName": "신정2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4725315"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4137844000"
+  },
+  "food": {
+    "$numberDecimal": "1194453000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "33313000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "5852000"
+  },
+  "medical": {
+    "$numberDecimal": "624353000"
+  },
+  "transport": {
+    "$numberDecimal": "105579000"
+  },
+  "education": {
+    "$numberDecimal": "815093000"
+  },
+  "entertainment": {
+    "$numberDecimal": "28417000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "248440000"
+  },
+  "other": {
+    "$numberDecimal": "100264000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "982080000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351249"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500550",
+  "adstrdName": "화곡2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2385531"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1875071000"
+  },
+  "food": {
+    "$numberDecimal": "438780000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "21312000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "144797000"
+  },
+  "medical": {
+    "$numberDecimal": "231987000"
+  },
+  "transport": {
+    "$numberDecimal": "343387000"
+  },
+  "education": {
+    "$numberDecimal": "101639000"
+  },
+  "entertainment": {
+    "$numberDecimal": "15018000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "350820000"
+  },
+  "other": {
+    "$numberDecimal": "44324000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "183007000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935124a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500604",
+  "adstrdName": "가양2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3065320"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3006976000"
+  },
+  "food": {
+    "$numberDecimal": "1643526000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "34045000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "44052000"
+  },
+  "medical": {
+    "$numberDecimal": "560060000"
+  },
+  "transport": {
+    "$numberDecimal": "255356000"
+  },
+  "education": {
+    "$numberDecimal": "30600000"
+  },
+  "entertainment": {
+    "$numberDecimal": "12574000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "152357000"
+  },
+  "other": {
+    "$numberDecimal": "63925000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "210481000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935124b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500640",
+  "adstrdName": "방화2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2708397"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8891747000"
+  },
+  "food": {
+    "$numberDecimal": "1307764000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "3362113000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "41745000"
+  },
+  "medical": {
+    "$numberDecimal": "682515000"
+  },
+  "transport": {
+    "$numberDecimal": "680578000"
+  },
+  "education": {
+    "$numberDecimal": "34367000"
+  },
+  "entertainment": {
+    "$numberDecimal": "106528000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "496659000"
+  },
+  "other": {
+    "$numberDecimal": "1009661000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1169817000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935124c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530510",
+  "adstrdName": "신도림동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4380318"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "11205286000"
+  },
+  "food": {
+    "$numberDecimal": "1453767000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "79928000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "61338000"
+  },
+  "medical": {
+    "$numberDecimal": "1164362000"
+  },
+  "transport": {
+    "$numberDecimal": "101821000"
+  },
+  "education": {
+    "$numberDecimal": "746503000"
+  },
+  "entertainment": {
+    "$numberDecimal": "142423000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "4151726000"
+  },
+  "other": {
+    "$numberDecimal": "1346163000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1957255000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935124d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530530",
+  "adstrdName": "구로2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2453690"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "13965332000"
+  },
+  "food": {
+    "$numberDecimal": "1225719000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "48209000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "518862000"
+  },
+  "medical": {
+    "$numberDecimal": "9475069000"
+  },
+  "transport": {
+    "$numberDecimal": "444068000"
+  },
+  "education": {
+    "$numberDecimal": "54718000"
+  },
+  "entertainment": {
+    "$numberDecimal": "163934000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "368293000"
+  },
+  "other": {
+    "$numberDecimal": "78927000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1587533000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935124e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560515",
+  "adstrdName": "영등포본동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3286751"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3837728000"
+  },
+  "food": {
+    "$numberDecimal": "1642077000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "87476000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "38382000"
+  },
+  "medical": {
+    "$numberDecimal": "490930000"
+  },
+  "transport": {
+    "$numberDecimal": "143952000"
+  },
+  "education": {
+    "$numberDecimal": "140339000"
+  },
+  "entertainment": {
+    "$numberDecimal": "60324000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "223443000"
+  },
+  "other": {
+    "$numberDecimal": "131795000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "879010000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935124f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560550",
+  "adstrdName": "당산1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3536432"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6337686000"
+  },
+  "food": {
+    "$numberDecimal": "1214404000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "62851000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "74786000"
+  },
+  "medical": {
+    "$numberDecimal": "744925000"
+  },
+  "transport": {
+    "$numberDecimal": "279803000"
+  },
+  "education": {
+    "$numberDecimal": "144688000"
+  },
+  "entertainment": {
+    "$numberDecimal": "213085000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "369268000"
+  },
+  "other": {
+    "$numberDecimal": "686900000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2546976000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351250"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560630",
+  "adstrdName": "신길1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2780044"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4187583000"
+  },
+  "food": {
+    "$numberDecimal": "1089243000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "59139000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "38050000"
+  },
+  "medical": {
+    "$numberDecimal": "1234998000"
+  },
+  "transport": {
+    "$numberDecimal": "481905000"
+  },
+  "education": {
+    "$numberDecimal": "113368000"
+  },
+  "entertainment": {
+    "$numberDecimal": "61211000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "209681000"
+  },
+  "other": {
+    "$numberDecimal": "100397000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "799591000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351251"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560690",
+  "adstrdName": "신길7동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3616070"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2791791000"
+  },
+  "food": {
+    "$numberDecimal": "776863000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "10064000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "12354000"
+  },
+  "medical": {
+    "$numberDecimal": "203669000"
+  },
+  "transport": {
+    "$numberDecimal": "176850000"
+  },
+  "education": {
+    "$numberDecimal": "156627000"
+  },
+  "entertainment": {
+    "$numberDecimal": "10272000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "979249000"
+  },
+  "other": {
+    "$numberDecimal": "49116000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "416727000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351252"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560720",
+  "adstrdName": "대림3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2907933"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7446652000"
+  },
+  "food": {
+    "$numberDecimal": "936143000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "32658000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "204372000"
+  },
+  "medical": {
+    "$numberDecimal": "1864447000"
+  },
+  "transport": {
+    "$numberDecimal": "1783757000"
+  },
+  "education": {
+    "$numberDecimal": "126761000"
+  },
+  "entertainment": {
+    "$numberDecimal": "230796000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "333321000"
+  },
+  "other": {
+    "$numberDecimal": "140133000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1794264000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351253"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590510",
+  "adstrdName": "노량진1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3583099"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6771623000"
+  },
+  "food": {
+    "$numberDecimal": "2089461000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "33561000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "97618000"
+  },
+  "medical": {
+    "$numberDecimal": "467811000"
+  },
+  "transport": {
+    "$numberDecimal": "21119000"
+  },
+  "education": {
+    "$numberDecimal": "750116000"
+  },
+  "entertainment": {
+    "$numberDecimal": "296165000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "509454000"
+  },
+  "other": {
+    "$numberDecimal": "265570000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2240748000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351254"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590530",
+  "adstrdName": "상도1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3875896"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7313633000"
+  },
+  "food": {
+    "$numberDecimal": "2188846000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "55051000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "40776000"
+  },
+  "medical": {
+    "$numberDecimal": "908356000"
+  },
+  "transport": {
+    "$numberDecimal": "494964000"
+  },
+  "education": {
+    "$numberDecimal": "490800000"
+  },
+  "entertainment": {
+    "$numberDecimal": "172289000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "448982000"
+  },
+  "other": {
+    "$numberDecimal": "394861000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2118708000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351255"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590560",
+  "adstrdName": "상도4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2563258"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2245087000"
+  },
+  "food": {
+    "$numberDecimal": "998444000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "34297000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "18192000"
+  },
+  "medical": {
+    "$numberDecimal": "223071000"
+  },
+  "transport": {
+    "$numberDecimal": "16057000"
+  },
+  "education": {
+    "$numberDecimal": "98980000"
+  },
+  "entertainment": {
+    "$numberDecimal": "61913000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "118553000"
+  },
+  "other": {
+    "$numberDecimal": "68903000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "606677000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351256"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590670",
+  "adstrdName": "신대방1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3845094"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3337377000"
+  },
+  "food": {
+    "$numberDecimal": "1194823000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "43027000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "8244000"
+  },
+  "medical": {
+    "$numberDecimal": "195516000"
+  },
+  "transport": {
+    "$numberDecimal": "390360000"
+  },
+  "education": {
+    "$numberDecimal": "179311000"
+  },
+  "entertainment": {
+    "$numberDecimal": "43997000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "238299000"
+  },
+  "other": {
+    "$numberDecimal": "141494000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "902306000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351257"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620745",
+  "adstrdName": "삼성동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2593695"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1812331000"
+  },
+  "food": {
+    "$numberDecimal": "1201756000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "30165000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "7674000"
+  },
+  "medical": {
+    "$numberDecimal": "204443000"
+  },
+  "transport": {
+    "$numberDecimal": "9747000"
+  },
+  "education": {
+    "$numberDecimal": "24451000"
+  },
+  "entertainment": {
+    "$numberDecimal": "14638000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "71820000"
+  },
+  "other": {
+    "$numberDecimal": "55035000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "192602000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351258"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650660",
+  "adstrdName": "내곡동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4047063"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2619632000"
+  },
+  "food": {
+    "$numberDecimal": "494977000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "26677000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "77753000"
+  },
+  "medical": {
+    "$numberDecimal": "235771000"
+  },
+  "transport": {
+    "$numberDecimal": "573575000"
+  },
+  "education": {
+    "$numberDecimal": "117414000"
+  },
+  "entertainment": {
+    "$numberDecimal": "13576000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "348504000"
+  },
+  "other": {
+    "$numberDecimal": "55024000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "676361000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351259"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680510",
+  "adstrdName": "신사동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5099915"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "39414790000"
+  },
+  "food": {
+    "$numberDecimal": "1748667000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "1589648000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "94401000"
+  },
+  "medical": {
+    "$numberDecimal": "19885378000"
+  },
+  "transport": {
+    "$numberDecimal": "297738000"
+  },
+  "education": {
+    "$numberDecimal": "897147000"
+  },
+  "entertainment": {
+    "$numberDecimal": "930740000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "6672382000"
+  },
+  "other": {
+    "$numberDecimal": "1368452000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "5930237000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935125a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680531",
+  "adstrdName": "논현2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3973993"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "24831276000"
+  },
+  "food": {
+    "$numberDecimal": "4042684000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "969605000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "447282000"
+  },
+  "medical": {
+    "$numberDecimal": "7671275000"
+  },
+  "transport": {
+    "$numberDecimal": "661350000"
+  },
+  "education": {
+    "$numberDecimal": "658063000"
+  },
+  "entertainment": {
+    "$numberDecimal": "706189000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "2545371000"
+  },
+  "other": {
+    "$numberDecimal": "1990828000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "5138629000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935125b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680580",
+  "adstrdName": "삼성1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5098096"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "33896929000"
+  },
+  "food": {
+    "$numberDecimal": "1695053000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "6810912000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "538508000"
+  },
+  "medical": {
+    "$numberDecimal": "4807178000"
+  },
+  "transport": {
+    "$numberDecimal": "195121000"
+  },
+  "education": {
+    "$numberDecimal": "429198000"
+  },
+  "entertainment": {
+    "$numberDecimal": "225217000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "10104780000"
+  },
+  "other": {
+    "$numberDecimal": "4390262000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4700700000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935125c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680690",
+  "adstrdName": "개포4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3550527"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3443490000"
+  },
+  "food": {
+    "$numberDecimal": "861728000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "51498000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "213959000"
+  },
+  "medical": {
+    "$numberDecimal": "664998000"
+  },
+  "transport": {
+    "$numberDecimal": "130124000"
+  },
+  "education": {
+    "$numberDecimal": "169815000"
+  },
+  "entertainment": {
+    "$numberDecimal": "33213000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "292936000"
+  },
+  "other": {
+    "$numberDecimal": "258523000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "766696000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935125d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710540",
+  "adstrdName": "마천1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2435636"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1384467000"
+  },
+  "food": {
+    "$numberDecimal": "619020000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "30786000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "83856000"
+  },
+  "medical": {
+    "$numberDecimal": "306956000"
+  },
+  "transport": {
+    "$numberDecimal": "33825000"
+  },
+  "education": {
+    "$numberDecimal": "56576000"
+  },
+  "entertainment": {
+    "$numberDecimal": "36995000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "30900000"
+  },
+  "other": {
+    "$numberDecimal": "26435000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "159118000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935125e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710561",
+  "adstrdName": "방이1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3970520"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5592505000"
+  },
+  "food": {
+    "$numberDecimal": "527098000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "87207000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "17733000"
+  },
+  "medical": {
+    "$numberDecimal": "784315000"
+  },
+  "transport": {
+    "$numberDecimal": "300468000"
+  },
+  "education": {
+    "$numberDecimal": "1947123000"
+  },
+  "entertainment": {
+    "$numberDecimal": "96370000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "152150000"
+  },
+  "other": {
+    "$numberDecimal": "144244000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1535797000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935125f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710566",
+  "adstrdName": "오륜동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "6095160"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2390415000"
+  },
+  "food": {
+    "$numberDecimal": "895889000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "50338000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "11891000"
+  },
+  "medical": {
+    "$numberDecimal": "203021000"
+  },
+  "transport": {
+    "$numberDecimal": "21517000"
+  },
+  "education": {
+    "$numberDecimal": "128927000"
+  },
+  "entertainment": {
+    "$numberDecimal": "12528000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "490724000"
+  },
+  "other": {
+    "$numberDecimal": "93945000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "481635000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351260"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710570",
+  "adstrdName": "오금동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3510674"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6578543000"
+  },
+  "food": {
+    "$numberDecimal": "1607907000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "77938000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "155169000"
+  },
+  "medical": {
+    "$numberDecimal": "1163133000"
+  },
+  "transport": {
+    "$numberDecimal": "765832000"
+  },
+  "education": {
+    "$numberDecimal": "765411000"
+  },
+  "entertainment": {
+    "$numberDecimal": "65291000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "345974000"
+  },
+  "other": {
+    "$numberDecimal": "120890000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1510998000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351261"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740590",
+  "adstrdName": "암사3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4470889"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1615810000"
+  },
+  "food": {
+    "$numberDecimal": "510852000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "21615000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "35653000"
+  },
+  "medical": {
+    "$numberDecimal": "186989000"
+  },
+  "transport": {
+    "$numberDecimal": "6989000"
+  },
+  "education": {
+    "$numberDecimal": "377607000"
+  },
+  "entertainment": {
+    "$numberDecimal": "0"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "128295000"
+  },
+  "other": {
+    "$numberDecimal": "92801000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "255009000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351262"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140540",
+  "adstrdName": "회현동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4442451"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4.66E+11"
+  },
+  "food": {
+    "$numberDecimal": "21919998000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "937489000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "1080067000"
+  },
+  "medical": {
+    "$numberDecimal": "4118812000"
+  },
+  "transport": {
+    "$numberDecimal": "3.72E+11"
+  },
+  "education": {
+    "$numberDecimal": "68960000"
+  },
+  "entertainment": {
+    "$numberDecimal": "71657000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "43556341000"
+  },
+  "other": {
+    "$numberDecimal": "19739836000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3171602000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351263"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140625",
+  "adstrdName": "다산동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2679845"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3467834000"
+  },
+  "food": {
+    "$numberDecimal": "697809000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "39024000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "48653000"
+  },
+  "medical": {
+    "$numberDecimal": "686984000"
+  },
+  "transport": {
+    "$numberDecimal": "20047000"
+  },
+  "education": {
+    "$numberDecimal": "109031000"
+  },
+  "entertainment": {
+    "$numberDecimal": "93866000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "189145000"
+  },
+  "other": {
+    "$numberDecimal": "140000000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1443275000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351264"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170570",
+  "adstrdName": "원효로2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3817026"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1044663000"
+  },
+  "food": {
+    "$numberDecimal": "256175000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "20990000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "61191000"
+  },
+  "medical": {
+    "$numberDecimal": "33968000"
+  },
+  "transport": {
+    "$numberDecimal": "205857000"
+  },
+  "education": {
+    "$numberDecimal": "108385000"
+  },
+  "entertainment": {
+    "$numberDecimal": "30333000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "34418000"
+  },
+  "other": {
+    "$numberDecimal": "14551000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "278795000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351265"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200660",
+  "adstrdName": "성수1가2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3263294"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "16160526000"
+  },
+  "food": {
+    "$numberDecimal": "1958275000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "341390000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "65212000"
+  },
+  "medical": {
+    "$numberDecimal": "802177000"
+  },
+  "transport": {
+    "$numberDecimal": "468717000"
+  },
+  "education": {
+    "$numberDecimal": "278367000"
+  },
+  "entertainment": {
+    "$numberDecimal": "127131000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "8374191000"
+  },
+  "other": {
+    "$numberDecimal": "428615000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3316451000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351266"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200670",
+  "adstrdName": "성수2가1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2900762"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7539819000"
+  },
+  "food": {
+    "$numberDecimal": "2253224000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "704069000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "186948000"
+  },
+  "medical": {
+    "$numberDecimal": "623229000"
+  },
+  "transport": {
+    "$numberDecimal": "301867000"
+  },
+  "education": {
+    "$numberDecimal": "26218000"
+  },
+  "entertainment": {
+    "$numberDecimal": "218090000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "485336000"
+  },
+  "other": {
+    "$numberDecimal": "219838000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2521000000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351267"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200690",
+  "adstrdName": "성수2가3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3358391"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "17113402000"
+  },
+  "food": {
+    "$numberDecimal": "2730737000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "2843173000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "155997000"
+  },
+  "medical": {
+    "$numberDecimal": "2221091000"
+  },
+  "transport": {
+    "$numberDecimal": "1469202000"
+  },
+  "education": {
+    "$numberDecimal": "354387000"
+  },
+  "entertainment": {
+    "$numberDecimal": "410775000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "779670000"
+  },
+  "other": {
+    "$numberDecimal": "558092000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "5590278000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351268"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230536",
+  "adstrdName": "용신동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2894254"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "13391895000"
+  },
+  "food": {
+    "$numberDecimal": "3898858000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "821323000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "306942000"
+  },
+  "medical": {
+    "$numberDecimal": "4016318000"
+  },
+  "transport": {
+    "$numberDecimal": "532318000"
+  },
+  "education": {
+    "$numberDecimal": "190437000"
+  },
+  "entertainment": {
+    "$numberDecimal": "190628000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "613956000"
+  },
+  "other": {
+    "$numberDecimal": "163660000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2657455000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351269"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230545",
+  "adstrdName": "제기동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2792227"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "11185298000"
+  },
+  "food": {
+    "$numberDecimal": "6433681000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "308188000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "91766000"
+  },
+  "medical": {
+    "$numberDecimal": "1465246000"
+  },
+  "transport": {
+    "$numberDecimal": "511714000"
+  },
+  "education": {
+    "$numberDecimal": "68756000"
+  },
+  "entertainment": {
+    "$numberDecimal": "61203000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "339144000"
+  },
+  "other": {
+    "$numberDecimal": "142231000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1763369000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935126a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260620",
+  "adstrdName": "묵1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3120718"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4913289000"
+  },
+  "food": {
+    "$numberDecimal": "1215792000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "120333000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "32899000"
+  },
+  "medical": {
+    "$numberDecimal": "1474790000"
+  },
+  "transport": {
+    "$numberDecimal": "57115000"
+  },
+  "education": {
+    "$numberDecimal": "217709000"
+  },
+  "entertainment": {
+    "$numberDecimal": "147760000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "227253000"
+  },
+  "other": {
+    "$numberDecimal": "273303000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1146335000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935126b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290770",
+  "adstrdName": "장위2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2411293"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2171489000"
+  },
+  "food": {
+    "$numberDecimal": "509497000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "48393000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "133328000"
+  },
+  "medical": {
+    "$numberDecimal": "325269000"
+  },
+  "transport": {
+    "$numberDecimal": "536280000"
+  },
+  "education": {
+    "$numberDecimal": "36588000"
+  },
+  "entertainment": {
+    "$numberDecimal": "44500000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "35067000"
+  },
+  "other": {
+    "$numberDecimal": "90098000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "412469000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935126c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305545",
+  "adstrdName": "송중동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2555447"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8780792000"
+  },
+  "food": {
+    "$numberDecimal": "1358505000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "177407000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "394372000"
+  },
+  "medical": {
+    "$numberDecimal": "2497789000"
+  },
+  "transport": {
+    "$numberDecimal": "346173000"
+  },
+  "education": {
+    "$numberDecimal": "169251000"
+  },
+  "entertainment": {
+    "$numberDecimal": "484602000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "365494000"
+  },
+  "other": {
+    "$numberDecimal": "360886000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2626313000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935126d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350612",
+  "adstrdName": "하계2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3625940"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "666642000"
+  },
+  "food": {
+    "$numberDecimal": "352854000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "25012000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "4239000"
+  },
+  "medical": {
+    "$numberDecimal": "6324000"
+  },
+  "transport": {
+    "$numberDecimal": "3040000"
+  },
+  "education": {
+    "$numberDecimal": "118094000"
+  },
+  "entertainment": {
+    "$numberDecimal": "3528000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "65763000"
+  },
+  "other": {
+    "$numberDecimal": "17374000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "70414000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935126e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350695",
+  "adstrdName": "상계6?7동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3152836"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "15019088000"
+  },
+  "food": {
+    "$numberDecimal": "1599125000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "178809000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "68411000"
+  },
+  "medical": {
+    "$numberDecimal": "7972239000"
+  },
+  "transport": {
+    "$numberDecimal": "6993000"
+  },
+  "education": {
+    "$numberDecimal": "965872000"
+  },
+  "entertainment": {
+    "$numberDecimal": "399202000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "911325000"
+  },
+  "other": {
+    "$numberDecimal": "917107000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2000005000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935126f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350700",
+  "adstrdName": "상계8동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3153561"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1698326000"
+  },
+  "food": {
+    "$numberDecimal": "515158000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "49251000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "11597000"
+  },
+  "medical": {
+    "$numberDecimal": "330032000"
+  },
+  "transport": {
+    "$numberDecimal": "3846000"
+  },
+  "education": {
+    "$numberDecimal": "266091000"
+  },
+  "entertainment": {
+    "$numberDecimal": "5891000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "155862000"
+  },
+  "other": {
+    "$numberDecimal": "36462000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "324136000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351270"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380552",
+  "adstrdName": "갈현2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2539257"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6328882000"
+  },
+  "food": {
+    "$numberDecimal": "1886026000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "162063000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "83738000"
+  },
+  "medical": {
+    "$numberDecimal": "519506000"
+  },
+  "transport": {
+    "$numberDecimal": "59840000"
+  },
+  "education": {
+    "$numberDecimal": "914693000"
+  },
+  "entertainment": {
+    "$numberDecimal": "265362000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "378740000"
+  },
+  "other": {
+    "$numberDecimal": "257279000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1801635000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351271"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380625",
+  "adstrdName": "역촌동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2521877"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6685357000"
+  },
+  "food": {
+    "$numberDecimal": "2178276000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "55904000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "161417000"
+  },
+  "medical": {
+    "$numberDecimal": "1179316000"
+  },
+  "transport": {
+    "$numberDecimal": "205363000"
+  },
+  "education": {
+    "$numberDecimal": "358965000"
+  },
+  "entertainment": {
+    "$numberDecimal": "163790000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "377558000"
+  },
+  "other": {
+    "$numberDecimal": "305626000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1699142000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351272"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380650",
+  "adstrdName": "수색동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3253972"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "838762000"
+  },
+  "food": {
+    "$numberDecimal": "120541000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "22151000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "64395000"
+  },
+  "medical": {
+    "$numberDecimal": "82532000"
+  },
+  "transport": {
+    "$numberDecimal": "230093000"
+  },
+  "education": {
+    "$numberDecimal": "37243000"
+  },
+  "entertainment": {
+    "$numberDecimal": "11758000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "26276000"
+  },
+  "other": {
+    "$numberDecimal": "26562000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "217211000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351273"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410555",
+  "adstrdName": "북아현동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4172659"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2163734000"
+  },
+  "food": {
+    "$numberDecimal": "993783000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "28577000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "102374000"
+  },
+  "medical": {
+    "$numberDecimal": "273729000"
+  },
+  "transport": {
+    "$numberDecimal": "14529000"
+  },
+  "education": {
+    "$numberDecimal": "116941000"
+  },
+  "entertainment": {
+    "$numberDecimal": "23416000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "98646000"
+  },
+  "other": {
+    "$numberDecimal": "145490000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "366249000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351274"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410690",
+  "adstrdName": "남가좌1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4622839"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3047024000"
+  },
+  "food": {
+    "$numberDecimal": "792332000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "54473000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "3080000"
+  },
+  "medical": {
+    "$numberDecimal": "1236861000"
+  },
+  "transport": {
+    "$numberDecimal": "15340000"
+  },
+  "education": {
+    "$numberDecimal": "117494000"
+  },
+  "entertainment": {
+    "$numberDecimal": "53188000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "110062000"
+  },
+  "other": {
+    "$numberDecimal": "179839000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "484355000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351275"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440600",
+  "adstrdName": "대흥동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3421062"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5748998000"
+  },
+  "food": {
+    "$numberDecimal": "987243000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "68978000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "70176000"
+  },
+  "medical": {
+    "$numberDecimal": "1358893000"
+  },
+  "transport": {
+    "$numberDecimal": "18237000"
+  },
+  "education": {
+    "$numberDecimal": "1124587000"
+  },
+  "entertainment": {
+    "$numberDecimal": "79099000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "492564000"
+  },
+  "other": {
+    "$numberDecimal": "239960000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1309261000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351276"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440630",
+  "adstrdName": "신수동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4157605"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2862154000"
+  },
+  "food": {
+    "$numberDecimal": "677591000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "23909000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "32405000"
+  },
+  "medical": {
+    "$numberDecimal": "1064631000"
+  },
+  "transport": {
+    "$numberDecimal": "59960000"
+  },
+  "education": {
+    "$numberDecimal": "159647000"
+  },
+  "entertainment": {
+    "$numberDecimal": "32213000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "108012000"
+  },
+  "other": {
+    "$numberDecimal": "58918000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "644868000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351277"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440660",
+  "adstrdName": "서교동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3212258"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "59548793000"
+  },
+  "food": {
+    "$numberDecimal": "7086127000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "4404785000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "790003000"
+  },
+  "medical": {
+    "$numberDecimal": "7717473000"
+  },
+  "transport": {
+    "$numberDecimal": "130685000"
+  },
+  "education": {
+    "$numberDecimal": "2197062000"
+  },
+  "entertainment": {
+    "$numberDecimal": "4790113000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "7365468000"
+  },
+  "other": {
+    "$numberDecimal": "3455301000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "21611776000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351278"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470590",
+  "adstrdName": "신월4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2639083"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3133645000"
+  },
+  "food": {
+    "$numberDecimal": "526828000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "8820000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "18956000"
+  },
+  "medical": {
+    "$numberDecimal": "451921000"
+  },
+  "transport": {
+    "$numberDecimal": "842218000"
+  },
+  "education": {
+    "$numberDecimal": "182631000"
+  },
+  "entertainment": {
+    "$numberDecimal": "131562000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "58836000"
+  },
+  "other": {
+    "$numberDecimal": "79544000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "832329000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351279"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500540",
+  "adstrdName": "화곡1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2485455"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "11374738000"
+  },
+  "food": {
+    "$numberDecimal": "2723573000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "236956000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "174866000"
+  },
+  "medical": {
+    "$numberDecimal": "1928023000"
+  },
+  "transport": {
+    "$numberDecimal": "590295000"
+  },
+  "education": {
+    "$numberDecimal": "221984000"
+  },
+  "entertainment": {
+    "$numberDecimal": "914216000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "792904000"
+  },
+  "other": {
+    "$numberDecimal": "600142000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3191779000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935127a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500605",
+  "adstrdName": "가양3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3047051"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "559841000"
+  },
+  "food": {
+    "$numberDecimal": "218250000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "6036000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "57839000"
+  },
+  "medical": {
+    "$numberDecimal": "69772000"
+  },
+  "transport": {
+    "$numberDecimal": "3836000"
+  },
+  "education": {
+    "$numberDecimal": "29956000"
+  },
+  "entertainment": {
+    "$numberDecimal": "381000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "62889000"
+  },
+  "other": {
+    "$numberDecimal": "42197000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "68685000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935127b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500615",
+  "adstrdName": "우장산동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4135674"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6998057000"
+  },
+  "food": {
+    "$numberDecimal": "2237883000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "141308000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "127358000"
+  },
+  "medical": {
+    "$numberDecimal": "1507299000"
+  },
+  "transport": {
+    "$numberDecimal": "116637000"
+  },
+  "education": {
+    "$numberDecimal": "1148617000"
+  },
+  "entertainment": {
+    "$numberDecimal": "75853000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "351089000"
+  },
+  "other": {
+    "$numberDecimal": "396965000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "895048000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935127c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530750",
+  "adstrdName": "개봉2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3068971"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3348912000"
+  },
+  "food": {
+    "$numberDecimal": "1007280000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "35789000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "47461000"
+  },
+  "medical": {
+    "$numberDecimal": "698783000"
+  },
+  "transport": {
+    "$numberDecimal": "13973000"
+  },
+  "education": {
+    "$numberDecimal": "268982000"
+  },
+  "entertainment": {
+    "$numberDecimal": "86072000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "151086000"
+  },
+  "other": {
+    "$numberDecimal": "122879000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "916607000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935127d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530790",
+  "adstrdName": "수궁동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2682295"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2605395000"
+  },
+  "food": {
+    "$numberDecimal": "725825000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "28588000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "5879000"
+  },
+  "medical": {
+    "$numberDecimal": "117231000"
+  },
+  "transport": {
+    "$numberDecimal": "679807000"
+  },
+  "education": {
+    "$numberDecimal": "539505000"
+  },
+  "entertainment": {
+    "$numberDecimal": "27512000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "80790000"
+  },
+  "other": {
+    "$numberDecimal": "36222000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "364036000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935127e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11545510",
+  "adstrdName": "가산동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2567594"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "35943050000"
+  },
+  "food": {
+    "$numberDecimal": "3539754000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "10529830000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "376380000"
+  },
+  "medical": {
+    "$numberDecimal": "3395296000"
+  },
+  "transport": {
+    "$numberDecimal": "545925000"
+  },
+  "education": {
+    "$numberDecimal": "295990000"
+  },
+  "entertainment": {
+    "$numberDecimal": "433708000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "10013285000"
+  },
+  "other": {
+    "$numberDecimal": "903299000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "5909583000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935127f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11545620",
+  "adstrdName": "독산2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2251577"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2660097000"
+  },
+  "food": {
+    "$numberDecimal": "974535000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "80324000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "20530000"
+  },
+  "medical": {
+    "$numberDecimal": "213718000"
+  },
+  "transport": {
+    "$numberDecimal": "460320000"
+  },
+  "education": {
+    "$numberDecimal": "74877000"
+  },
+  "entertainment": {
+    "$numberDecimal": "54521000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "158592000"
+  },
+  "other": {
+    "$numberDecimal": "58658000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "564022000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351280"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11545700",
+  "adstrdName": "시흥4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2405620"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1261009000"
+  },
+  "food": {
+    "$numberDecimal": "728046000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "23992000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "8036000"
+  },
+  "medical": {
+    "$numberDecimal": "191358000"
+  },
+  "transport": {
+    "$numberDecimal": "16851000"
+  },
+  "education": {
+    "$numberDecimal": "45039000"
+  },
+  "entertainment": {
+    "$numberDecimal": "30106000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "43953000"
+  },
+  "other": {
+    "$numberDecimal": "31316000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "142312000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351281"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560540",
+  "adstrdName": "여의동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5590853"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.26E+11"
+  },
+  "food": {
+    "$numberDecimal": "3862209000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "692030000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "300098000"
+  },
+  "medical": {
+    "$numberDecimal": "7306684000"
+  },
+  "transport": {
+    "$numberDecimal": "52523795000"
+  },
+  "education": {
+    "$numberDecimal": "857522000"
+  },
+  "entertainment": {
+    "$numberDecimal": "668871000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "25514164000"
+  },
+  "other": {
+    "$numberDecimal": "20125733000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "14126190000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351282"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560700",
+  "adstrdName": "대림1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2582442"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5033227000"
+  },
+  "food": {
+    "$numberDecimal": "1844013000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "35565000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "131910000"
+  },
+  "medical": {
+    "$numberDecimal": "1983497000"
+  },
+  "transport": {
+    "$numberDecimal": "16634000"
+  },
+  "education": {
+    "$numberDecimal": "51233000"
+  },
+  "entertainment": {
+    "$numberDecimal": "55750000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "139972000"
+  },
+  "other": {
+    "$numberDecimal": "72546000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "702107000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351283"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590550",
+  "adstrdName": "상도3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2575897"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4872020000"
+  },
+  "food": {
+    "$numberDecimal": "2691245000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "117465000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "24504000"
+  },
+  "medical": {
+    "$numberDecimal": "443143000"
+  },
+  "transport": {
+    "$numberDecimal": "115527000"
+  },
+  "education": {
+    "$numberDecimal": "71778000"
+  },
+  "entertainment": {
+    "$numberDecimal": "66488000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "225017000"
+  },
+  "other": {
+    "$numberDecimal": "157927000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "958926000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351284"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620545",
+  "adstrdName": "청림동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3682775"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1160686000"
+  },
+  "food": {
+    "$numberDecimal": "683347000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "5754000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "2452000"
+  },
+  "medical": {
+    "$numberDecimal": "66517000"
+  },
+  "transport": {
+    "$numberDecimal": "1655000"
+  },
+  "education": {
+    "$numberDecimal": "144054000"
+  },
+  "entertainment": {
+    "$numberDecimal": "21665000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "106486000"
+  },
+  "other": {
+    "$numberDecimal": "24797000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "103959000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351285"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620585",
+  "adstrdName": "낙성대동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3225725"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8868798000"
+  },
+  "food": {
+    "$numberDecimal": "811319000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "88503000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "7590000"
+  },
+  "medical": {
+    "$numberDecimal": "1750324000"
+  },
+  "transport": {
+    "$numberDecimal": "229319000"
+  },
+  "education": {
+    "$numberDecimal": "90959000"
+  },
+  "entertainment": {
+    "$numberDecimal": "472246000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "602973000"
+  },
+  "other": {
+    "$numberDecimal": "368323000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4447242000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351286"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620605",
+  "adstrdName": "은천동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3063077"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6271154000"
+  },
+  "food": {
+    "$numberDecimal": "2519653000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "72052000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "418838000"
+  },
+  "medical": {
+    "$numberDecimal": "486272000"
+  },
+  "transport": {
+    "$numberDecimal": "348778000"
+  },
+  "education": {
+    "$numberDecimal": "262929000"
+  },
+  "entertainment": {
+    "$numberDecimal": "106914000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "195322000"
+  },
+  "other": {
+    "$numberDecimal": "219526000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1640870000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351287"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620615",
+  "adstrdName": "중앙동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2633493"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5860073000"
+  },
+  "food": {
+    "$numberDecimal": "1810643000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "96397000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "11770000"
+  },
+  "medical": {
+    "$numberDecimal": "1483135000"
+  },
+  "transport": {
+    "$numberDecimal": "33164000"
+  },
+  "education": {
+    "$numberDecimal": "496434000"
+  },
+  "entertainment": {
+    "$numberDecimal": "80064000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "279919000"
+  },
+  "other": {
+    "$numberDecimal": "214989000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1353558000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351288"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620765",
+  "adstrdName": "미성동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2676537"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3578127000"
+  },
+  "food": {
+    "$numberDecimal": "954950000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "235418000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "67602000"
+  },
+  "medical": {
+    "$numberDecimal": "403261000"
+  },
+  "transport": {
+    "$numberDecimal": "293922000"
+  },
+  "education": {
+    "$numberDecimal": "224050000"
+  },
+  "entertainment": {
+    "$numberDecimal": "136959000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "168925000"
+  },
+  "other": {
+    "$numberDecimal": "324653000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "768387000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351289"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650530",
+  "adstrdName": "서초3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4678950"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2.34E+11"
+  },
+  "food": {
+    "$numberDecimal": "2125083000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "200626000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "9991387000"
+  },
+  "medical": {
+    "$numberDecimal": "3938275000"
+  },
+  "transport": {
+    "$numberDecimal": "612898000"
+  },
+  "education": {
+    "$numberDecimal": "769559000"
+  },
+  "entertainment": {
+    "$numberDecimal": "433748000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "2.08E+11"
+  },
+  "other": {
+    "$numberDecimal": "696613000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "7082528000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935128a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650580",
+  "adstrdName": "반포3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "6140775"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4859746000"
+  },
+  "food": {
+    "$numberDecimal": "406577000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "428962000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "100788000"
+  },
+  "medical": {
+    "$numberDecimal": "926103000"
+  },
+  "transport": {
+    "$numberDecimal": "21348000"
+  },
+  "education": {
+    "$numberDecimal": "1020098000"
+  },
+  "entertainment": {
+    "$numberDecimal": "51935000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "723828000"
+  },
+  "other": {
+    "$numberDecimal": "108155000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1071952000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935128b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680656",
+  "adstrdName": "도곡2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "6567504"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "66590430000"
+  },
+  "food": {
+    "$numberDecimal": "1153189000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "211048000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "103872000"
+  },
+  "medical": {
+    "$numberDecimal": "855672000"
+  },
+  "transport": {
+    "$numberDecimal": "262016000"
+  },
+  "education": {
+    "$numberDecimal": "477425000"
+  },
+  "entertainment": {
+    "$numberDecimal": "75603000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "60501689000"
+  },
+  "other": {
+    "$numberDecimal": "552892000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2397024000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935128c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680670",
+  "adstrdName": "개포2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5195802"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2308596000"
+  },
+  "food": {
+    "$numberDecimal": "771093000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "30923000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "1432000"
+  },
+  "medical": {
+    "$numberDecimal": "409618000"
+  },
+  "transport": {
+    "$numberDecimal": "14653000"
+  },
+  "education": {
+    "$numberDecimal": "211118000"
+  },
+  "entertainment": {
+    "$numberDecimal": "61561000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "151925000"
+  },
+  "other": {
+    "$numberDecimal": "132092000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "524181000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935128d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680700",
+  "adstrdName": "세곡동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3885403"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5566489000"
+  },
+  "food": {
+    "$numberDecimal": "1499299000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "49296000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "96758000"
+  },
+  "medical": {
+    "$numberDecimal": "685306000"
+  },
+  "transport": {
+    "$numberDecimal": "774644000"
+  },
+  "education": {
+    "$numberDecimal": "686268000"
+  },
+  "entertainment": {
+    "$numberDecimal": "24282000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "336396000"
+  },
+  "other": {
+    "$numberDecimal": "390363000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1023877000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935128e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710550",
+  "adstrdName": "마천2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2339431"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3904680000"
+  },
+  "food": {
+    "$numberDecimal": "1609006000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "115028000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "62692000"
+  },
+  "medical": {
+    "$numberDecimal": "854976000"
+  },
+  "transport": {
+    "$numberDecimal": "139633000"
+  },
+  "education": {
+    "$numberDecimal": "61613000"
+  },
+  "entertainment": {
+    "$numberDecimal": "98106000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "102856000"
+  },
+  "other": {
+    "$numberDecimal": "63238000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "797532000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935128f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740515",
+  "adstrdName": "강일동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3073250"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3336062000"
+  },
+  "food": {
+    "$numberDecimal": "1231102000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "13500000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "11468000"
+  },
+  "medical": {
+    "$numberDecimal": "575267000"
+  },
+  "transport": {
+    "$numberDecimal": "239396000"
+  },
+  "education": {
+    "$numberDecimal": "390581000"
+  },
+  "entertainment": {
+    "$numberDecimal": "4753000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "187079000"
+  },
+  "other": {
+    "$numberDecimal": "103776000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "579140000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351290"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740540",
+  "adstrdName": "명일2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4514278"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7144394000"
+  },
+  "food": {
+    "$numberDecimal": "888114000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "37249000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "14611000"
+  },
+  "medical": {
+    "$numberDecimal": "2016252000"
+  },
+  "transport": {
+    "$numberDecimal": "25569000"
+  },
+  "education": {
+    "$numberDecimal": "2264779000"
+  },
+  "entertainment": {
+    "$numberDecimal": "42424000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "367891000"
+  },
+  "other": {
+    "$numberDecimal": "208922000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1278583000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351291"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740570",
+  "adstrdName": "암사1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2852157"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6380239000"
+  },
+  "food": {
+    "$numberDecimal": "3034181000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "77131000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "42423000"
+  },
+  "medical": {
+    "$numberDecimal": "785813000"
+  },
+  "transport": {
+    "$numberDecimal": "426899000"
+  },
+  "education": {
+    "$numberDecimal": "172408000"
+  },
+  "entertainment": {
+    "$numberDecimal": "141233000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "178536000"
+  },
+  "other": {
+    "$numberDecimal": "286486000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1235129000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351292"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740685",
+  "adstrdName": "길동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2840603"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "13400194000"
+  },
+  "food": {
+    "$numberDecimal": "3403423000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "130452000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "359757000"
+  },
+  "medical": {
+    "$numberDecimal": "4148510000"
+  },
+  "transport": {
+    "$numberDecimal": "128309000"
+  },
+  "education": {
+    "$numberDecimal": "371346000"
+  },
+  "entertainment": {
+    "$numberDecimal": "532570000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "775539000"
+  },
+  "other": {
+    "$numberDecimal": "370631000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3179657000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351293"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110515",
+  "adstrdName": "청운효자동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3780222"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2682246000"
+  },
+  "food": {
+    "$numberDecimal": "886367000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "192955000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "61591000"
+  },
+  "medical": {
+    "$numberDecimal": "109434000"
+  },
+  "transport": {
+    "$numberDecimal": "62858000"
+  },
+  "education": {
+    "$numberDecimal": "94572000"
+  },
+  "entertainment": {
+    "$numberDecimal": "73323000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "82519000"
+  },
+  "other": {
+    "$numberDecimal": "81010000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1037617000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351294"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110530",
+  "adstrdName": "사직동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5007768"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "49235459000"
+  },
+  "food": {
+    "$numberDecimal": "1539134000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "614264000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "22723000"
+  },
+  "medical": {
+    "$numberDecimal": "1876966000"
+  },
+  "transport": {
+    "$numberDecimal": "964662000"
+  },
+  "education": {
+    "$numberDecimal": "239884000"
+  },
+  "entertainment": {
+    "$numberDecimal": "329720000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1530477000"
+  },
+  "other": {
+    "$numberDecimal": "35815159000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "6302470000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351295"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110540",
+  "adstrdName": "삼청동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3442534"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2971164000"
+  },
+  "food": {
+    "$numberDecimal": "556724000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "350161000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "40602000"
+  },
+  "medical": {
+    "$numberDecimal": "64833000"
+  },
+  "transport": {
+    "$numberDecimal": "115000"
+  },
+  "education": {
+    "$numberDecimal": "5160000"
+  },
+  "entertainment": {
+    "$numberDecimal": "53087000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "284015000"
+  },
+  "other": {
+    "$numberDecimal": "81458000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1535009000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351296"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110550",
+  "adstrdName": "부암동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3647449"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2006364000"
+  },
+  "food": {
+    "$numberDecimal": "199491000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "45079000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "6568000"
+  },
+  "medical": {
+    "$numberDecimal": "78894000"
+  },
+  "transport": {
+    "$numberDecimal": "125067000"
+  },
+  "education": {
+    "$numberDecimal": "676976000"
+  },
+  "entertainment": {
+    "$numberDecimal": "837000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "230863000"
+  },
+  "other": {
+    "$numberDecimal": "32575000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "610014000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351297"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110560",
+  "adstrdName": "평창동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4504006"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2600629000"
+  },
+  "food": {
+    "$numberDecimal": "716553000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "58755000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "59022000"
+  },
+  "medical": {
+    "$numberDecimal": "300012000"
+  },
+  "transport": {
+    "$numberDecimal": "154865000"
+  },
+  "education": {
+    "$numberDecimal": "183588000"
+  },
+  "entertainment": {
+    "$numberDecimal": "15373000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "134929000"
+  },
+  "other": {
+    "$numberDecimal": "93868000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "883664000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351298"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110570",
+  "adstrdName": "무악동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5136717"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2879424000"
+  },
+  "food": {
+    "$numberDecimal": "263458000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "930000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "0"
+  },
+  "medical": {
+    "$numberDecimal": "2293730000"
+  },
+  "transport": {
+    "$numberDecimal": "2643000"
+  },
+  "education": {
+    "$numberDecimal": "56618000"
+  },
+  "entertainment": {
+    "$numberDecimal": "6321000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "58727000"
+  },
+  "other": {
+    "$numberDecimal": "53177000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "143820000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351299"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110580",
+  "adstrdName": "교남동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4616890"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2511152000"
+  },
+  "food": {
+    "$numberDecimal": "347573000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "30253000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "7304000"
+  },
+  "medical": {
+    "$numberDecimal": "1338691000"
+  },
+  "transport": {
+    "$numberDecimal": "18378000"
+  },
+  "education": {
+    "$numberDecimal": "217213000"
+  },
+  "entertainment": {
+    "$numberDecimal": "37049000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "39317000"
+  },
+  "other": {
+    "$numberDecimal": "59333000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "416041000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935129a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110600",
+  "adstrdName": "가회동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3479766"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2640448000"
+  },
+  "food": {
+    "$numberDecimal": "563812000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "94347000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "17409000"
+  },
+  "medical": {
+    "$numberDecimal": "25143000"
+  },
+  "transport": {
+    "$numberDecimal": "968000"
+  },
+  "education": {
+    "$numberDecimal": "77121000"
+  },
+  "entertainment": {
+    "$numberDecimal": "71866000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "222876000"
+  },
+  "other": {
+    "$numberDecimal": "24776000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1542130000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935129b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110650",
+  "adstrdName": "혜화동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3333112"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "10061923000"
+  },
+  "food": {
+    "$numberDecimal": "1731551000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "113496000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "13859000"
+  },
+  "medical": {
+    "$numberDecimal": "1689144000"
+  },
+  "transport": {
+    "$numberDecimal": "31277000"
+  },
+  "education": {
+    "$numberDecimal": "263448000"
+  },
+  "entertainment": {
+    "$numberDecimal": "401175000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "729246000"
+  },
+  "other": {
+    "$numberDecimal": "477581000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4611146000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935129c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140550",
+  "adstrdName": "명동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3733600"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.23E+11"
+  },
+  "food": {
+    "$numberDecimal": "2427428000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "1649583000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "3347509000"
+  },
+  "medical": {
+    "$numberDecimal": "3365352000"
+  },
+  "transport": {
+    "$numberDecimal": "30984075000"
+  },
+  "education": {
+    "$numberDecimal": "22350078000"
+  },
+  "entertainment": {
+    "$numberDecimal": "297829000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "8795793000"
+  },
+  "other": {
+    "$numberDecimal": "40745286000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "8853062000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935129d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140670",
+  "adstrdName": "황학동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3247840"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4227276000"
+  },
+  "food": {
+    "$numberDecimal": "1193405000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "52505000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "249635000"
+  },
+  "medical": {
+    "$numberDecimal": "631425000"
+  },
+  "transport": {
+    "$numberDecimal": "53386000"
+  },
+  "education": {
+    "$numberDecimal": "44757000"
+  },
+  "entertainment": {
+    "$numberDecimal": "96144000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "393265000"
+  },
+  "other": {
+    "$numberDecimal": "92620000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1420134000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935129e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170520",
+  "adstrdName": "용산2가동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2540319"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.37E+11"
+  },
+  "food": {
+    "$numberDecimal": "1.35E+11"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "66293000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "11960000"
+  },
+  "medical": {
+    "$numberDecimal": "31887000"
+  },
+  "transport": {
+    "$numberDecimal": "1998000"
+  },
+  "education": {
+    "$numberDecimal": "19416000"
+  },
+  "entertainment": {
+    "$numberDecimal": "61180000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "149899000"
+  },
+  "other": {
+    "$numberDecimal": "14621000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1374680000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935129f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170530",
+  "adstrdName": "남영동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3183091"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "43688827000"
+  },
+  "food": {
+    "$numberDecimal": "1909906000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "106756000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "896737000"
+  },
+  "medical": {
+    "$numberDecimal": "681571000"
+  },
+  "transport": {
+    "$numberDecimal": "151669000"
+  },
+  "education": {
+    "$numberDecimal": "81643000"
+  },
+  "entertainment": {
+    "$numberDecimal": "292181000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "13034128000"
+  },
+  "other": {
+    "$numberDecimal": "23253053000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3281183000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512a0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170590",
+  "adstrdName": "용문동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3568910"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1548812000"
+  },
+  "food": {
+    "$numberDecimal": "725967000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "33490000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "56285000"
+  },
+  "medical": {
+    "$numberDecimal": "92617000"
+  },
+  "transport": {
+    "$numberDecimal": "5134000"
+  },
+  "education": {
+    "$numberDecimal": "44489000"
+  },
+  "entertainment": {
+    "$numberDecimal": "32288000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "46615000"
+  },
+  "other": {
+    "$numberDecimal": "58982000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "452945000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512a1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170640",
+  "adstrdName": "이촌2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3596083"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "379321000"
+  },
+  "food": {
+    "$numberDecimal": "178383000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "22475000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "1558000"
+  },
+  "medical": {
+    "$numberDecimal": "1744000"
+  },
+  "transport": {
+    "$numberDecimal": "56422000"
+  },
+  "education": {
+    "$numberDecimal": "23265000"
+  },
+  "entertainment": {
+    "$numberDecimal": "0"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "16721000"
+  },
+  "other": {
+    "$numberDecimal": "5134000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "73619000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512a2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200550",
+  "adstrdName": "사근동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3099614"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5408273000"
+  },
+  "food": {
+    "$numberDecimal": "970225000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "20959000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "5252000"
+  },
+  "medical": {
+    "$numberDecimal": "554407000"
+  },
+  "transport": {
+    "$numberDecimal": "18980000"
+  },
+  "education": {
+    "$numberDecimal": "44380000"
+  },
+  "entertainment": {
+    "$numberDecimal": "565582000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "287278000"
+  },
+  "other": {
+    "$numberDecimal": "438857000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2502353000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512a3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215740",
+  "adstrdName": "중곡1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2542359"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5182812000"
+  },
+  "food": {
+    "$numberDecimal": "1838614000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "69288000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "171225000"
+  },
+  "medical": {
+    "$numberDecimal": "610728000"
+  },
+  "transport": {
+    "$numberDecimal": "777019000"
+  },
+  "education": {
+    "$numberDecimal": "52965000"
+  },
+  "entertainment": {
+    "$numberDecimal": "200084000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "259198000"
+  },
+  "other": {
+    "$numberDecimal": "162362000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1041329000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512a4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215870",
+  "adstrdName": "구의3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4010979"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9674505000"
+  },
+  "food": {
+    "$numberDecimal": "1974301000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "417641000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "477084000"
+  },
+  "medical": {
+    "$numberDecimal": "1454182000"
+  },
+  "transport": {
+    "$numberDecimal": "37779000"
+  },
+  "education": {
+    "$numberDecimal": "913027000"
+  },
+  "entertainment": {
+    "$numberDecimal": "118709000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "757640000"
+  },
+  "other": {
+    "$numberDecimal": "1264673000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2259469000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512a5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230750",
+  "adstrdName": "이문2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3137841"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1386543000"
+  },
+  "food": {
+    "$numberDecimal": "590120000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "13965000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "3331000"
+  },
+  "medical": {
+    "$numberDecimal": "239982000"
+  },
+  "transport": {
+    "$numberDecimal": "0"
+  },
+  "education": {
+    "$numberDecimal": "143108000"
+  },
+  "entertainment": {
+    "$numberDecimal": "38918000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "49329000"
+  },
+  "other": {
+    "$numberDecimal": "41594000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "266196000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512a6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260540",
+  "adstrdName": "면목4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2573570"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "984850000"
+  },
+  "food": {
+    "$numberDecimal": "411448000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "7435000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "57017000"
+  },
+  "medical": {
+    "$numberDecimal": "69305000"
+  },
+  "transport": {
+    "$numberDecimal": "20502000"
+  },
+  "education": {
+    "$numberDecimal": "62994000"
+  },
+  "entertainment": {
+    "$numberDecimal": "48314000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "67424000"
+  },
+  "other": {
+    "$numberDecimal": "44962000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "195449000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512a7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260550",
+  "adstrdName": "면목5동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2233073"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2602329000"
+  },
+  "food": {
+    "$numberDecimal": "349278000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "10846000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "28551000"
+  },
+  "medical": {
+    "$numberDecimal": "124595000"
+  },
+  "transport": {
+    "$numberDecimal": "1745129000"
+  },
+  "education": {
+    "$numberDecimal": "53549000"
+  },
+  "entertainment": {
+    "$numberDecimal": "17807000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "72552000"
+  },
+  "other": {
+    "$numberDecimal": "20915000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "179107000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512a8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260580",
+  "adstrdName": "상봉1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2969913"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4890853000"
+  },
+  "food": {
+    "$numberDecimal": "2526255000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "34255000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "10428000"
+  },
+  "medical": {
+    "$numberDecimal": "667876000"
+  },
+  "transport": {
+    "$numberDecimal": "28102000"
+  },
+  "education": {
+    "$numberDecimal": "119814000"
+  },
+  "entertainment": {
+    "$numberDecimal": "36302000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "79270000"
+  },
+  "other": {
+    "$numberDecimal": "226458000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1162093000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512a9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260660",
+  "adstrdName": "망우3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2231082"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1741578000"
+  },
+  "food": {
+    "$numberDecimal": "462173000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "15249000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "8645000"
+  },
+  "medical": {
+    "$numberDecimal": "223149000"
+  },
+  "transport": {
+    "$numberDecimal": "587943000"
+  },
+  "education": {
+    "$numberDecimal": "28837000"
+  },
+  "entertainment": {
+    "$numberDecimal": "14350000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "69557000"
+  },
+  "other": {
+    "$numberDecimal": "23118000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "308557000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512aa"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290575",
+  "adstrdName": "동선동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2821008"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "11143422000"
+  },
+  "food": {
+    "$numberDecimal": "1368054000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "386162000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "76078000"
+  },
+  "medical": {
+    "$numberDecimal": "2555489000"
+  },
+  "transport": {
+    "$numberDecimal": "36427000"
+  },
+  "education": {
+    "$numberDecimal": "537881000"
+  },
+  "entertainment": {
+    "$numberDecimal": "647153000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1147209000"
+  },
+  "other": {
+    "$numberDecimal": "524277000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3864692000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ab"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290590",
+  "adstrdName": "돈암2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4297592"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "910725000"
+  },
+  "food": {
+    "$numberDecimal": "216706000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "13999000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "0"
+  },
+  "medical": {
+    "$numberDecimal": "108445000"
+  },
+  "transport": {
+    "$numberDecimal": "4000"
+  },
+  "education": {
+    "$numberDecimal": "156704000"
+  },
+  "entertainment": {
+    "$numberDecimal": "3146000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "162100000"
+  },
+  "other": {
+    "$numberDecimal": "150142000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "99479000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ac"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290650",
+  "adstrdName": "정릉4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3038165"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3392210000"
+  },
+  "food": {
+    "$numberDecimal": "1032954000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "36983000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "6338000"
+  },
+  "medical": {
+    "$numberDecimal": "487870000"
+  },
+  "transport": {
+    "$numberDecimal": "732841000"
+  },
+  "education": {
+    "$numberDecimal": "101114000"
+  },
+  "entertainment": {
+    "$numberDecimal": "54699000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "120378000"
+  },
+  "other": {
+    "$numberDecimal": "80491000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "738542000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ad"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305595",
+  "adstrdName": "번1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2303972"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7181715000"
+  },
+  "food": {
+    "$numberDecimal": "832042000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "139399000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "35489000"
+  },
+  "medical": {
+    "$numberDecimal": "2237746000"
+  },
+  "transport": {
+    "$numberDecimal": "499171000"
+  },
+  "education": {
+    "$numberDecimal": "233610000"
+  },
+  "entertainment": {
+    "$numberDecimal": "252553000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "732515000"
+  },
+  "other": {
+    "$numberDecimal": "466826000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1752364000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ae"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320521",
+  "adstrdName": "도봉1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2275377"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4693821000"
+  },
+  "food": {
+    "$numberDecimal": "1482577000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "41349000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "16519000"
+  },
+  "medical": {
+    "$numberDecimal": "198697000"
+  },
+  "transport": {
+    "$numberDecimal": "896036000"
+  },
+  "education": {
+    "$numberDecimal": "26940000"
+  },
+  "entertainment": {
+    "$numberDecimal": "136161000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "488701000"
+  },
+  "other": {
+    "$numberDecimal": "47414000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1359427000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512af"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320681",
+  "adstrdName": "쌍문4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2968285"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1650326000"
+  },
+  "food": {
+    "$numberDecimal": "847863000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "22640000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "59518000"
+  },
+  "medical": {
+    "$numberDecimal": "155963000"
+  },
+  "transport": {
+    "$numberDecimal": "0"
+  },
+  "education": {
+    "$numberDecimal": "304895000"
+  },
+  "entertainment": {
+    "$numberDecimal": "1928000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "72519000"
+  },
+  "other": {
+    "$numberDecimal": "23019000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "161981000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512b0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350640",
+  "adstrdName": "상계2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3122902"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "19134731000"
+  },
+  "food": {
+    "$numberDecimal": "1970897000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "271755000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "119345000"
+  },
+  "medical": {
+    "$numberDecimal": "2552288000"
+  },
+  "transport": {
+    "$numberDecimal": "454364000"
+  },
+  "education": {
+    "$numberDecimal": "404344000"
+  },
+  "entertainment": {
+    "$numberDecimal": "1064896000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "5695566000"
+  },
+  "other": {
+    "$numberDecimal": "837538000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "5763738000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512b1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350665",
+  "adstrdName": "상계3?4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2644186"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1370941000"
+  },
+  "food": {
+    "$numberDecimal": "581120000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "30187000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "63781000"
+  },
+  "medical": {
+    "$numberDecimal": "154070000"
+  },
+  "transport": {
+    "$numberDecimal": "12201000"
+  },
+  "education": {
+    "$numberDecimal": "94468000"
+  },
+  "entertainment": {
+    "$numberDecimal": "30252000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "59861000"
+  },
+  "other": {
+    "$numberDecimal": "40088000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "304913000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512b2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350670",
+  "adstrdName": "상계5동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2481440"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2450525000"
+  },
+  "food": {
+    "$numberDecimal": "933416000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "57878000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "108616000"
+  },
+  "medical": {
+    "$numberDecimal": "155821000"
+  },
+  "transport": {
+    "$numberDecimal": "44964000"
+  },
+  "education": {
+    "$numberDecimal": "136732000"
+  },
+  "entertainment": {
+    "$numberDecimal": "89926000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "120172000"
+  },
+  "other": {
+    "$numberDecimal": "128197000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "674803000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512b3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380640",
+  "adstrdName": "증산동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2838450"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2140533000"
+  },
+  "food": {
+    "$numberDecimal": "383148000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "64707000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "98449000"
+  },
+  "medical": {
+    "$numberDecimal": "272081000"
+  },
+  "transport": {
+    "$numberDecimal": "664986000"
+  },
+  "education": {
+    "$numberDecimal": "108832000"
+  },
+  "entertainment": {
+    "$numberDecimal": "14135000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "128579000"
+  },
+  "other": {
+    "$numberDecimal": "47653000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "357963000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512b4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410655",
+  "adstrdName": "홍제2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3664523"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1652244000"
+  },
+  "food": {
+    "$numberDecimal": "253844000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "59333000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "5436000"
+  },
+  "medical": {
+    "$numberDecimal": "419726000"
+  },
+  "transport": {
+    "$numberDecimal": "376595000"
+  },
+  "education": {
+    "$numberDecimal": "87064000"
+  },
+  "entertainment": {
+    "$numberDecimal": "15569000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "78745000"
+  },
+  "other": {
+    "$numberDecimal": "32497000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "323435000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512b5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470580",
+  "adstrdName": "신월3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2152244"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2442662000"
+  },
+  "food": {
+    "$numberDecimal": "516535000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "20806000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "19362000"
+  },
+  "medical": {
+    "$numberDecimal": "241073000"
+  },
+  "transport": {
+    "$numberDecimal": "1146956000"
+  },
+  "education": {
+    "$numberDecimal": "71123000"
+  },
+  "entertainment": {
+    "$numberDecimal": "25578000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "41837000"
+  },
+  "other": {
+    "$numberDecimal": "63074000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "296318000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512b6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500520",
+  "adstrdName": "등촌1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3322838"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5283575000"
+  },
+  "food": {
+    "$numberDecimal": "1060284000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "88162000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "72647000"
+  },
+  "medical": {
+    "$numberDecimal": "1273457000"
+  },
+  "transport": {
+    "$numberDecimal": "348158000"
+  },
+  "education": {
+    "$numberDecimal": "171204000"
+  },
+  "entertainment": {
+    "$numberDecimal": "143255000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "456296000"
+  },
+  "other": {
+    "$numberDecimal": "218804000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1451308000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512b7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500530",
+  "adstrdName": "등촌2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3352636"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2345377000"
+  },
+  "food": {
+    "$numberDecimal": "401428000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "396156000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "74094000"
+  },
+  "medical": {
+    "$numberDecimal": "251490000"
+  },
+  "transport": {
+    "$numberDecimal": "445688000"
+  },
+  "education": {
+    "$numberDecimal": "96815000"
+  },
+  "entertainment": {
+    "$numberDecimal": "42460000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "60362000"
+  },
+  "other": {
+    "$numberDecimal": "44601000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "532283000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512b8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500535",
+  "adstrdName": "등촌3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3403390"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8816822000"
+  },
+  "food": {
+    "$numberDecimal": "1425267000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "44076000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "103486000"
+  },
+  "medical": {
+    "$numberDecimal": "3273815000"
+  },
+  "transport": {
+    "$numberDecimal": "76539000"
+  },
+  "education": {
+    "$numberDecimal": "587383000"
+  },
+  "entertainment": {
+    "$numberDecimal": "83914000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "541367000"
+  },
+  "other": {
+    "$numberDecimal": "709879000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1971096000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512b9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560710",
+  "adstrdName": "대림2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2686240"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4478590000"
+  },
+  "food": {
+    "$numberDecimal": "1394270000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "174141000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "26800000"
+  },
+  "medical": {
+    "$numberDecimal": "520999000"
+  },
+  "transport": {
+    "$numberDecimal": "14308000"
+  },
+  "education": {
+    "$numberDecimal": "26629000"
+  },
+  "entertainment": {
+    "$numberDecimal": "199348000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "175215000"
+  },
+  "other": {
+    "$numberDecimal": "302522000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1644358000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ba"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590520",
+  "adstrdName": "노량진2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2420761"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6623041000"
+  },
+  "food": {
+    "$numberDecimal": "3777310000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "22944000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "70914000"
+  },
+  "medical": {
+    "$numberDecimal": "450184000"
+  },
+  "transport": {
+    "$numberDecimal": "11161000"
+  },
+  "education": {
+    "$numberDecimal": "307307000"
+  },
+  "entertainment": {
+    "$numberDecimal": "157678000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "125069000"
+  },
+  "other": {
+    "$numberDecimal": "140449000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1560025000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512bb"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590650",
+  "adstrdName": "사당4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2844168"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2281112000"
+  },
+  "food": {
+    "$numberDecimal": "1299617000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "47398000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "19232000"
+  },
+  "medical": {
+    "$numberDecimal": "207725000"
+  },
+  "transport": {
+    "$numberDecimal": "8002000"
+  },
+  "education": {
+    "$numberDecimal": "111622000"
+  },
+  "entertainment": {
+    "$numberDecimal": "14458000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "94408000"
+  },
+  "other": {
+    "$numberDecimal": "142736000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "335914000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512bc"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620565",
+  "adstrdName": "성현동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3455108"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1449328000"
+  },
+  "food": {
+    "$numberDecimal": "510784000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "37113000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "17578000"
+  },
+  "medical": {
+    "$numberDecimal": "125706000"
+  },
+  "transport": {
+    "$numberDecimal": "61590000"
+  },
+  "education": {
+    "$numberDecimal": "335645000"
+  },
+  "entertainment": {
+    "$numberDecimal": "8620000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "178652000"
+  },
+  "other": {
+    "$numberDecimal": "32878000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "140762000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512bd"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620625",
+  "adstrdName": "인헌동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2783693"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4186581000"
+  },
+  "food": {
+    "$numberDecimal": "1176671000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "82163000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "4882000"
+  },
+  "medical": {
+    "$numberDecimal": "629479000"
+  },
+  "transport": {
+    "$numberDecimal": "517213000"
+  },
+  "education": {
+    "$numberDecimal": "106530000"
+  },
+  "entertainment": {
+    "$numberDecimal": "91608000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "218029000"
+  },
+  "other": {
+    "$numberDecimal": "186573000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1173433000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512be"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620630",
+  "adstrdName": "남현동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3234026"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6079357000"
+  },
+  "food": {
+    "$numberDecimal": "1613551000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "35617000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "31324000"
+  },
+  "medical": {
+    "$numberDecimal": "451205000"
+  },
+  "transport": {
+    "$numberDecimal": "651373000"
+  },
+  "education": {
+    "$numberDecimal": "95813000"
+  },
+  "entertainment": {
+    "$numberDecimal": "311732000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "515114000"
+  },
+  "other": {
+    "$numberDecimal": "262590000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2111038000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512bf"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650621",
+  "adstrdName": "방배4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4557937"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6318868000"
+  },
+  "food": {
+    "$numberDecimal": "828622000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "136498000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "58737000"
+  },
+  "medical": {
+    "$numberDecimal": "2019446000"
+  },
+  "transport": {
+    "$numberDecimal": "226876000"
+  },
+  "education": {
+    "$numberDecimal": "526505000"
+  },
+  "entertainment": {
+    "$numberDecimal": "58380000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "454240000"
+  },
+  "other": {
+    "$numberDecimal": "397034000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1612530000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512c0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680630",
+  "adstrdName": "대치4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4101144"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.82E+11"
+  },
+  "food": {
+    "$numberDecimal": "2156331000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "121163000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "129728000"
+  },
+  "medical": {
+    "$numberDecimal": "2622851000"
+  },
+  "transport": {
+    "$numberDecimal": "497419000"
+  },
+  "education": {
+    "$numberDecimal": "6677617000"
+  },
+  "entertainment": {
+    "$numberDecimal": "457331000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "823300000"
+  },
+  "other": {
+    "$numberDecimal": "1.64E+11"
+  },
+  "eatingOut": {
+    "$numberDecimal": "5189038000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512c1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710580",
+  "adstrdName": "송파1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3129216"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9223085000"
+  },
+  "food": {
+    "$numberDecimal": "1605619000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "146329000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "95776000"
+  },
+  "medical": {
+    "$numberDecimal": "1503976000"
+  },
+  "transport": {
+    "$numberDecimal": "93151000"
+  },
+  "education": {
+    "$numberDecimal": "334496000"
+  },
+  "entertainment": {
+    "$numberDecimal": "220126000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "578334000"
+  },
+  "other": {
+    "$numberDecimal": "597470000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4047808000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512c2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740530",
+  "adstrdName": "명일1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3540203"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7166806000"
+  },
+  "food": {
+    "$numberDecimal": "1860934000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "165439000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "70939000"
+  },
+  "medical": {
+    "$numberDecimal": "1624960000"
+  },
+  "transport": {
+    "$numberDecimal": "57685000"
+  },
+  "education": {
+    "$numberDecimal": "770681000"
+  },
+  "entertainment": {
+    "$numberDecimal": "154771000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "267501000"
+  },
+  "other": {
+    "$numberDecimal": "243627000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1950269000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512c3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740560",
+  "adstrdName": "고덕2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2465499"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2847936000"
+  },
+  "food": {
+    "$numberDecimal": "826361000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "26806000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "53925000"
+  },
+  "medical": {
+    "$numberDecimal": "789063000"
+  },
+  "transport": {
+    "$numberDecimal": "26448000"
+  },
+  "education": {
+    "$numberDecimal": "373683000"
+  },
+  "entertainment": {
+    "$numberDecimal": "14182000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "148408000"
+  },
+  "other": {
+    "$numberDecimal": "116168000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "472892000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512c4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740620",
+  "adstrdName": "천호3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3165328"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6075566000"
+  },
+  "food": {
+    "$numberDecimal": "879398000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "110797000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "72438000"
+  },
+  "medical": {
+    "$numberDecimal": "2508048000"
+  },
+  "transport": {
+    "$numberDecimal": "18352000"
+  },
+  "education": {
+    "$numberDecimal": "99096000"
+  },
+  "entertainment": {
+    "$numberDecimal": "241349000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "375875000"
+  },
+  "other": {
+    "$numberDecimal": "301824000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1468389000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512c5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110680",
+  "adstrdName": "창신2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2112817"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1187238000"
+  },
+  "food": {
+    "$numberDecimal": "428579000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "22621000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "17459000"
+  },
+  "medical": {
+    "$numberDecimal": "150206000"
+  },
+  "transport": {
+    "$numberDecimal": "11128000"
+  },
+  "education": {
+    "$numberDecimal": "2875000"
+  },
+  "entertainment": {
+    "$numberDecimal": "13370000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "25057000"
+  },
+  "other": {
+    "$numberDecimal": "19808000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "496135000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512c6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140605",
+  "adstrdName": "을지로동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3082514"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.37E+11"
+  },
+  "food": {
+    "$numberDecimal": "1283581000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "116087000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "180055000"
+  },
+  "medical": {
+    "$numberDecimal": "685752000"
+  },
+  "transport": {
+    "$numberDecimal": "1326721000"
+  },
+  "education": {
+    "$numberDecimal": "61782000"
+  },
+  "entertainment": {
+    "$numberDecimal": "642527000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1.28E+11"
+  },
+  "other": {
+    "$numberDecimal": "40641000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4806762000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512c7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140615",
+  "adstrdName": "신당동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2816850"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5107757000"
+  },
+  "food": {
+    "$numberDecimal": "813259000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "749399000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "118181000"
+  },
+  "medical": {
+    "$numberDecimal": "364703000"
+  },
+  "transport": {
+    "$numberDecimal": "310331000"
+  },
+  "education": {
+    "$numberDecimal": "33709000"
+  },
+  "entertainment": {
+    "$numberDecimal": "149799000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "220172000"
+  },
+  "other": {
+    "$numberDecimal": "155701000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2192503000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512c8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140635",
+  "adstrdName": "약수동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3894878"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2810737000"
+  },
+  "food": {
+    "$numberDecimal": "1264404000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "29296000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "2681000"
+  },
+  "medical": {
+    "$numberDecimal": "439963000"
+  },
+  "transport": {
+    "$numberDecimal": "3081000"
+  },
+  "education": {
+    "$numberDecimal": "85314000"
+  },
+  "entertainment": {
+    "$numberDecimal": "46742000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "185279000"
+  },
+  "other": {
+    "$numberDecimal": "86607000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "667370000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512c9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170555",
+  "adstrdName": "청파동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2608804"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3208312000"
+  },
+  "food": {
+    "$numberDecimal": "806645000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "26810000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "21958000"
+  },
+  "medical": {
+    "$numberDecimal": "230985000"
+  },
+  "transport": {
+    "$numberDecimal": "87295000"
+  },
+  "education": {
+    "$numberDecimal": "63242000"
+  },
+  "entertainment": {
+    "$numberDecimal": "36478000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "230794000"
+  },
+  "other": {
+    "$numberDecimal": "160468000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1543637000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ca"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170580",
+  "adstrdName": "효창동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3523201"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "969967000"
+  },
+  "food": {
+    "$numberDecimal": "427864000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "5859000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "6537000"
+  },
+  "medical": {
+    "$numberDecimal": "185115000"
+  },
+  "transport": {
+    "$numberDecimal": "11256000"
+  },
+  "education": {
+    "$numberDecimal": "67003000"
+  },
+  "entertainment": {
+    "$numberDecimal": "0"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "49582000"
+  },
+  "other": {
+    "$numberDecimal": "21793000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "194958000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512cb"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170650",
+  "adstrdName": "이태원1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3682946"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8616116000"
+  },
+  "food": {
+    "$numberDecimal": "783368000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "337124000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "89195000"
+  },
+  "medical": {
+    "$numberDecimal": "689291000"
+  },
+  "transport": {
+    "$numberDecimal": "23723000"
+  },
+  "education": {
+    "$numberDecimal": "25623000"
+  },
+  "entertainment": {
+    "$numberDecimal": "1234833000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "318206000"
+  },
+  "other": {
+    "$numberDecimal": "235481000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4879272000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512cc"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170685",
+  "adstrdName": "한남동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4381088"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "11860508000"
+  },
+  "food": {
+    "$numberDecimal": "1336901000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "1796860000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "70357000"
+  },
+  "medical": {
+    "$numberDecimal": "900196000"
+  },
+  "transport": {
+    "$numberDecimal": "328530000"
+  },
+  "education": {
+    "$numberDecimal": "223336000"
+  },
+  "entertainment": {
+    "$numberDecimal": "394802000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1946257000"
+  },
+  "other": {
+    "$numberDecimal": "729988000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4133281000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512cd"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200520",
+  "adstrdName": "왕십리2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3474994"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2099661000"
+  },
+  "food": {
+    "$numberDecimal": "463401000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "59492000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "163981000"
+  },
+  "medical": {
+    "$numberDecimal": "617022000"
+  },
+  "transport": {
+    "$numberDecimal": "3708000"
+  },
+  "education": {
+    "$numberDecimal": "109962000"
+  },
+  "entertainment": {
+    "$numberDecimal": "46646000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "117948000"
+  },
+  "other": {
+    "$numberDecimal": "106298000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "411203000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ce"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200620",
+  "adstrdName": "금호4가동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4442144"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3065594000"
+  },
+  "food": {
+    "$numberDecimal": "1123935000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "51020000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "11585000"
+  },
+  "medical": {
+    "$numberDecimal": "661524000"
+  },
+  "transport": {
+    "$numberDecimal": "68481000"
+  },
+  "education": {
+    "$numberDecimal": "314266000"
+  },
+  "entertainment": {
+    "$numberDecimal": "38991000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "171769000"
+  },
+  "other": {
+    "$numberDecimal": "193185000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "430838000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512cf"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215810",
+  "adstrdName": "광장동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5284540"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5462488000"
+  },
+  "food": {
+    "$numberDecimal": "1720111000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "58649000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "8878000"
+  },
+  "medical": {
+    "$numberDecimal": "488093000"
+  },
+  "transport": {
+    "$numberDecimal": "756390000"
+  },
+  "education": {
+    "$numberDecimal": "678921000"
+  },
+  "entertainment": {
+    "$numberDecimal": "45603000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "299646000"
+  },
+  "other": {
+    "$numberDecimal": "194126000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1212071000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512d0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230650",
+  "adstrdName": "장안1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2863708"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "11532252000"
+  },
+  "food": {
+    "$numberDecimal": "2692430000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "140403000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "110524000"
+  },
+  "medical": {
+    "$numberDecimal": "3088286000"
+  },
+  "transport": {
+    "$numberDecimal": "725227000"
+  },
+  "education": {
+    "$numberDecimal": "255645000"
+  },
+  "entertainment": {
+    "$numberDecimal": "286029000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "764365000"
+  },
+  "other": {
+    "$numberDecimal": "376902000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3092441000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512d1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260610",
+  "adstrdName": "중화2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2253552"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3904399000"
+  },
+  "food": {
+    "$numberDecimal": "1251824000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "55434000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "47213000"
+  },
+  "medical": {
+    "$numberDecimal": "423804000"
+  },
+  "transport": {
+    "$numberDecimal": "65208000"
+  },
+  "education": {
+    "$numberDecimal": "29408000"
+  },
+  "entertainment": {
+    "$numberDecimal": "187474000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "347226000"
+  },
+  "other": {
+    "$numberDecimal": "122648000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1374160000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512d2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290580",
+  "adstrdName": "돈암1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3583117"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "966303000"
+  },
+  "food": {
+    "$numberDecimal": "277105000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "18699000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "1781000"
+  },
+  "medical": {
+    "$numberDecimal": "201132000"
+  },
+  "transport": {
+    "$numberDecimal": "4530000"
+  },
+  "education": {
+    "$numberDecimal": "140237000"
+  },
+  "entertainment": {
+    "$numberDecimal": "0"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "18336000"
+  },
+  "other": {
+    "$numberDecimal": "66893000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "237590000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512d3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290630",
+  "adstrdName": "정릉2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2934717"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3737470000"
+  },
+  "food": {
+    "$numberDecimal": "1369477000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "40570000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "56699000"
+  },
+  "medical": {
+    "$numberDecimal": "629986000"
+  },
+  "transport": {
+    "$numberDecimal": "373766000"
+  },
+  "education": {
+    "$numberDecimal": "161106000"
+  },
+  "entertainment": {
+    "$numberDecimal": "73320000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "234565000"
+  },
+  "other": {
+    "$numberDecimal": "155666000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "642315000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512d4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290640",
+  "adstrdName": "정릉3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2482564"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2011437000"
+  },
+  "food": {
+    "$numberDecimal": "736511000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "20453000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "26470000"
+  },
+  "medical": {
+    "$numberDecimal": "83683000"
+  },
+  "transport": {
+    "$numberDecimal": "103437000"
+  },
+  "education": {
+    "$numberDecimal": "124912000"
+  },
+  "entertainment": {
+    "$numberDecimal": "80603000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "107506000"
+  },
+  "other": {
+    "$numberDecimal": "56800000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "671062000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512d5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290810",
+  "adstrdName": "석관동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2864182"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6527678000"
+  },
+  "food": {
+    "$numberDecimal": "2025440000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "61341000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "134494000"
+  },
+  "medical": {
+    "$numberDecimal": "842275000"
+  },
+  "transport": {
+    "$numberDecimal": "49756000"
+  },
+  "education": {
+    "$numberDecimal": "771548000"
+  },
+  "entertainment": {
+    "$numberDecimal": "280033000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "253313000"
+  },
+  "other": {
+    "$numberDecimal": "241493000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1867985000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512d6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305534",
+  "adstrdName": "삼양동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2473211"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3475402000"
+  },
+  "food": {
+    "$numberDecimal": "1638604000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "34788000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "95639000"
+  },
+  "medical": {
+    "$numberDecimal": "774351000"
+  },
+  "transport": {
+    "$numberDecimal": "241579000"
+  },
+  "education": {
+    "$numberDecimal": "153234000"
+  },
+  "entertainment": {
+    "$numberDecimal": "40699000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "134138000"
+  },
+  "other": {
+    "$numberDecimal": "92560000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "269810000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512d7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305645",
+  "adstrdName": "우이동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2457144"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3314064000"
+  },
+  "food": {
+    "$numberDecimal": "823010000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "47278000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "26470000"
+  },
+  "medical": {
+    "$numberDecimal": "184856000"
+  },
+  "transport": {
+    "$numberDecimal": "58634000"
+  },
+  "education": {
+    "$numberDecimal": "21360000"
+  },
+  "entertainment": {
+    "$numberDecimal": "81586000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "189236000"
+  },
+  "other": {
+    "$numberDecimal": "569708000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1311926000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512d8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320511",
+  "adstrdName": "창1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3038009"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3503136000"
+  },
+  "food": {
+    "$numberDecimal": "868193000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "25306000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "25882000"
+  },
+  "medical": {
+    "$numberDecimal": "871074000"
+  },
+  "transport": {
+    "$numberDecimal": "119136000"
+  },
+  "education": {
+    "$numberDecimal": "97399000"
+  },
+  "entertainment": {
+    "$numberDecimal": "86019000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "214579000"
+  },
+  "other": {
+    "$numberDecimal": "197981000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "997567000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512d9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320690",
+  "adstrdName": "방학1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2895702"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9202058000"
+  },
+  "food": {
+    "$numberDecimal": "3591943000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "106174000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "209077000"
+  },
+  "medical": {
+    "$numberDecimal": "875424000"
+  },
+  "transport": {
+    "$numberDecimal": "1269563000"
+  },
+  "education": {
+    "$numberDecimal": "252137000"
+  },
+  "entertainment": {
+    "$numberDecimal": "249339000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "363813000"
+  },
+  "other": {
+    "$numberDecimal": "360121000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1924467000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512da"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350580",
+  "adstrdName": "월계3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3110675"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7127848000"
+  },
+  "food": {
+    "$numberDecimal": "5749041000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "55016000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "4084000"
+  },
+  "medical": {
+    "$numberDecimal": "204950000"
+  },
+  "transport": {
+    "$numberDecimal": "9603000"
+  },
+  "education": {
+    "$numberDecimal": "181710000"
+  },
+  "entertainment": {
+    "$numberDecimal": "5124000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "149792000"
+  },
+  "other": {
+    "$numberDecimal": "180012000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "588516000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512db"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350619",
+  "adstrdName": "중계본동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4197248"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6369757000"
+  },
+  "food": {
+    "$numberDecimal": "1669850000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "37958000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "2779000"
+  },
+  "medical": {
+    "$numberDecimal": "738797000"
+  },
+  "transport": {
+    "$numberDecimal": "397658000"
+  },
+  "education": {
+    "$numberDecimal": "2061101000"
+  },
+  "entertainment": {
+    "$numberDecimal": "37667000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "350653000"
+  },
+  "other": {
+    "$numberDecimal": "217340000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "855954000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512dc"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350621",
+  "adstrdName": "중계1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4623227"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4554245000"
+  },
+  "food": {
+    "$numberDecimal": "675917000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "68272000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "105954000"
+  },
+  "medical": {
+    "$numberDecimal": "436218000"
+  },
+  "transport": {
+    "$numberDecimal": "63206000"
+  },
+  "education": {
+    "$numberDecimal": "1924993000"
+  },
+  "entertainment": {
+    "$numberDecimal": "12802000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "362568000"
+  },
+  "other": {
+    "$numberDecimal": "78432000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "825883000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512dd"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380690",
+  "adstrdName": "진관동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4070863"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "17208470000"
+  },
+  "food": {
+    "$numberDecimal": "1820458000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "2630337000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "157278000"
+  },
+  "medical": {
+    "$numberDecimal": "6580410000"
+  },
+  "transport": {
+    "$numberDecimal": "717391000"
+  },
+  "education": {
+    "$numberDecimal": "785983000"
+  },
+  "entertainment": {
+    "$numberDecimal": "52843000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "762189000"
+  },
+  "other": {
+    "$numberDecimal": "865658000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2835923000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512de"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410620",
+  "adstrdName": "홍제1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3459117"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3585159000"
+  },
+  "food": {
+    "$numberDecimal": "938033000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "26588000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "24686000"
+  },
+  "medical": {
+    "$numberDecimal": "929627000"
+  },
+  "transport": {
+    "$numberDecimal": "393587000"
+  },
+  "education": {
+    "$numberDecimal": "84692000"
+  },
+  "entertainment": {
+    "$numberDecimal": "95049000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "153787000"
+  },
+  "other": {
+    "$numberDecimal": "142728000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "796382000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512df"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410660",
+  "adstrdName": "홍은1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3093859"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1361649000"
+  },
+  "food": {
+    "$numberDecimal": "477997000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "24205000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "49815000"
+  },
+  "medical": {
+    "$numberDecimal": "159079000"
+  },
+  "transport": {
+    "$numberDecimal": "5737000"
+  },
+  "education": {
+    "$numberDecimal": "98694000"
+  },
+  "entertainment": {
+    "$numberDecimal": "13432000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "187246000"
+  },
+  "other": {
+    "$numberDecimal": "43449000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "301995000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512e0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410710",
+  "adstrdName": "북가좌1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4005416"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1843112000"
+  },
+  "food": {
+    "$numberDecimal": "397017000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "16555000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "7116000"
+  },
+  "medical": {
+    "$numberDecimal": "666724000"
+  },
+  "transport": {
+    "$numberDecimal": "42571000"
+  },
+  "education": {
+    "$numberDecimal": "263403000"
+  },
+  "entertainment": {
+    "$numberDecimal": "7309000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "128439000"
+  },
+  "other": {
+    "$numberDecimal": "125395000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "188583000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512e1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11440565",
+  "adstrdName": "공덕동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4047702"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5872392000"
+  },
+  "food": {
+    "$numberDecimal": "1059027000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "37975000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "165884000"
+  },
+  "medical": {
+    "$numberDecimal": "930632000"
+  },
+  "transport": {
+    "$numberDecimal": "206250000"
+  },
+  "education": {
+    "$numberDecimal": "213623000"
+  },
+  "entertainment": {
+    "$numberDecimal": "120541000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1069407000"
+  },
+  "other": {
+    "$numberDecimal": "280891000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1788162000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512e2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500510",
+  "adstrdName": "염창동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4127504"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6589194000"
+  },
+  "food": {
+    "$numberDecimal": "2001492000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "84393000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "189475000"
+  },
+  "medical": {
+    "$numberDecimal": "636823000"
+  },
+  "transport": {
+    "$numberDecimal": "666548000"
+  },
+  "education": {
+    "$numberDecimal": "689698000"
+  },
+  "entertainment": {
+    "$numberDecimal": "53097000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "594952000"
+  },
+  "other": {
+    "$numberDecimal": "396132000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1276584000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512e3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11500611",
+  "adstrdName": "발산1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3192517"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "24726089000"
+  },
+  "food": {
+    "$numberDecimal": "4198123000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "131083000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "191224000"
+  },
+  "medical": {
+    "$numberDecimal": "10046096000"
+  },
+  "transport": {
+    "$numberDecimal": "3357383000"
+  },
+  "education": {
+    "$numberDecimal": "1776571000"
+  },
+  "entertainment": {
+    "$numberDecimal": "28817000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1216795000"
+  },
+  "other": {
+    "$numberDecimal": "782231000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2997766000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512e4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530730",
+  "adstrdName": "고척2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2882639"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3233925000"
+  },
+  "food": {
+    "$numberDecimal": "1152557000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "30954000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "52415000"
+  },
+  "medical": {
+    "$numberDecimal": "600345000"
+  },
+  "transport": {
+    "$numberDecimal": "371767000"
+  },
+  "education": {
+    "$numberDecimal": "156044000"
+  },
+  "entertainment": {
+    "$numberDecimal": "54071000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "89579000"
+  },
+  "other": {
+    "$numberDecimal": "80704000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "645489000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512e5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530780",
+  "adstrdName": "오류2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2781178"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3880368000"
+  },
+  "food": {
+    "$numberDecimal": "1881840000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "27907000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "29640000"
+  },
+  "medical": {
+    "$numberDecimal": "304331000"
+  },
+  "transport": {
+    "$numberDecimal": "129131000"
+  },
+  "education": {
+    "$numberDecimal": "294801000"
+  },
+  "entertainment": {
+    "$numberDecimal": "59835000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "304739000"
+  },
+  "other": {
+    "$numberDecimal": "143528000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "704616000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512e6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11545630",
+  "adstrdName": "독산3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2386851"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4688002000"
+  },
+  "food": {
+    "$numberDecimal": "1937702000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "97114000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "83818000"
+  },
+  "medical": {
+    "$numberDecimal": "654474000"
+  },
+  "transport": {
+    "$numberDecimal": "403922000"
+  },
+  "education": {
+    "$numberDecimal": "142928000"
+  },
+  "entertainment": {
+    "$numberDecimal": "151558000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "260821000"
+  },
+  "other": {
+    "$numberDecimal": "128099000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "827566000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512e7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590620",
+  "adstrdName": "사당1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2855173"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9095091000"
+  },
+  "food": {
+    "$numberDecimal": "1670323000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "124419000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "48402000"
+  },
+  "medical": {
+    "$numberDecimal": "1536805000"
+  },
+  "transport": {
+    "$numberDecimal": "259444000"
+  },
+  "education": {
+    "$numberDecimal": "161199000"
+  },
+  "entertainment": {
+    "$numberDecimal": "247004000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "529300000"
+  },
+  "other": {
+    "$numberDecimal": "215821000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4302374000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512e8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590630",
+  "adstrdName": "사당2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3884988"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9003069000"
+  },
+  "food": {
+    "$numberDecimal": "2796045000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "126746000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "41650000"
+  },
+  "medical": {
+    "$numberDecimal": "1311041000"
+  },
+  "transport": {
+    "$numberDecimal": "178196000"
+  },
+  "education": {
+    "$numberDecimal": "319390000"
+  },
+  "entertainment": {
+    "$numberDecimal": "456758000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "463411000"
+  },
+  "other": {
+    "$numberDecimal": "352060000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2957772000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512e9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590680",
+  "adstrdName": "신대방2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3340157"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "83610333000"
+  },
+  "food": {
+    "$numberDecimal": "1589839000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "20759000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "922742000"
+  },
+  "medical": {
+    "$numberDecimal": "4328408000"
+  },
+  "transport": {
+    "$numberDecimal": "73341270000"
+  },
+  "education": {
+    "$numberDecimal": "149735000"
+  },
+  "entertainment": {
+    "$numberDecimal": "67967000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "253408000"
+  },
+  "other": {
+    "$numberDecimal": "961923000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1974282000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ea"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620525",
+  "adstrdName": "보라매동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2529995"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "13915199000"
+  },
+  "food": {
+    "$numberDecimal": "1133122000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "29444000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "18917000"
+  },
+  "medical": {
+    "$numberDecimal": "418241000"
+  },
+  "transport": {
+    "$numberDecimal": "239535000"
+  },
+  "education": {
+    "$numberDecimal": "10814054000"
+  },
+  "entertainment": {
+    "$numberDecimal": "92445000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "195880000"
+  },
+  "other": {
+    "$numberDecimal": "100759000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "872802000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512eb"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620575",
+  "adstrdName": "행운동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2889475"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6198842000"
+  },
+  "food": {
+    "$numberDecimal": "2183941000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "167306000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "46946000"
+  },
+  "medical": {
+    "$numberDecimal": "1376317000"
+  },
+  "transport": {
+    "$numberDecimal": "26170000"
+  },
+  "education": {
+    "$numberDecimal": "249118000"
+  },
+  "entertainment": {
+    "$numberDecimal": "181392000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "294098000"
+  },
+  "other": {
+    "$numberDecimal": "214414000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1459140000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ec"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620645",
+  "adstrdName": "서원동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2412001"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "12769777000"
+  },
+  "food": {
+    "$numberDecimal": "1622985000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "697288000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "164325000"
+  },
+  "medical": {
+    "$numberDecimal": "3594018000"
+  },
+  "transport": {
+    "$numberDecimal": "72804000"
+  },
+  "education": {
+    "$numberDecimal": "202005000"
+  },
+  "entertainment": {
+    "$numberDecimal": "869116000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1002919000"
+  },
+  "other": {
+    "$numberDecimal": "492329000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4051988000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ed"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620715",
+  "adstrdName": "난향동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3262195"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "700996000"
+  },
+  "food": {
+    "$numberDecimal": "357792000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "4295000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "2197000"
+  },
+  "medical": {
+    "$numberDecimal": "38980000"
+  },
+  "transport": {
+    "$numberDecimal": "0"
+  },
+  "education": {
+    "$numberDecimal": "68540000"
+  },
+  "entertainment": {
+    "$numberDecimal": "29551000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "68502000"
+  },
+  "other": {
+    "$numberDecimal": "20743000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "110396000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ee"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650540",
+  "adstrdName": "잠원동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5458458"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "10113484000"
+  },
+  "food": {
+    "$numberDecimal": "667965000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "138463000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "45319000"
+  },
+  "medical": {
+    "$numberDecimal": "5398361000"
+  },
+  "transport": {
+    "$numberDecimal": "117480000"
+  },
+  "education": {
+    "$numberDecimal": "674513000"
+  },
+  "entertainment": {
+    "$numberDecimal": "450956000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "467949000"
+  },
+  "other": {
+    "$numberDecimal": "341343000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1811135000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ef"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680565",
+  "adstrdName": "청담동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5010204"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "29143899000"
+  },
+  "food": {
+    "$numberDecimal": "2015815000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "3026680000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "455902000"
+  },
+  "medical": {
+    "$numberDecimal": "10449353000"
+  },
+  "transport": {
+    "$numberDecimal": "366870000"
+  },
+  "education": {
+    "$numberDecimal": "343265000"
+  },
+  "entertainment": {
+    "$numberDecimal": "584197000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1506334000"
+  },
+  "other": {
+    "$numberDecimal": "5274524000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "5120959000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512f0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680650",
+  "adstrdName": "역삼2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5367397"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6.99E+11"
+  },
+  "food": {
+    "$numberDecimal": "1862368000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "149961000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "228696000"
+  },
+  "medical": {
+    "$numberDecimal": "4432450000"
+  },
+  "transport": {
+    "$numberDecimal": "525974000"
+  },
+  "education": {
+    "$numberDecimal": "730913000"
+  },
+  "entertainment": {
+    "$numberDecimal": "148491000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1.50E+11"
+  },
+  "other": {
+    "$numberDecimal": "5.37E+11"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3336468000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512f1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680655",
+  "adstrdName": "도곡1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5412484"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "33884048000"
+  },
+  "food": {
+    "$numberDecimal": "874311000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "29529000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "78777000"
+  },
+  "medical": {
+    "$numberDecimal": "10776502000"
+  },
+  "transport": {
+    "$numberDecimal": "703190000"
+  },
+  "education": {
+    "$numberDecimal": "609303000"
+  },
+  "entertainment": {
+    "$numberDecimal": "47666000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "18720264000"
+  },
+  "other": {
+    "$numberDecimal": "351308000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1693198000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512f2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710590",
+  "adstrdName": "송파2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4370970"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3014994000"
+  },
+  "food": {
+    "$numberDecimal": "645340000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "20077000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "195124000"
+  },
+  "medical": {
+    "$numberDecimal": "378535000"
+  },
+  "transport": {
+    "$numberDecimal": "679505000"
+  },
+  "education": {
+    "$numberDecimal": "326132000"
+  },
+  "entertainment": {
+    "$numberDecimal": "23087000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "152963000"
+  },
+  "other": {
+    "$numberDecimal": "97496000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "496735000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512f3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710600",
+  "adstrdName": "석촌동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2927911"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "10805065000"
+  },
+  "food": {
+    "$numberDecimal": "2674571000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "238858000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "142037000"
+  },
+  "medical": {
+    "$numberDecimal": "1924638000"
+  },
+  "transport": {
+    "$numberDecimal": "961838000"
+  },
+  "education": {
+    "$numberDecimal": "522535000"
+  },
+  "entertainment": {
+    "$numberDecimal": "258625000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "624972000"
+  },
+  "other": {
+    "$numberDecimal": "584467000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2872524000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512f4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710647",
+  "adstrdName": "위례동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4202887"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4213526000"
+  },
+  "food": {
+    "$numberDecimal": "711564000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "75996000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "4105000"
+  },
+  "medical": {
+    "$numberDecimal": "474799000"
+  },
+  "transport": {
+    "$numberDecimal": "818649000"
+  },
+  "education": {
+    "$numberDecimal": "723525000"
+  },
+  "entertainment": {
+    "$numberDecimal": "24268000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "208910000"
+  },
+  "other": {
+    "$numberDecimal": "187890000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "983820000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512f5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740550",
+  "adstrdName": "고덕1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4618641"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1782849000"
+  },
+  "food": {
+    "$numberDecimal": "879795000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "24422000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "14966000"
+  },
+  "medical": {
+    "$numberDecimal": "185185000"
+  },
+  "transport": {
+    "$numberDecimal": "22249000"
+  },
+  "education": {
+    "$numberDecimal": "237709000"
+  },
+  "entertainment": {
+    "$numberDecimal": "26734000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "62849000"
+  },
+  "other": {
+    "$numberDecimal": "57494000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "271446000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512f6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740580",
+  "adstrdName": "암사2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3688535"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2650866000"
+  },
+  "food": {
+    "$numberDecimal": "475032000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "13505000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "30459000"
+  },
+  "medical": {
+    "$numberDecimal": "592283000"
+  },
+  "transport": {
+    "$numberDecimal": "115829000"
+  },
+  "education": {
+    "$numberDecimal": "212073000"
+  },
+  "entertainment": {
+    "$numberDecimal": "39960000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "272530000"
+  },
+  "other": {
+    "$numberDecimal": "100981000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "798214000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512f7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740660",
+  "adstrdName": "성내3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2897346"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7885761000"
+  },
+  "food": {
+    "$numberDecimal": "1737213000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "210270000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "72059000"
+  },
+  "medical": {
+    "$numberDecimal": "1287045000"
+  },
+  "transport": {
+    "$numberDecimal": "337504000"
+  },
+  "education": {
+    "$numberDecimal": "381897000"
+  },
+  "entertainment": {
+    "$numberDecimal": "180186000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "504510000"
+  },
+  "other": {
+    "$numberDecimal": "323325000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2851752000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512f8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110615",
+  "adstrdName": "종로1?2?3?4가동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3245251"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.10E+11"
+  },
+  "food": {
+    "$numberDecimal": "4341033000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "2031173000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "616049000"
+  },
+  "medical": {
+    "$numberDecimal": "7017482000"
+  },
+  "transport": {
+    "$numberDecimal": "4404078000"
+  },
+  "education": {
+    "$numberDecimal": "1533692000"
+  },
+  "entertainment": {
+    "$numberDecimal": "2311850000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "11008677000"
+  },
+  "other": {
+    "$numberDecimal": "57286605000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "19128562000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512f9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11110640",
+  "adstrdName": "이화동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3024996"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "10810127000"
+  },
+  "food": {
+    "$numberDecimal": "996657000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "145792000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "33739000"
+  },
+  "medical": {
+    "$numberDecimal": "3013638000"
+  },
+  "transport": {
+    "$numberDecimal": "25774000"
+  },
+  "education": {
+    "$numberDecimal": "3148838000"
+  },
+  "entertainment": {
+    "$numberDecimal": "138847000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "339584000"
+  },
+  "other": {
+    "$numberDecimal": "133514000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2833744000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512fa"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140580",
+  "adstrdName": "장충동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2895026"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2346146000"
+  },
+  "food": {
+    "$numberDecimal": "320842000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "75120000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "25296000"
+  },
+  "medical": {
+    "$numberDecimal": "12239000"
+  },
+  "transport": {
+    "$numberDecimal": "323345000"
+  },
+  "education": {
+    "$numberDecimal": "70122000"
+  },
+  "entertainment": {
+    "$numberDecimal": "6885000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "73549000"
+  },
+  "other": {
+    "$numberDecimal": "102898000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1335850000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512fb"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11140650",
+  "adstrdName": "신당5동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3027979"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2718492000"
+  },
+  "food": {
+    "$numberDecimal": "493927000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "46094000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "49894000"
+  },
+  "medical": {
+    "$numberDecimal": "390729000"
+  },
+  "transport": {
+    "$numberDecimal": "99365000"
+  },
+  "education": {
+    "$numberDecimal": "22261000"
+  },
+  "entertainment": {
+    "$numberDecimal": "167319000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "233706000"
+  },
+  "other": {
+    "$numberDecimal": "49532000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1165665000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512fc"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11170625",
+  "adstrdName": "한강로동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4948344"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "31344211000"
+  },
+  "food": {
+    "$numberDecimal": "3272540000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "222713000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "4177211000"
+  },
+  "medical": {
+    "$numberDecimal": "1768894000"
+  },
+  "transport": {
+    "$numberDecimal": "1641976000"
+  },
+  "education": {
+    "$numberDecimal": "204575000"
+  },
+  "entertainment": {
+    "$numberDecimal": "492149000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "5214771000"
+  },
+  "other": {
+    "$numberDecimal": "1064108000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "13285274000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512fd"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200570",
+  "adstrdName": "행당2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4408744"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1739514000"
+  },
+  "food": {
+    "$numberDecimal": "520837000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "30560000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "0"
+  },
+  "medical": {
+    "$numberDecimal": "276399000"
+  },
+  "transport": {
+    "$numberDecimal": "0"
+  },
+  "education": {
+    "$numberDecimal": "372046000"
+  },
+  "entertainment": {
+    "$numberDecimal": "3751000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "195140000"
+  },
+  "other": {
+    "$numberDecimal": "50690000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "290091000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512fe"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200615",
+  "adstrdName": "금호2?3가동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3751434"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2661878000"
+  },
+  "food": {
+    "$numberDecimal": "1016405000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "121541000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "14057000"
+  },
+  "medical": {
+    "$numberDecimal": "388903000"
+  },
+  "transport": {
+    "$numberDecimal": "6131000"
+  },
+  "education": {
+    "$numberDecimal": "90776000"
+  },
+  "entertainment": {
+    "$numberDecimal": "53355000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "159714000"
+  },
+  "other": {
+    "$numberDecimal": "131063000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "679933000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c4328717096293512ff"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11200650",
+  "adstrdName": "성수1가1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3870717"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3069821000"
+  },
+  "food": {
+    "$numberDecimal": "662320000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "229985000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "29012000"
+  },
+  "medical": {
+    "$numberDecimal": "279489000"
+  },
+  "transport": {
+    "$numberDecimal": "173688000"
+  },
+  "education": {
+    "$numberDecimal": "99688000"
+  },
+  "entertainment": {
+    "$numberDecimal": "79810000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "189720000"
+  },
+  "other": {
+    "$numberDecimal": "177428000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1148681000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351300"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215760",
+  "adstrdName": "중곡3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2390961"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2382641000"
+  },
+  "food": {
+    "$numberDecimal": "600557000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "27921000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "118849000"
+  },
+  "medical": {
+    "$numberDecimal": "397851000"
+  },
+  "transport": {
+    "$numberDecimal": "385320000"
+  },
+  "education": {
+    "$numberDecimal": "85939000"
+  },
+  "entertainment": {
+    "$numberDecimal": "83637000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "99172000"
+  },
+  "other": {
+    "$numberDecimal": "147965000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "435430000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351301"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215770",
+  "adstrdName": "중곡4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2523958"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3630673000"
+  },
+  "food": {
+    "$numberDecimal": "1178832000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "95873000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "29329000"
+  },
+  "medical": {
+    "$numberDecimal": "392504000"
+  },
+  "transport": {
+    "$numberDecimal": "312146000"
+  },
+  "education": {
+    "$numberDecimal": "89000000"
+  },
+  "entertainment": {
+    "$numberDecimal": "102474000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "246717000"
+  },
+  "other": {
+    "$numberDecimal": "108534000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1075264000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351302"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215820",
+  "adstrdName": "자양1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2745988"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6753305000"
+  },
+  "food": {
+    "$numberDecimal": "2001718000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "188572000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "41911000"
+  },
+  "medical": {
+    "$numberDecimal": "2185183000"
+  },
+  "transport": {
+    "$numberDecimal": "112183000"
+  },
+  "education": {
+    "$numberDecimal": "195113000"
+  },
+  "entertainment": {
+    "$numberDecimal": "95989000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "270933000"
+  },
+  "other": {
+    "$numberDecimal": "257196000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1404507000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351303"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215847",
+  "adstrdName": "자양4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2795134"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8733109000"
+  },
+  "food": {
+    "$numberDecimal": "2619677000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "156194000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "19758000"
+  },
+  "medical": {
+    "$numberDecimal": "1160929000"
+  },
+  "transport": {
+    "$numberDecimal": "28907000"
+  },
+  "education": {
+    "$numberDecimal": "122926000"
+  },
+  "entertainment": {
+    "$numberDecimal": "251754000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "594745000"
+  },
+  "other": {
+    "$numberDecimal": "564065000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3214154000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351304"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11215850",
+  "adstrdName": "구의1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2683701"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4407265000"
+  },
+  "food": {
+    "$numberDecimal": "884920000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "86373000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "147285000"
+  },
+  "medical": {
+    "$numberDecimal": "586479000"
+  },
+  "transport": {
+    "$numberDecimal": "68912000"
+  },
+  "education": {
+    "$numberDecimal": "66423000"
+  },
+  "entertainment": {
+    "$numberDecimal": "272076000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "219190000"
+  },
+  "other": {
+    "$numberDecimal": "107632000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1967975000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351305"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230560",
+  "adstrdName": "전농1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3070695"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6497384000"
+  },
+  "food": {
+    "$numberDecimal": "1675939000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "173554000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "38841000"
+  },
+  "medical": {
+    "$numberDecimal": "1409015000"
+  },
+  "transport": {
+    "$numberDecimal": "820601000"
+  },
+  "education": {
+    "$numberDecimal": "223544000"
+  },
+  "entertainment": {
+    "$numberDecimal": "143780000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "196700000"
+  },
+  "other": {
+    "$numberDecimal": "243465000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1571945000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351306"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230730",
+  "adstrdName": "휘경2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3071586"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1938269000"
+  },
+  "food": {
+    "$numberDecimal": "489789000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "26660000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "3042000"
+  },
+  "medical": {
+    "$numberDecimal": "423730000"
+  },
+  "transport": {
+    "$numberDecimal": "215494000"
+  },
+  "education": {
+    "$numberDecimal": "82615000"
+  },
+  "entertainment": {
+    "$numberDecimal": "29780000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "268150000"
+  },
+  "other": {
+    "$numberDecimal": "69820000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "329189000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351307"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11230740",
+  "adstrdName": "이문1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3000929"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3288495000"
+  },
+  "food": {
+    "$numberDecimal": "924437000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "37904000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "7267000"
+  },
+  "medical": {
+    "$numberDecimal": "300202000"
+  },
+  "transport": {
+    "$numberDecimal": "232224000"
+  },
+  "education": {
+    "$numberDecimal": "53732000"
+  },
+  "entertainment": {
+    "$numberDecimal": "88398000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "187671000"
+  },
+  "other": {
+    "$numberDecimal": "163779000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1292881000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351308"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11260630",
+  "adstrdName": "묵2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2533867"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3583272000"
+  },
+  "food": {
+    "$numberDecimal": "808099000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "105582000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "140950000"
+  },
+  "medical": {
+    "$numberDecimal": "703587000"
+  },
+  "transport": {
+    "$numberDecimal": "229603000"
+  },
+  "education": {
+    "$numberDecimal": "67250000"
+  },
+  "entertainment": {
+    "$numberDecimal": "229206000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "255740000"
+  },
+  "other": {
+    "$numberDecimal": "89355000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "953900000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351309"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11290600",
+  "adstrdName": "안암동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2896471"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6356996000"
+  },
+  "food": {
+    "$numberDecimal": "1156406000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "46021000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "72155000"
+  },
+  "medical": {
+    "$numberDecimal": "1105355000"
+  },
+  "transport": {
+    "$numberDecimal": "37678000"
+  },
+  "education": {
+    "$numberDecimal": "77775000"
+  },
+  "entertainment": {
+    "$numberDecimal": "271225000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "413851000"
+  },
+  "other": {
+    "$numberDecimal": "272981000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2903549000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935130a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305615",
+  "adstrdName": "수유1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2220463"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4724271000"
+  },
+  "food": {
+    "$numberDecimal": "2083309000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "116578000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "123899000"
+  },
+  "medical": {
+    "$numberDecimal": "423041000"
+  },
+  "transport": {
+    "$numberDecimal": "530733000"
+  },
+  "education": {
+    "$numberDecimal": "26352000"
+  },
+  "entertainment": {
+    "$numberDecimal": "44116000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "321929000"
+  },
+  "other": {
+    "$numberDecimal": "233806000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "820508000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935130b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11305625",
+  "adstrdName": "수유2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2577008"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2178547000"
+  },
+  "food": {
+    "$numberDecimal": "695168000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "40287000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "43013000"
+  },
+  "medical": {
+    "$numberDecimal": "250933000"
+  },
+  "transport": {
+    "$numberDecimal": "85593000"
+  },
+  "education": {
+    "$numberDecimal": "77885000"
+  },
+  "entertainment": {
+    "$numberDecimal": "89320000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "159781000"
+  },
+  "other": {
+    "$numberDecimal": "68882000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "667685000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935130c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320514",
+  "adstrdName": "창4동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3547959"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3578079000"
+  },
+  "food": {
+    "$numberDecimal": "662938000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "31497000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "39705000"
+  },
+  "medical": {
+    "$numberDecimal": "305515000"
+  },
+  "transport": {
+    "$numberDecimal": "626089000"
+  },
+  "education": {
+    "$numberDecimal": "284600000"
+  },
+  "entertainment": {
+    "$numberDecimal": "210851000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "175104000"
+  },
+  "other": {
+    "$numberDecimal": "107020000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1134760000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935130d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11320700",
+  "adstrdName": "방학2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2099146"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2625129000"
+  },
+  "food": {
+    "$numberDecimal": "1268280000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "20837000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "56412000"
+  },
+  "medical": {
+    "$numberDecimal": "409871000"
+  },
+  "transport": {
+    "$numberDecimal": "249671000"
+  },
+  "education": {
+    "$numberDecimal": "54496000"
+  },
+  "entertainment": {
+    "$numberDecimal": "25090000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "51112000"
+  },
+  "other": {
+    "$numberDecimal": "68659000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "420701000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935130e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350611",
+  "adstrdName": "하계1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3611061"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6948722000"
+  },
+  "food": {
+    "$numberDecimal": "3027587000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "42026000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "3378000"
+  },
+  "medical": {
+    "$numberDecimal": "1033897000"
+  },
+  "transport": {
+    "$numberDecimal": "475979000"
+  },
+  "education": {
+    "$numberDecimal": "326815000"
+  },
+  "entertainment": {
+    "$numberDecimal": "10366000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "320686000"
+  },
+  "other": {
+    "$numberDecimal": "339465000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1368523000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935130f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350625",
+  "adstrdName": "중계2?3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2936682"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8950911000"
+  },
+  "food": {
+    "$numberDecimal": "5645738000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "117673000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "127165000"
+  },
+  "medical": {
+    "$numberDecimal": "612097000"
+  },
+  "transport": {
+    "$numberDecimal": "135063000"
+  },
+  "education": {
+    "$numberDecimal": "315953000"
+  },
+  "entertainment": {
+    "$numberDecimal": "96867000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "464945000"
+  },
+  "other": {
+    "$numberDecimal": "332392000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1103018000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351310"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350630",
+  "adstrdName": "상계1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3030316"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8961292000"
+  },
+  "food": {
+    "$numberDecimal": "3079076000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "59534000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "170853000"
+  },
+  "medical": {
+    "$numberDecimal": "964012000"
+  },
+  "transport": {
+    "$numberDecimal": "316680000"
+  },
+  "education": {
+    "$numberDecimal": "274619000"
+  },
+  "entertainment": {
+    "$numberDecimal": "188629000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "383253000"
+  },
+  "other": {
+    "$numberDecimal": "350094000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3174542000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351311"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350710",
+  "adstrdName": "상계9동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2955988"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1871796000"
+  },
+  "food": {
+    "$numberDecimal": "636402000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "40220000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "2184000"
+  },
+  "medical": {
+    "$numberDecimal": "392399000"
+  },
+  "transport": {
+    "$numberDecimal": "0"
+  },
+  "education": {
+    "$numberDecimal": "198863000"
+  },
+  "entertainment": {
+    "$numberDecimal": "24954000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "131834000"
+  },
+  "other": {
+    "$numberDecimal": "156867000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "288073000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351312"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11350720",
+  "adstrdName": "상계10동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3132098"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1083867000"
+  },
+  "food": {
+    "$numberDecimal": "336620000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "37116000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "70254000"
+  },
+  "medical": {
+    "$numberDecimal": "151872000"
+  },
+  "transport": {
+    "$numberDecimal": "11298000"
+  },
+  "education": {
+    "$numberDecimal": "132758000"
+  },
+  "entertainment": {
+    "$numberDecimal": "430000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "134151000"
+  },
+  "other": {
+    "$numberDecimal": "69900000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "139468000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351313"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380560",
+  "adstrdName": "구산동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2602334"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2618811000"
+  },
+  "food": {
+    "$numberDecimal": "821521000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "36140000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "9360000"
+  },
+  "medical": {
+    "$numberDecimal": "719459000"
+  },
+  "transport": {
+    "$numberDecimal": "83393000"
+  },
+  "education": {
+    "$numberDecimal": "360306000"
+  },
+  "entertainment": {
+    "$numberDecimal": "20735000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "91345000"
+  },
+  "other": {
+    "$numberDecimal": "88384000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "388168000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351314"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11380580",
+  "adstrdName": "응암1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2726133"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6349851000"
+  },
+  "food": {
+    "$numberDecimal": "1007006000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "85219000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "49266000"
+  },
+  "medical": {
+    "$numberDecimal": "2210729000"
+  },
+  "transport": {
+    "$numberDecimal": "15525000"
+  },
+  "education": {
+    "$numberDecimal": "632308000"
+  },
+  "entertainment": {
+    "$numberDecimal": "119050000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "349787000"
+  },
+  "other": {
+    "$numberDecimal": "381923000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1499038000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351315"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410520",
+  "adstrdName": "천연동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4197718"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2622114000"
+  },
+  "food": {
+    "$numberDecimal": "1257839000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "34477000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "7392000"
+  },
+  "medical": {
+    "$numberDecimal": "192704000"
+  },
+  "transport": {
+    "$numberDecimal": "16541000"
+  },
+  "education": {
+    "$numberDecimal": "179125000"
+  },
+  "entertainment": {
+    "$numberDecimal": "29138000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "124597000"
+  },
+  "other": {
+    "$numberDecimal": "38890000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "741411000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351316"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410565",
+  "adstrdName": "충현동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3210231"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4032857000"
+  },
+  "food": {
+    "$numberDecimal": "751113000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "55505000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "29056000"
+  },
+  "medical": {
+    "$numberDecimal": "453587000"
+  },
+  "transport": {
+    "$numberDecimal": "676517000"
+  },
+  "education": {
+    "$numberDecimal": "63292000"
+  },
+  "entertainment": {
+    "$numberDecimal": "87420000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "507869000"
+  },
+  "other": {
+    "$numberDecimal": "95478000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1313020000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351317"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11410615",
+  "adstrdName": "연희동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3383749"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "55520376000"
+  },
+  "food": {
+    "$numberDecimal": "2067370000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "297485000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "221294000"
+  },
+  "medical": {
+    "$numberDecimal": "49275277000"
+  },
+  "transport": {
+    "$numberDecimal": "537166000"
+  },
+  "education": {
+    "$numberDecimal": "267155000"
+  },
+  "entertainment": {
+    "$numberDecimal": "74246000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "416616000"
+  },
+  "other": {
+    "$numberDecimal": "185181000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2178586000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351318"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470530",
+  "adstrdName": "목3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3101712"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6468009000"
+  },
+  "food": {
+    "$numberDecimal": "2867545000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "129262000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "133726000"
+  },
+  "medical": {
+    "$numberDecimal": "1181503000"
+  },
+  "transport": {
+    "$numberDecimal": "22252000"
+  },
+  "education": {
+    "$numberDecimal": "210252000"
+  },
+  "entertainment": {
+    "$numberDecimal": "177358000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "346443000"
+  },
+  "other": {
+    "$numberDecimal": "265622000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1134046000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351319"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470550",
+  "adstrdName": "목5동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5987821"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "13254328000"
+  },
+  "food": {
+    "$numberDecimal": "1963422000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "77094000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "20687000"
+  },
+  "medical": {
+    "$numberDecimal": "4659429000"
+  },
+  "transport": {
+    "$numberDecimal": "8066000"
+  },
+  "education": {
+    "$numberDecimal": "4521948000"
+  },
+  "entertainment": {
+    "$numberDecimal": "21093000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "493160000"
+  },
+  "other": {
+    "$numberDecimal": "231769000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1257660000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935131a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470560",
+  "adstrdName": "신월1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2227154"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3917536000"
+  },
+  "food": {
+    "$numberDecimal": "2095059000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "57220000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "97048000"
+  },
+  "medical": {
+    "$numberDecimal": "323561000"
+  },
+  "transport": {
+    "$numberDecimal": "66080000"
+  },
+  "education": {
+    "$numberDecimal": "72363000"
+  },
+  "entertainment": {
+    "$numberDecimal": "135695000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "207292000"
+  },
+  "other": {
+    "$numberDecimal": "86631000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "776587000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935131b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470570",
+  "adstrdName": "신월2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2727225"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2917989000"
+  },
+  "food": {
+    "$numberDecimal": "1322911000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "41158000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "51046000"
+  },
+  "medical": {
+    "$numberDecimal": "572011000"
+  },
+  "transport": {
+    "$numberDecimal": "144079000"
+  },
+  "education": {
+    "$numberDecimal": "164054000"
+  },
+  "entertainment": {
+    "$numberDecimal": "11314000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "102612000"
+  },
+  "other": {
+    "$numberDecimal": "53917000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "454887000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935131c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470640",
+  "adstrdName": "신정3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3158844"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "5227228000"
+  },
+  "food": {
+    "$numberDecimal": "1583057000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "86199000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "26643000"
+  },
+  "medical": {
+    "$numberDecimal": "1730097000"
+  },
+  "transport": {
+    "$numberDecimal": "90446000"
+  },
+  "education": {
+    "$numberDecimal": "454075000"
+  },
+  "entertainment": {
+    "$numberDecimal": "61030000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "384478000"
+  },
+  "other": {
+    "$numberDecimal": "111870000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "699333000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935131d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11470680",
+  "adstrdName": "신정7동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4094404"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4386608000"
+  },
+  "food": {
+    "$numberDecimal": "1304824000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "23586000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "21435000"
+  },
+  "medical": {
+    "$numberDecimal": "1047041000"
+  },
+  "transport": {
+    "$numberDecimal": "484109000"
+  },
+  "education": {
+    "$numberDecimal": "477312000"
+  },
+  "entertainment": {
+    "$numberDecimal": "14128000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "211085000"
+  },
+  "other": {
+    "$numberDecimal": "102804000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "700284000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935131e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530520",
+  "adstrdName": "구로1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3368067"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1782259000"
+  },
+  "food": {
+    "$numberDecimal": "744910000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "16386000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "12861000"
+  },
+  "medical": {
+    "$numberDecimal": "265672000"
+  },
+  "transport": {
+    "$numberDecimal": "13831000"
+  },
+  "education": {
+    "$numberDecimal": "248779000"
+  },
+  "entertainment": {
+    "$numberDecimal": "12667000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "80485000"
+  },
+  "other": {
+    "$numberDecimal": "96261000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "290407000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935131f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530595",
+  "adstrdName": "가리봉동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2336331"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1409132000"
+  },
+  "food": {
+    "$numberDecimal": "545028000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "7781000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "29661000"
+  },
+  "medical": {
+    "$numberDecimal": "139544000"
+  },
+  "transport": {
+    "$numberDecimal": "176336000"
+  },
+  "education": {
+    "$numberDecimal": "4329000"
+  },
+  "entertainment": {
+    "$numberDecimal": "92681000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "61425000"
+  },
+  "other": {
+    "$numberDecimal": "30748000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "321599000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351320"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11530800",
+  "adstrdName": "항동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3007261"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1098741000"
+  },
+  "food": {
+    "$numberDecimal": "287899000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "9452000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "519000"
+  },
+  "medical": {
+    "$numberDecimal": "116904000"
+  },
+  "transport": {
+    "$numberDecimal": "217846000"
+  },
+  "education": {
+    "$numberDecimal": "211026000"
+  },
+  "entertainment": {
+    "$numberDecimal": "2129000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "38956000"
+  },
+  "other": {
+    "$numberDecimal": "27766000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "186244000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351321"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11545670",
+  "adstrdName": "시흥1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2757307"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9973939000"
+  },
+  "food": {
+    "$numberDecimal": "3572138000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "168465000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "105938000"
+  },
+  "medical": {
+    "$numberDecimal": "1614990000"
+  },
+  "transport": {
+    "$numberDecimal": "535996000"
+  },
+  "education": {
+    "$numberDecimal": "353451000"
+  },
+  "entertainment": {
+    "$numberDecimal": "346330000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "476679000"
+  },
+  "other": {
+    "$numberDecimal": "276780000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2523172000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351322"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11545680",
+  "adstrdName": "시흥2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3181421"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "742027000"
+  },
+  "food": {
+    "$numberDecimal": "422919000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "18171000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "4714000"
+  },
+  "medical": {
+    "$numberDecimal": "53647000"
+  },
+  "transport": {
+    "$numberDecimal": "532000"
+  },
+  "education": {
+    "$numberDecimal": "124922000"
+  },
+  "entertainment": {
+    "$numberDecimal": "3900000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "31265000"
+  },
+  "other": {
+    "$numberDecimal": "23539000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "58418000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351323"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11545710",
+  "adstrdName": "시흥5동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2375052"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1583474000"
+  },
+  "food": {
+    "$numberDecimal": "602296000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "11341000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "53141000"
+  },
+  "medical": {
+    "$numberDecimal": "164819000"
+  },
+  "transport": {
+    "$numberDecimal": "39241000"
+  },
+  "education": {
+    "$numberDecimal": "49764000"
+  },
+  "entertainment": {
+    "$numberDecimal": "64962000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "103868000"
+  },
+  "other": {
+    "$numberDecimal": "91852000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "402190000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351324"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11560620",
+  "adstrdName": "양평2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3672088"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "13457180000"
+  },
+  "food": {
+    "$numberDecimal": "1433987000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "73064000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "207466000"
+  },
+  "medical": {
+    "$numberDecimal": "525326000"
+  },
+  "transport": {
+    "$numberDecimal": "699861000"
+  },
+  "education": {
+    "$numberDecimal": "192424000"
+  },
+  "entertainment": {
+    "$numberDecimal": "137961000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "8268017000"
+  },
+  "other": {
+    "$numberDecimal": "159450000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1759624000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351325"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11590651",
+  "adstrdName": "사당5동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3047661"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "876259000"
+  },
+  "food": {
+    "$numberDecimal": "269223000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "13559000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "18625000"
+  },
+  "medical": {
+    "$numberDecimal": "54034000"
+  },
+  "transport": {
+    "$numberDecimal": "18570000"
+  },
+  "education": {
+    "$numberDecimal": "94271000"
+  },
+  "entertainment": {
+    "$numberDecimal": "24999000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "61610000"
+  },
+  "other": {
+    "$numberDecimal": "27285000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "294083000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351326"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620595",
+  "adstrdName": "청룡동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2768161"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "8638168000"
+  },
+  "food": {
+    "$numberDecimal": "1999047000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "226509000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "484041000"
+  },
+  "medical": {
+    "$numberDecimal": "1979946000"
+  },
+  "transport": {
+    "$numberDecimal": "12900000"
+  },
+  "education": {
+    "$numberDecimal": "341777000"
+  },
+  "entertainment": {
+    "$numberDecimal": "236430000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "802069000"
+  },
+  "other": {
+    "$numberDecimal": "534132000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2021317000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351327"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620655",
+  "adstrdName": "신원동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2403237"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "5"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2042199000"
+  },
+  "food": {
+    "$numberDecimal": "990009000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "24854000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "19369000"
+  },
+  "medical": {
+    "$numberDecimal": "127401000"
+  },
+  "transport": {
+    "$numberDecimal": "48701000"
+  },
+  "education": {
+    "$numberDecimal": "27401000"
+  },
+  "entertainment": {
+    "$numberDecimal": "58563000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "111579000"
+  },
+  "other": {
+    "$numberDecimal": "46320000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "588002000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351328"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11620735",
+  "adstrdName": "대학동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2622408"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "6797414000"
+  },
+  "food": {
+    "$numberDecimal": "2927319000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "37822000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "6253000"
+  },
+  "medical": {
+    "$numberDecimal": "767266000"
+  },
+  "transport": {
+    "$numberDecimal": "7171000"
+  },
+  "education": {
+    "$numberDecimal": "231700000"
+  },
+  "entertainment": {
+    "$numberDecimal": "199116000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "387832000"
+  },
+  "other": {
+    "$numberDecimal": "203116000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2029819000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351329"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650510",
+  "adstrdName": "서초1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4769119"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "10603693000"
+  },
+  "food": {
+    "$numberDecimal": "1399118000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "343898000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "158445000"
+  },
+  "medical": {
+    "$numberDecimal": "3442579000"
+  },
+  "transport": {
+    "$numberDecimal": "404047000"
+  },
+  "education": {
+    "$numberDecimal": "793901000"
+  },
+  "entertainment": {
+    "$numberDecimal": "155665000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "990566000"
+  },
+  "other": {
+    "$numberDecimal": "538078000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2377396000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935132a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11650620",
+  "adstrdName": "방배3동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4681587"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4526093000"
+  },
+  "food": {
+    "$numberDecimal": "486525000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "28141000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "43699000"
+  },
+  "medical": {
+    "$numberDecimal": "3041221000"
+  },
+  "transport": {
+    "$numberDecimal": "136312000"
+  },
+  "education": {
+    "$numberDecimal": "175631000"
+  },
+  "entertainment": {
+    "$numberDecimal": "4188000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "133736000"
+  },
+  "other": {
+    "$numberDecimal": "67988000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "408652000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935132b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680590",
+  "adstrdName": "삼성2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5055114"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "15226377000"
+  },
+  "food": {
+    "$numberDecimal": "2744056000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "739195000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "852859000"
+  },
+  "medical": {
+    "$numberDecimal": "2093110000"
+  },
+  "transport": {
+    "$numberDecimal": "235783000"
+  },
+  "education": {
+    "$numberDecimal": "4284771000"
+  },
+  "entertainment": {
+    "$numberDecimal": "273800000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1116262000"
+  },
+  "other": {
+    "$numberDecimal": "624823000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "2261718000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935132c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680610",
+  "adstrdName": "대치2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "6017362"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "25285787000"
+  },
+  "food": {
+    "$numberDecimal": "1975337000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "6665378000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "228936000"
+  },
+  "medical": {
+    "$numberDecimal": "5006516000"
+  },
+  "transport": {
+    "$numberDecimal": "368584000"
+  },
+  "education": {
+    "$numberDecimal": "5049108000"
+  },
+  "entertainment": {
+    "$numberDecimal": "166706000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1406258000"
+  },
+  "other": {
+    "$numberDecimal": "1106360000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3312604000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935132d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680640",
+  "adstrdName": "역삼1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3607265"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.26E+12"
+  },
+  "food": {
+    "$numberDecimal": "7075392000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "2373891000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "714046000"
+  },
+  "medical": {
+    "$numberDecimal": "35035992000"
+  },
+  "transport": {
+    "$numberDecimal": "592715000"
+  },
+  "education": {
+    "$numberDecimal": "4533046000"
+  },
+  "entertainment": {
+    "$numberDecimal": "2593447000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1.02E+12"
+  },
+  "other": {
+    "$numberDecimal": "1.66E+11"
+  },
+  "eatingOut": {
+    "$numberDecimal": "18990367000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935132e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680660",
+  "adstrdName": "개포1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5336373"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "380817000"
+  },
+  "food": {
+    "$numberDecimal": "83467000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "15813000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "4366000"
+  },
+  "medical": {
+    "$numberDecimal": "236458000"
+  },
+  "transport": {
+    "$numberDecimal": "0"
+  },
+  "education": {
+    "$numberDecimal": "12046000"
+  },
+  "entertainment": {
+    "$numberDecimal": "0"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "4431000"
+  },
+  "other": {
+    "$numberDecimal": "8713000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "15523000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c43287170962935132f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680720",
+  "adstrdName": "일원본동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "5444886"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "9"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "4478902000"
+  },
+  "food": {
+    "$numberDecimal": "785630000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "13745000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "16929000"
+  },
+  "medical": {
+    "$numberDecimal": "2729439000"
+  },
+  "transport": {
+    "$numberDecimal": "3045000"
+  },
+  "education": {
+    "$numberDecimal": "195257000"
+  },
+  "entertainment": {
+    "$numberDecimal": "0"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "169850000"
+  },
+  "other": {
+    "$numberDecimal": "81380000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "483627000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351330"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11680730",
+  "adstrdName": "일원1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3022931"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "2469883000"
+  },
+  "food": {
+    "$numberDecimal": "498698000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "16777000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "28347000"
+  },
+  "medical": {
+    "$numberDecimal": "614492000"
+  },
+  "transport": {
+    "$numberDecimal": "196998000"
+  },
+  "education": {
+    "$numberDecimal": "59032000"
+  },
+  "entertainment": {
+    "$numberDecimal": "81371000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "129298000"
+  },
+  "other": {
+    "$numberDecimal": "59861000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "785009000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351331"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710531",
+  "adstrdName": "거여1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2789100"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1796555000"
+  },
+  "food": {
+    "$numberDecimal": "531381000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "10753000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "54778000"
+  },
+  "medical": {
+    "$numberDecimal": "262597000"
+  },
+  "transport": {
+    "$numberDecimal": "90595000"
+  },
+  "education": {
+    "$numberDecimal": "131939000"
+  },
+  "entertainment": {
+    "$numberDecimal": "109023000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "85418000"
+  },
+  "other": {
+    "$numberDecimal": "71796000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "448275000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351332"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710562",
+  "adstrdName": "방이2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2928271"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "1.58E+11"
+  },
+  "food": {
+    "$numberDecimal": "2428037000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "102744000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "43854000"
+  },
+  "medical": {
+    "$numberDecimal": "2184697000"
+  },
+  "transport": {
+    "$numberDecimal": "472504000"
+  },
+  "education": {
+    "$numberDecimal": "936981000"
+  },
+  "entertainment": {
+    "$numberDecimal": "995327000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1.43E+11"
+  },
+  "other": {
+    "$numberDecimal": "571331000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "7431958000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351333"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710620",
+  "adstrdName": "가락본동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3521561"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "9110295000"
+  },
+  "food": {
+    "$numberDecimal": "1295469000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "152691000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "67449000"
+  },
+  "medical": {
+    "$numberDecimal": "2710419000"
+  },
+  "transport": {
+    "$numberDecimal": "169250000"
+  },
+  "education": {
+    "$numberDecimal": "158985000"
+  },
+  "entertainment": {
+    "$numberDecimal": "435655000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "786747000"
+  },
+  "other": {
+    "$numberDecimal": "261639000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "3071991000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351334"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710642",
+  "adstrdName": "문정2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "4425648"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "8"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "21086984000"
+  },
+  "food": {
+    "$numberDecimal": "2917968000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "3703095000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "1628357000"
+  },
+  "medical": {
+    "$numberDecimal": "4772869000"
+  },
+  "transport": {
+    "$numberDecimal": "911721000"
+  },
+  "education": {
+    "$numberDecimal": "246929000"
+  },
+  "entertainment": {
+    "$numberDecimal": "302239000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1100884000"
+  },
+  "other": {
+    "$numberDecimal": "865256000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "4637666000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351335"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11710650",
+  "adstrdName": "잠실본동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "3079387"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "7"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "18050352000"
+  },
+  "food": {
+    "$numberDecimal": "3073063000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "116297000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "135423000"
+  },
+  "medical": {
+    "$numberDecimal": "4527179000"
+  },
+  "transport": {
+    "$numberDecimal": "1294904000"
+  },
+  "education": {
+    "$numberDecimal": "730151000"
+  },
+  "entertainment": {
+    "$numberDecimal": "860704000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "1213920000"
+  },
+  "other": {
+    "$numberDecimal": "661909000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "5436802000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351336"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740600",
+  "adstrdName": "천호1동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2473111"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "3141945000"
+  },
+  "food": {
+    "$numberDecimal": "818940000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "77405000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "56544000"
+  },
+  "medical": {
+    "$numberDecimal": "474505000"
+  },
+  "transport": {
+    "$numberDecimal": "44792000"
+  },
+  "education": {
+    "$numberDecimal": "216877000"
+  },
+  "entertainment": {
+    "$numberDecimal": "34966000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "235530000"
+  },
+  "other": {
+    "$numberDecimal": "155074000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1027312000"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a85c432871709629351337"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrCode": "11740650",
+  "adstrdName": "성내2동",
+  "monthlyIncomeAvg": {
+    "$numberDecimal": "2824592"
+  },
+  "incomeClassCode": {
+    "$numberDecimal": "6"
+  },
+  "spendingTotal": {
+    "$numberDecimal": "7237520000"
+  },
+  "food": {
+    "$numberDecimal": "1515967000"
+  },
+  "clothingFootwear": {
+    "$numberDecimal": "550272000"
+  },
+  "livingGoods": {
+    "$numberDecimal": "116078000"
+  },
+  "medical": {
+    "$numberDecimal": "2153413000"
+  },
+  "transport": {
+    "$numberDecimal": "127732000"
+  },
+  "education": {
+    "$numberDecimal": "143284000"
+  },
+  "entertainment": {
+    "$numberDecimal": "179148000"
+  },
+  "leisureCulture": {
+    "$numberDecimal": "281397000"
+  },
+  "other": {
+    "$numberDecimal": "228568000"
+  },
+  "eatingOut": {
+    "$numberDecimal": "1941661000"
+  }
+}]

--- a/cleopatra.population.json
+++ b/cleopatra.population.json
@@ -1,0 +1,35700 @@
+[{
+  "_id": {
+    "$oid": "68a81c699631f01cc002010e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650651"
+  },
+  "adstrdName": "양재1동",
+  "totalResident": {
+    "$numberInt": "41970"
+  },
+  "maleResident": {
+    "$numberInt": "19916"
+  },
+  "femaleResident": {
+    "$numberInt": "22054"
+  },
+  "age10Resident": {
+    "$numberInt": "7162"
+  },
+  "age20Resident": {
+    "$numberInt": "4669"
+  },
+  "age30Resident": {
+    "$numberInt": "5981"
+  },
+  "age40Resident": {
+    "$numberInt": "7018"
+  },
+  "age50Resident": {
+    "$numberInt": "6403"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10737"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3612"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2305"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2898"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3364"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3050"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4687"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3550"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2364"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3083"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3654"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3353"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "6050"
+  },
+  "totalHouseholds": {
+    "$numberInt": "17799"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "17799"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002010f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440730"
+  },
+  "adstrdName": "성산2동",
+  "totalResident": {
+    "$numberInt": "38537"
+  },
+  "maleResident": {
+    "$numberInt": "17159"
+  },
+  "femaleResident": {
+    "$numberInt": "21378"
+  },
+  "age10Resident": {
+    "$numberInt": "4756"
+  },
+  "age20Resident": {
+    "$numberInt": "6487"
+  },
+  "age30Resident": {
+    "$numberInt": "6726"
+  },
+  "age40Resident": {
+    "$numberInt": "5575"
+  },
+  "age50Resident": {
+    "$numberInt": "5968"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9025"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2416"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2439"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3011"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2635"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2891"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3767"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2340"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "4048"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3715"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2940"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3077"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5258"
+  },
+  "totalHouseholds": {
+    "$numberInt": "19332"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "19332"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020110"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305534"
+  },
+  "adstrdName": "삼양동",
+  "totalResident": {
+    "$numberInt": "22402"
+  },
+  "maleResident": {
+    "$numberInt": "11147"
+  },
+  "femaleResident": {
+    "$numberInt": "11255"
+  },
+  "age10Resident": {
+    "$numberInt": "2574"
+  },
+  "age20Resident": {
+    "$numberInt": "2809"
+  },
+  "age30Resident": {
+    "$numberInt": "2595"
+  },
+  "age40Resident": {
+    "$numberInt": "3062"
+  },
+  "age50Resident": {
+    "$numberInt": "4170"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7192"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1354"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1477"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1373"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1585"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2071"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3287"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1220"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1332"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1222"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1477"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2099"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3905"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10805"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10805"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020111"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380570"
+  },
+  "adstrdName": "대조동",
+  "totalResident": {
+    "$numberInt": "27359"
+  },
+  "maleResident": {
+    "$numberInt": "12627"
+  },
+  "femaleResident": {
+    "$numberInt": "14732"
+  },
+  "age10Resident": {
+    "$numberInt": "2350"
+  },
+  "age20Resident": {
+    "$numberInt": "5092"
+  },
+  "age30Resident": {
+    "$numberInt": "4895"
+  },
+  "age40Resident": {
+    "$numberInt": "3556"
+  },
+  "age50Resident": {
+    "$numberInt": "4097"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7369"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1168"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2033"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2437"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1772"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1972"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3245"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1182"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3059"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2458"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1784"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2125"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4124"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15341"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15341"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020112"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620605"
+  },
+  "adstrdName": "은천동",
+  "totalResident": {
+    "$numberInt": "32359"
+  },
+  "maleResident": {
+    "$numberInt": "15843"
+  },
+  "femaleResident": {
+    "$numberInt": "16516"
+  },
+  "age10Resident": {
+    "$numberInt": "4077"
+  },
+  "age20Resident": {
+    "$numberInt": "5082"
+  },
+  "age30Resident": {
+    "$numberInt": "5050"
+  },
+  "age40Resident": {
+    "$numberInt": "4730"
+  },
+  "age50Resident": {
+    "$numberInt": "4764"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8656"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2107"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2408"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2642"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2396"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2413"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3877"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1970"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2674"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2408"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2334"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2351"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4779"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16051"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16051"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020113"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290685"
+  },
+  "adstrdName": "길음2동",
+  "totalResident": {
+    "$numberInt": "21666"
+  },
+  "maleResident": {
+    "$numberInt": "10347"
+  },
+  "femaleResident": {
+    "$numberInt": "11319"
+  },
+  "age10Resident": {
+    "$numberInt": "4065"
+  },
+  "age20Resident": {
+    "$numberInt": "2507"
+  },
+  "age30Resident": {
+    "$numberInt": "2856"
+  },
+  "age40Resident": {
+    "$numberInt": "3847"
+  },
+  "age50Resident": {
+    "$numberInt": "3714"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4677"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2097"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1180"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1335"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1818"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1835"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2082"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1968"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1327"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1521"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2029"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1879"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2595"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8617"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8617"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020114"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440655"
+  },
+  "adstrdName": "서강동",
+  "totalResident": {
+    "$numberInt": "24556"
+  },
+  "maleResident": {
+    "$numberInt": "11694"
+  },
+  "femaleResident": {
+    "$numberInt": "12862"
+  },
+  "age10Resident": {
+    "$numberInt": "3262"
+  },
+  "age20Resident": {
+    "$numberInt": "4707"
+  },
+  "age30Resident": {
+    "$numberInt": "4051"
+  },
+  "age40Resident": {
+    "$numberInt": "3790"
+  },
+  "age50Resident": {
+    "$numberInt": "3723"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5023"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1689"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2198"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1925"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1859"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1775"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2248"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1573"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2509"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2126"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1931"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1948"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2775"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12147"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12147"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020115"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290610"
+  },
+  "adstrdName": "보문동",
+  "totalResident": {
+    "$numberInt": "16145"
+  },
+  "maleResident": {
+    "$numberInt": "7748"
+  },
+  "femaleResident": {
+    "$numberInt": "8397"
+  },
+  "age10Resident": {
+    "$numberInt": "1933"
+  },
+  "age20Resident": {
+    "$numberInt": "2644"
+  },
+  "age30Resident": {
+    "$numberInt": "2807"
+  },
+  "age40Resident": {
+    "$numberInt": "2275"
+  },
+  "age50Resident": {
+    "$numberInt": "2686"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3800"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "957"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1228"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1404"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1166"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1307"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1686"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "976"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1416"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1403"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1109"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1379"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2114"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8126"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8126"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020116"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380530"
+  },
+  "adstrdName": "불광2동",
+  "totalResident": {
+    "$numberInt": "26600"
+  },
+  "maleResident": {
+    "$numberInt": "12782"
+  },
+  "femaleResident": {
+    "$numberInt": "13818"
+  },
+  "age10Resident": {
+    "$numberInt": "2240"
+  },
+  "age20Resident": {
+    "$numberInt": "3809"
+  },
+  "age30Resident": {
+    "$numberInt": "3761"
+  },
+  "age40Resident": {
+    "$numberInt": "3318"
+  },
+  "age50Resident": {
+    "$numberInt": "4614"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8858"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1149"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1840"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1946"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1713"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2193"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3941"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1091"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1969"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1815"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1605"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2421"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4917"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13965"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13965"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020117"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215780"
+  },
+  "adstrdName": "능동",
+  "totalResident": {
+    "$numberInt": "11053"
+  },
+  "maleResident": {
+    "$numberInt": "5063"
+  },
+  "femaleResident": {
+    "$numberInt": "5990"
+  },
+  "age10Resident": {
+    "$numberInt": "919"
+  },
+  "age20Resident": {
+    "$numberInt": "2217"
+  },
+  "age30Resident": {
+    "$numberInt": "2459"
+  },
+  "age40Resident": {
+    "$numberInt": "1604"
+  },
+  "age50Resident": {
+    "$numberInt": "1443"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2411"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "462"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "958"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1120"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "771"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "687"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1065"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "457"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1259"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1339"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "833"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "756"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1346"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6456"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6456"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020118"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320680"
+  },
+  "adstrdName": "쌍문3동",
+  "totalResident": {
+    "$numberInt": "16449"
+  },
+  "maleResident": {
+    "$numberInt": "7872"
+  },
+  "femaleResident": {
+    "$numberInt": "8577"
+  },
+  "age10Resident": {
+    "$numberInt": "1590"
+  },
+  "age20Resident": {
+    "$numberInt": "2375"
+  },
+  "age30Resident": {
+    "$numberInt": "2361"
+  },
+  "age40Resident": {
+    "$numberInt": "2240"
+  },
+  "age50Resident": {
+    "$numberInt": "2788"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5095"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "791"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1114"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1214"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1151"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1332"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2270"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "799"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1261"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1147"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1089"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1456"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2825"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8192"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8192"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020119"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470520"
+  },
+  "adstrdName": "목2동",
+  "totalResident": {
+    "$numberInt": "28816"
+  },
+  "maleResident": {
+    "$numberInt": "13924"
+  },
+  "femaleResident": {
+    "$numberInt": "14892"
+  },
+  "age10Resident": {
+    "$numberInt": "3551"
+  },
+  "age20Resident": {
+    "$numberInt": "4299"
+  },
+  "age30Resident": {
+    "$numberInt": "5100"
+  },
+  "age40Resident": {
+    "$numberInt": "4253"
+  },
+  "age50Resident": {
+    "$numberInt": "4698"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6915"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1877"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2069"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2568"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2067"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2174"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3169"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1674"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2230"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2532"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2186"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2524"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3746"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13299"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13299"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002011a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215820"
+  },
+  "adstrdName": "자양1동",
+  "totalResident": {
+    "$numberInt": "21795"
+  },
+  "maleResident": {
+    "$numberInt": "10556"
+  },
+  "femaleResident": {
+    "$numberInt": "11239"
+  },
+  "age10Resident": {
+    "$numberInt": "2105"
+  },
+  "age20Resident": {
+    "$numberInt": "3873"
+  },
+  "age30Resident": {
+    "$numberInt": "3812"
+  },
+  "age40Resident": {
+    "$numberInt": "3127"
+  },
+  "age50Resident": {
+    "$numberInt": "3377"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5501"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1095"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1879"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1986"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1530"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1654"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2412"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1010"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1994"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1826"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1597"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1723"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3089"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11960"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11960"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002011b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350670"
+  },
+  "adstrdName": "상계5동",
+  "totalResident": {
+    "$numberInt": "22979"
+  },
+  "maleResident": {
+    "$numberInt": "11152"
+  },
+  "femaleResident": {
+    "$numberInt": "11827"
+  },
+  "age10Resident": {
+    "$numberInt": "2533"
+  },
+  "age20Resident": {
+    "$numberInt": "2909"
+  },
+  "age30Resident": {
+    "$numberInt": "2567"
+  },
+  "age40Resident": {
+    "$numberInt": "2991"
+  },
+  "age50Resident": {
+    "$numberInt": "4369"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7610"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1298"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1503"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1383"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1484"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2114"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3370"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1235"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1406"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1184"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1507"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2255"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4240"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10900"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10900"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002011c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560660"
+  },
+  "adstrdName": "신길4동",
+  "totalResident": {
+    "$numberInt": "10315"
+  },
+  "maleResident": {
+    "$numberInt": "5096"
+  },
+  "femaleResident": {
+    "$numberInt": "5219"
+  },
+  "age10Resident": {
+    "$numberInt": "1110"
+  },
+  "age20Resident": {
+    "$numberInt": "1231"
+  },
+  "age30Resident": {
+    "$numberInt": "1489"
+  },
+  "age40Resident": {
+    "$numberInt": "1375"
+  },
+  "age50Resident": {
+    "$numberInt": "1756"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3354"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "579"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "630"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "796"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "714"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "871"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1506"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "531"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "601"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "693"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "661"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "885"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1848"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5081"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5081"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002011d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470580"
+  },
+  "adstrdName": "신월3동",
+  "totalResident": {
+    "$numberInt": "14261"
+  },
+  "maleResident": {
+    "$numberInt": "7502"
+  },
+  "femaleResident": {
+    "$numberInt": "6759"
+  },
+  "age10Resident": {
+    "$numberInt": "1565"
+  },
+  "age20Resident": {
+    "$numberInt": "1685"
+  },
+  "age30Resident": {
+    "$numberInt": "1854"
+  },
+  "age40Resident": {
+    "$numberInt": "1910"
+  },
+  "age50Resident": {
+    "$numberInt": "2539"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4708"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "840"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "892"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1002"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1044"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1408"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2316"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "725"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "793"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "852"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "866"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1131"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2392"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7693"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7693"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002011e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740560"
+  },
+  "adstrdName": "고덕2동",
+  "totalResident": {
+    "$numberInt": "22684"
+  },
+  "maleResident": {
+    "$numberInt": "11427"
+  },
+  "femaleResident": {
+    "$numberInt": "11257"
+  },
+  "age10Resident": {
+    "$numberInt": "4754"
+  },
+  "age20Resident": {
+    "$numberInt": "2039"
+  },
+  "age30Resident": {
+    "$numberInt": "3425"
+  },
+  "age40Resident": {
+    "$numberInt": "4400"
+  },
+  "age50Resident": {
+    "$numberInt": "3203"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4863"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2520"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1039"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1636"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2261"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1594"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2377"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2234"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1000"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1789"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2139"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1609"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2486"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8924"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8924"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002011f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260580"
+  },
+  "adstrdName": "상봉1동",
+  "totalResident": {
+    "$numberInt": "23195"
+  },
+  "maleResident": {
+    "$numberInt": "11266"
+  },
+  "femaleResident": {
+    "$numberInt": "11929"
+  },
+  "age10Resident": {
+    "$numberInt": "3239"
+  },
+  "age20Resident": {
+    "$numberInt": "2914"
+  },
+  "age30Resident": {
+    "$numberInt": "3373"
+  },
+  "age40Resident": {
+    "$numberInt": "3269"
+  },
+  "age50Resident": {
+    "$numberInt": "3951"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6449"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1690"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1420"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1675"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1676"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1851"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2954"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1549"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1494"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1698"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1593"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2100"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3495"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10132"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10132"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020120"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500591"
+  },
+  "adstrdName": "화곡6동",
+  "totalResident": {
+    "$numberInt": "24357"
+  },
+  "maleResident": {
+    "$numberInt": "11645"
+  },
+  "femaleResident": {
+    "$numberInt": "12712"
+  },
+  "age10Resident": {
+    "$numberInt": "2370"
+  },
+  "age20Resident": {
+    "$numberInt": "4127"
+  },
+  "age30Resident": {
+    "$numberInt": "4399"
+  },
+  "age40Resident": {
+    "$numberInt": "3369"
+  },
+  "age50Resident": {
+    "$numberInt": "3688"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6404"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1244"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1810"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2169"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1757"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1755"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2910"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1126"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2317"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2230"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1612"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1933"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3494"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12808"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12808"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020121"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500550"
+  },
+  "adstrdName": "화곡2동",
+  "totalResident": {
+    "$numberInt": "17041"
+  },
+  "maleResident": {
+    "$numberInt": "8180"
+  },
+  "femaleResident": {
+    "$numberInt": "8861"
+  },
+  "age10Resident": {
+    "$numberInt": "2091"
+  },
+  "age20Resident": {
+    "$numberInt": "2333"
+  },
+  "age30Resident": {
+    "$numberInt": "2600"
+  },
+  "age40Resident": {
+    "$numberInt": "2758"
+  },
+  "age50Resident": {
+    "$numberInt": "2777"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4482"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1053"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1136"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1390"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1368"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1307"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1926"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1038"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1197"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1210"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1390"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1470"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2556"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8150"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8150"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020122"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170520"
+  },
+  "adstrdName": "용산2가동",
+  "totalResident": {
+    "$numberInt": "8866"
+  },
+  "maleResident": {
+    "$numberInt": "4311"
+  },
+  "femaleResident": {
+    "$numberInt": "4555"
+  },
+  "age10Resident": {
+    "$numberInt": "691"
+  },
+  "age20Resident": {
+    "$numberInt": "1307"
+  },
+  "age30Resident": {
+    "$numberInt": "1624"
+  },
+  "age40Resident": {
+    "$numberInt": "1227"
+  },
+  "age50Resident": {
+    "$numberInt": "1243"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2774"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "361"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "663"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "845"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "659"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "590"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1193"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "330"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "644"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "779"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "568"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "653"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1581"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5007"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5007"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020123"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500615"
+  },
+  "adstrdName": "우장산동",
+  "totalResident": {
+    "$numberInt": "43709"
+  },
+  "maleResident": {
+    "$numberInt": "20877"
+  },
+  "femaleResident": {
+    "$numberInt": "22832"
+  },
+  "age10Resident": {
+    "$numberInt": "8547"
+  },
+  "age20Resident": {
+    "$numberInt": "5208"
+  },
+  "age30Resident": {
+    "$numberInt": "5251"
+  },
+  "age40Resident": {
+    "$numberInt": "8190"
+  },
+  "age50Resident": {
+    "$numberInt": "7110"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9403"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "4204"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2384"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2553"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3812"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3546"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4378"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "4343"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2824"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2698"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "4378"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3564"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5025"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16799"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16799"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020124"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140605"
+  },
+  "adstrdName": "을지로동",
+  "totalResident": {
+    "$numberInt": "3208"
+  },
+  "maleResident": {
+    "$numberInt": "1742"
+  },
+  "femaleResident": {
+    "$numberInt": "1466"
+  },
+  "age10Resident": {
+    "$numberInt": "211"
+  },
+  "age20Resident": {
+    "$numberInt": "512"
+  },
+  "age30Resident": {
+    "$numberInt": "956"
+  },
+  "age40Resident": {
+    "$numberInt": "454"
+  },
+  "age50Resident": {
+    "$numberInt": "370"
+  },
+  "age60PlusResident": {
+    "$numberInt": "705"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "98"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "203"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "536"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "249"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "225"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "431"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "113"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "309"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "420"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "205"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "145"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "274"
+  },
+  "totalHouseholds": {
+    "$numberInt": "2292"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "2292"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020125"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260620"
+  },
+  "adstrdName": "묵1동",
+  "totalResident": {
+    "$numberInt": "33661"
+  },
+  "maleResident": {
+    "$numberInt": "16051"
+  },
+  "femaleResident": {
+    "$numberInt": "17610"
+  },
+  "age10Resident": {
+    "$numberInt": "4651"
+  },
+  "age20Resident": {
+    "$numberInt": "4688"
+  },
+  "age30Resident": {
+    "$numberInt": "4558"
+  },
+  "age40Resident": {
+    "$numberInt": "5110"
+  },
+  "age50Resident": {
+    "$numberInt": "5530"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9124"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2354"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2163"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2237"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2504"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2664"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4129"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2297"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2525"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2321"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2606"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2866"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4995"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14934"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14934"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020126"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740590"
+  },
+  "adstrdName": "암사3동",
+  "totalResident": {
+    "$numberInt": "17136"
+  },
+  "maleResident": {
+    "$numberInt": "8416"
+  },
+  "femaleResident": {
+    "$numberInt": "8720"
+  },
+  "age10Resident": {
+    "$numberInt": "3437"
+  },
+  "age20Resident": {
+    "$numberInt": "1763"
+  },
+  "age30Resident": {
+    "$numberInt": "2030"
+  },
+  "age40Resident": {
+    "$numberInt": "3124"
+  },
+  "age50Resident": {
+    "$numberInt": "2594"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4188"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1811"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "890"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "943"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1520"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1275"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1977"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1626"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "873"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1087"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1604"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1319"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2211"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6078"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6078"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020127"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740520"
+  },
+  "adstrdName": "상일동",
+  "totalResident": {
+    "$numberInt": "39307"
+  },
+  "maleResident": {
+    "$numberInt": "19334"
+  },
+  "femaleResident": {
+    "$numberInt": "19973"
+  },
+  "age10Resident": {
+    "$numberInt": "9332"
+  },
+  "age20Resident": {
+    "$numberInt": "3437"
+  },
+  "age30Resident": {
+    "$numberInt": "5097"
+  },
+  "age40Resident": {
+    "$numberInt": "8026"
+  },
+  "age50Resident": {
+    "$numberInt": "5494"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7921"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "4772"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1726"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2319"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3983"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2720"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3814"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "4560"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1711"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2778"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "4043"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2774"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4107"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13601"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13601"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020128"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590510"
+  },
+  "adstrdName": "노량진1동",
+  "totalResident": {
+    "$numberInt": "32005"
+  },
+  "maleResident": {
+    "$numberInt": "16255"
+  },
+  "femaleResident": {
+    "$numberInt": "15750"
+  },
+  "age10Resident": {
+    "$numberInt": "3388"
+  },
+  "age20Resident": {
+    "$numberInt": "5723"
+  },
+  "age30Resident": {
+    "$numberInt": "5768"
+  },
+  "age40Resident": {
+    "$numberInt": "4068"
+  },
+  "age50Resident": {
+    "$numberInt": "4572"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8486"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1747"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3044"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3276"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2172"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2296"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3720"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1641"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2679"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2492"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1896"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2276"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4766"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16917"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16917"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020129"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560550"
+  },
+  "adstrdName": "당산1동",
+  "totalResident": {
+    "$numberInt": "20951"
+  },
+  "maleResident": {
+    "$numberInt": "10105"
+  },
+  "femaleResident": {
+    "$numberInt": "10846"
+  },
+  "age10Resident": {
+    "$numberInt": "1865"
+  },
+  "age20Resident": {
+    "$numberInt": "3681"
+  },
+  "age30Resident": {
+    "$numberInt": "4911"
+  },
+  "age40Resident": {
+    "$numberInt": "2670"
+  },
+  "age50Resident": {
+    "$numberInt": "2884"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4940"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "947"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1533"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2518"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1369"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1468"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2270"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "918"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2148"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2393"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1301"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1416"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2670"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11632"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11632"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002012a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470550"
+  },
+  "adstrdName": "목5동",
+  "totalResident": {
+    "$numberInt": "40702"
+  },
+  "maleResident": {
+    "$numberInt": "20159"
+  },
+  "femaleResident": {
+    "$numberInt": "20543"
+  },
+  "age10Resident": {
+    "$numberInt": "10213"
+  },
+  "age20Resident": {
+    "$numberInt": "3947"
+  },
+  "age30Resident": {
+    "$numberInt": "3450"
+  },
+  "age40Resident": {
+    "$numberInt": "8541"
+  },
+  "age50Resident": {
+    "$numberInt": "6786"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7765"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "5574"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2006"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1555"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3792"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3495"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3737"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "4639"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1941"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1895"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "4749"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3291"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4028"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13447"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13447"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002012b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320514"
+  },
+  "adstrdName": "창4동",
+  "totalResident": {
+    "$numberInt": "26168"
+  },
+  "maleResident": {
+    "$numberInt": "12513"
+  },
+  "femaleResident": {
+    "$numberInt": "13655"
+  },
+  "age10Resident": {
+    "$numberInt": "3711"
+  },
+  "age20Resident": {
+    "$numberInt": "3414"
+  },
+  "age30Resident": {
+    "$numberInt": "3341"
+  },
+  "age40Resident": {
+    "$numberInt": "3902"
+  },
+  "age50Resident": {
+    "$numberInt": "4742"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7058"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1907"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1656"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1653"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1858"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2204"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3235"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1804"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1758"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1688"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2044"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2538"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3823"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10984"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10984"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002012c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110710"
+  },
+  "adstrdName": "숭인2동",
+  "totalResident": {
+    "$numberInt": "9499"
+  },
+  "maleResident": {
+    "$numberInt": "4638"
+  },
+  "femaleResident": {
+    "$numberInt": "4861"
+  },
+  "age10Resident": {
+    "$numberInt": "483"
+  },
+  "age20Resident": {
+    "$numberInt": "2234"
+  },
+  "age30Resident": {
+    "$numberInt": "1740"
+  },
+  "age40Resident": {
+    "$numberInt": "1013"
+  },
+  "age50Resident": {
+    "$numberInt": "1536"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2493"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "227"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "859"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "890"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "547"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "835"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1280"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "256"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1375"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "850"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "466"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "701"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1213"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6369"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6369"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002012d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110530"
+  },
+  "adstrdName": "사직동",
+  "totalResident": {
+    "$numberInt": "8992"
+  },
+  "maleResident": {
+    "$numberInt": "3989"
+  },
+  "femaleResident": {
+    "$numberInt": "5003"
+  },
+  "age10Resident": {
+    "$numberInt": "1122"
+  },
+  "age20Resident": {
+    "$numberInt": "1044"
+  },
+  "age30Resident": {
+    "$numberInt": "1412"
+  },
+  "age40Resident": {
+    "$numberInt": "1407"
+  },
+  "age50Resident": {
+    "$numberInt": "1477"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2530"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "510"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "440"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "632"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "611"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "680"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1116"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "612"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "604"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "780"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "796"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "797"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1414"
+  },
+  "totalHouseholds": {
+    "$numberInt": "4532"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "4532"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002012e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170570"
+  },
+  "adstrdName": "원효로2동",
+  "totalResident": {
+    "$numberInt": "13626"
+  },
+  "maleResident": {
+    "$numberInt": "6396"
+  },
+  "femaleResident": {
+    "$numberInt": "7230"
+  },
+  "age10Resident": {
+    "$numberInt": "1710"
+  },
+  "age20Resident": {
+    "$numberInt": "1909"
+  },
+  "age30Resident": {
+    "$numberInt": "2315"
+  },
+  "age40Resident": {
+    "$numberInt": "1973"
+  },
+  "age50Resident": {
+    "$numberInt": "2222"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3497"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "776"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "842"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1138"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "987"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1083"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1570"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "934"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1067"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1177"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "986"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1139"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1927"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6245"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6245"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002012f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11545670"
+  },
+  "adstrdName": "시흥1동",
+  "totalResident": {
+    "$numberInt": "32115"
+  },
+  "maleResident": {
+    "$numberInt": "15959"
+  },
+  "femaleResident": {
+    "$numberInt": "16156"
+  },
+  "age10Resident": {
+    "$numberInt": "3415"
+  },
+  "age20Resident": {
+    "$numberInt": "4325"
+  },
+  "age30Resident": {
+    "$numberInt": "4825"
+  },
+  "age40Resident": {
+    "$numberInt": "4376"
+  },
+  "age50Resident": {
+    "$numberInt": "5529"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9645"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1800"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2136"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2539"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2286"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2771"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4427"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1615"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2189"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2286"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2090"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2758"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5218"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16342"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16342"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020130"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470570"
+  },
+  "adstrdName": "신월2동",
+  "totalResident": {
+    "$numberInt": "20779"
+  },
+  "maleResident": {
+    "$numberInt": "10130"
+  },
+  "femaleResident": {
+    "$numberInt": "10649"
+  },
+  "age10Resident": {
+    "$numberInt": "2995"
+  },
+  "age20Resident": {
+    "$numberInt": "2437"
+  },
+  "age30Resident": {
+    "$numberInt": "2722"
+  },
+  "age40Resident": {
+    "$numberInt": "3270"
+  },
+  "age50Resident": {
+    "$numberInt": "3235"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6120"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1500"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1246"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1358"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1669"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1584"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2773"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1495"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1191"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1364"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1601"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1651"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3347"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8702"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8702"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020131"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350600"
+  },
+  "adstrdName": "공릉2동",
+  "totalResident": {
+    "$numberInt": "41435"
+  },
+  "maleResident": {
+    "$numberInt": "20163"
+  },
+  "femaleResident": {
+    "$numberInt": "21272"
+  },
+  "age10Resident": {
+    "$numberInt": "7053"
+  },
+  "age20Resident": {
+    "$numberInt": "6862"
+  },
+  "age30Resident": {
+    "$numberInt": "5438"
+  },
+  "age40Resident": {
+    "$numberInt": "6599"
+  },
+  "age50Resident": {
+    "$numberInt": "6387"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9096"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3643"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3362"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2693"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3179"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3130"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4156"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3410"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3500"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2745"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3420"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3257"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4940"
+  },
+  "totalHouseholds": {
+    "$numberInt": "17741"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "17741"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020132"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170660"
+  },
+  "adstrdName": "이태원2동",
+  "totalResident": {
+    "$numberInt": "8657"
+  },
+  "maleResident": {
+    "$numberInt": "4044"
+  },
+  "femaleResident": {
+    "$numberInt": "4613"
+  },
+  "age10Resident": {
+    "$numberInt": "767"
+  },
+  "age20Resident": {
+    "$numberInt": "1192"
+  },
+  "age30Resident": {
+    "$numberInt": "1695"
+  },
+  "age40Resident": {
+    "$numberInt": "1293"
+  },
+  "age50Resident": {
+    "$numberInt": "1247"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2463"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "370"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "605"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "850"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "634"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "568"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1017"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "397"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "587"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "845"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "659"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "679"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1446"
+  },
+  "totalHouseholds": {
+    "$numberInt": "4845"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "4845"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020133"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710646"
+  },
+  "adstrdName": "장지동",
+  "totalResident": {
+    "$numberInt": "28473"
+  },
+  "maleResident": {
+    "$numberInt": "13711"
+  },
+  "femaleResident": {
+    "$numberInt": "14762"
+  },
+  "age10Resident": {
+    "$numberInt": "4331"
+  },
+  "age20Resident": {
+    "$numberInt": "3521"
+  },
+  "age30Resident": {
+    "$numberInt": "4383"
+  },
+  "age40Resident": {
+    "$numberInt": "4387"
+  },
+  "age50Resident": {
+    "$numberInt": "4637"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7214"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2192"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1799"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2173"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2194"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2141"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3212"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2139"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1722"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2210"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2193"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2496"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4002"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12055"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12055"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020134"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650570"
+  },
+  "adstrdName": "반포2동",
+  "totalResident": {
+    "$numberInt": "23322"
+  },
+  "maleResident": {
+    "$numberInt": "11070"
+  },
+  "femaleResident": {
+    "$numberInt": "12252"
+  },
+  "age10Resident": {
+    "$numberInt": "5945"
+  },
+  "age20Resident": {
+    "$numberInt": "2189"
+  },
+  "age30Resident": {
+    "$numberInt": "2186"
+  },
+  "age40Resident": {
+    "$numberInt": "4645"
+  },
+  "age50Resident": {
+    "$numberInt": "3835"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4522"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2970"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1043"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "901"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2069"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2012"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2075"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2975"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1146"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1285"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2576"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1823"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2447"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7603"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7603"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020135"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350570"
+  },
+  "adstrdName": "월계2동",
+  "totalResident": {
+    "$numberInt": "25485"
+  },
+  "maleResident": {
+    "$numberInt": "12230"
+  },
+  "femaleResident": {
+    "$numberInt": "13255"
+  },
+  "age10Resident": {
+    "$numberInt": "3245"
+  },
+  "age20Resident": {
+    "$numberInt": "2758"
+  },
+  "age30Resident": {
+    "$numberInt": "2828"
+  },
+  "age40Resident": {
+    "$numberInt": "3747"
+  },
+  "age50Resident": {
+    "$numberInt": "4300"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8607"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1680"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1420"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1408"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1897"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2107"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3718"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1565"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1338"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1420"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1850"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2193"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4889"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11694"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11694"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020136"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620765"
+  },
+  "adstrdName": "미성동",
+  "totalResident": {
+    "$numberInt": "29526"
+  },
+  "maleResident": {
+    "$numberInt": "14465"
+  },
+  "femaleResident": {
+    "$numberInt": "15061"
+  },
+  "age10Resident": {
+    "$numberInt": "3333"
+  },
+  "age20Resident": {
+    "$numberInt": "4339"
+  },
+  "age30Resident": {
+    "$numberInt": "4111"
+  },
+  "age40Resident": {
+    "$numberInt": "4090"
+  },
+  "age50Resident": {
+    "$numberInt": "4825"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8828"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1680"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2109"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2204"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2088"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2337"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4047"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1653"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2230"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1907"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2002"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2488"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4781"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14233"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14233"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020137"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380650"
+  },
+  "adstrdName": "수색동",
+  "totalResident": {
+    "$numberInt": "20440"
+  },
+  "maleResident": {
+    "$numberInt": "9936"
+  },
+  "femaleResident": {
+    "$numberInt": "10504"
+  },
+  "age10Resident": {
+    "$numberInt": "3213"
+  },
+  "age20Resident": {
+    "$numberInt": "2561"
+  },
+  "age30Resident": {
+    "$numberInt": "3587"
+  },
+  "age40Resident": {
+    "$numberInt": "2992"
+  },
+  "age50Resident": {
+    "$numberInt": "3554"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4533"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1616"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1289"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1750"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1521"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1717"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2043"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1597"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1272"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1837"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1471"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1837"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2490"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8249"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8249"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020138"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350625"
+  },
+  "adstrdName": "중계2?3동",
+  "totalResident": {
+    "$numberInt": "32502"
+  },
+  "maleResident": {
+    "$numberInt": "14828"
+  },
+  "femaleResident": {
+    "$numberInt": "17674"
+  },
+  "age10Resident": {
+    "$numberInt": "4195"
+  },
+  "age20Resident": {
+    "$numberInt": "3658"
+  },
+  "age30Resident": {
+    "$numberInt": "3820"
+  },
+  "age40Resident": {
+    "$numberInt": "4805"
+  },
+  "age50Resident": {
+    "$numberInt": "5565"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10459"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2088"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1801"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1884"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2319"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2622"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4114"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2107"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1857"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1936"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2486"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2943"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "6345"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14980"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14980"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020139"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110580"
+  },
+  "adstrdName": "교남동",
+  "totalResident": {
+    "$numberInt": "9715"
+  },
+  "maleResident": {
+    "$numberInt": "4456"
+  },
+  "femaleResident": {
+    "$numberInt": "5259"
+  },
+  "age10Resident": {
+    "$numberInt": "1530"
+  },
+  "age20Resident": {
+    "$numberInt": "1142"
+  },
+  "age30Resident": {
+    "$numberInt": "1407"
+  },
+  "age40Resident": {
+    "$numberInt": "1697"
+  },
+  "age50Resident": {
+    "$numberInt": "1622"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2317"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "741"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "521"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "639"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "785"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "789"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "981"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "789"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "621"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "768"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "912"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "833"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1336"
+  },
+  "totalHouseholds": {
+    "$numberInt": "4341"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "4341"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002013a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350612"
+  },
+  "adstrdName": "하계2동",
+  "totalResident": {
+    "$numberInt": "21306"
+  },
+  "maleResident": {
+    "$numberInt": "10129"
+  },
+  "femaleResident": {
+    "$numberInt": "11177"
+  },
+  "age10Resident": {
+    "$numberInt": "3682"
+  },
+  "age20Resident": {
+    "$numberInt": "2596"
+  },
+  "age30Resident": {
+    "$numberInt": "2462"
+  },
+  "age40Resident": {
+    "$numberInt": "3461"
+  },
+  "age50Resident": {
+    "$numberInt": "3825"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5280"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1905"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1356"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1168"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1602"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1825"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2273"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1777"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1240"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1294"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1859"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2000"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3007"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8207"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8207"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002013b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350621"
+  },
+  "adstrdName": "중계1동",
+  "totalResident": {
+    "$numberInt": "26318"
+  },
+  "maleResident": {
+    "$numberInt": "12840"
+  },
+  "femaleResident": {
+    "$numberInt": "13478"
+  },
+  "age10Resident": {
+    "$numberInt": "6900"
+  },
+  "age20Resident": {
+    "$numberInt": "2811"
+  },
+  "age30Resident": {
+    "$numberInt": "1858"
+  },
+  "age40Resident": {
+    "$numberInt": "5725"
+  },
+  "age50Resident": {
+    "$numberInt": "4881"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4143"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3691"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1467"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "829"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2470"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2516"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1867"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3209"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1344"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1029"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3255"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2365"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2276"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8923"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8923"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002013c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230610"
+  },
+  "adstrdName": "답십리2동",
+  "totalResident": {
+    "$numberInt": "27467"
+  },
+  "maleResident": {
+    "$numberInt": "13247"
+  },
+  "femaleResident": {
+    "$numberInt": "14220"
+  },
+  "age10Resident": {
+    "$numberInt": "3293"
+  },
+  "age20Resident": {
+    "$numberInt": "3181"
+  },
+  "age30Resident": {
+    "$numberInt": "4231"
+  },
+  "age40Resident": {
+    "$numberInt": "3775"
+  },
+  "age50Resident": {
+    "$numberInt": "4588"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8399"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1605"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1584"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2158"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1912"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2237"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3751"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1688"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1597"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2073"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1863"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2351"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4648"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12454"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12454"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002013d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710520"
+  },
+  "adstrdName": "풍납2동",
+  "totalResident": {
+    "$numberInt": "23552"
+  },
+  "maleResident": {
+    "$numberInt": "11093"
+  },
+  "femaleResident": {
+    "$numberInt": "12459"
+  },
+  "age10Resident": {
+    "$numberInt": "3408"
+  },
+  "age20Resident": {
+    "$numberInt": "3330"
+  },
+  "age30Resident": {
+    "$numberInt": "3689"
+  },
+  "age40Resident": {
+    "$numberInt": "3709"
+  },
+  "age50Resident": {
+    "$numberInt": "3552"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5864"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1727"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1415"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1735"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1817"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1709"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2690"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1681"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1915"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1954"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1892"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1843"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3174"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10513"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10513"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002013e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260590"
+  },
+  "adstrdName": "상봉2동",
+  "totalResident": {
+    "$numberInt": "20258"
+  },
+  "maleResident": {
+    "$numberInt": "9631"
+  },
+  "femaleResident": {
+    "$numberInt": "10627"
+  },
+  "age10Resident": {
+    "$numberInt": "1387"
+  },
+  "age20Resident": {
+    "$numberInt": "4154"
+  },
+  "age30Resident": {
+    "$numberInt": "4749"
+  },
+  "age40Resident": {
+    "$numberInt": "2415"
+  },
+  "age50Resident": {
+    "$numberInt": "2869"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4684"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "702"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1649"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2314"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1283"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1453"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2230"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "685"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2505"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2435"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1132"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1416"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2454"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12531"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12531"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002013f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650590"
+  },
+  "adstrdName": "방배본동",
+  "totalResident": {
+    "$numberInt": "20401"
+  },
+  "maleResident": {
+    "$numberInt": "9406"
+  },
+  "femaleResident": {
+    "$numberInt": "10995"
+  },
+  "age10Resident": {
+    "$numberInt": "3930"
+  },
+  "age20Resident": {
+    "$numberInt": "2442"
+  },
+  "age30Resident": {
+    "$numberInt": "2230"
+  },
+  "age40Resident": {
+    "$numberInt": "3630"
+  },
+  "age50Resident": {
+    "$numberInt": "3553"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4616"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1855"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1101"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "998"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1601"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1740"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2111"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2075"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1341"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1232"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2029"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1813"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2505"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7917"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7917"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020140"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230710"
+  },
+  "adstrdName": "회기동",
+  "totalResident": {
+    "$numberInt": "10313"
+  },
+  "maleResident": {
+    "$numberInt": "4883"
+  },
+  "femaleResident": {
+    "$numberInt": "5430"
+  },
+  "age10Resident": {
+    "$numberInt": "996"
+  },
+  "age20Resident": {
+    "$numberInt": "3406"
+  },
+  "age30Resident": {
+    "$numberInt": "1479"
+  },
+  "age40Resident": {
+    "$numberInt": "1160"
+  },
+  "age50Resident": {
+    "$numberInt": "1219"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2053"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "494"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1536"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "797"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "565"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "630"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "861"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "502"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1870"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "682"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "595"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "589"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1192"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6575"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6575"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020141"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320700"
+  },
+  "adstrdName": "방학2동",
+  "totalResident": {
+    "$numberInt": "18535"
+  },
+  "maleResident": {
+    "$numberInt": "9360"
+  },
+  "femaleResident": {
+    "$numberInt": "9175"
+  },
+  "age10Resident": {
+    "$numberInt": "1901"
+  },
+  "age20Resident": {
+    "$numberInt": "2134"
+  },
+  "age30Resident": {
+    "$numberInt": "1972"
+  },
+  "age40Resident": {
+    "$numberInt": "2338"
+  },
+  "age50Resident": {
+    "$numberInt": "3524"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6666"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "986"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1159"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1103"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1212"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1791"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3109"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "915"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "975"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "869"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1126"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1733"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3557"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9126"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9126"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020142"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260565"
+  },
+  "adstrdName": "면목본동",
+  "totalResident": {
+    "$numberInt": "32648"
+  },
+  "maleResident": {
+    "$numberInt": "16095"
+  },
+  "femaleResident": {
+    "$numberInt": "16553"
+  },
+  "age10Resident": {
+    "$numberInt": "2811"
+  },
+  "age20Resident": {
+    "$numberInt": "4744"
+  },
+  "age30Resident": {
+    "$numberInt": "5276"
+  },
+  "age40Resident": {
+    "$numberInt": "4441"
+  },
+  "age50Resident": {
+    "$numberInt": "5854"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9522"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1442"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2267"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2771"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2364"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2912"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4339"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1369"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2477"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2505"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2077"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2942"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5183"
+  },
+  "totalHouseholds": {
+    "$numberInt": "17709"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "17709"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020143"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650510"
+  },
+  "adstrdName": "서초1동",
+  "totalResident": {
+    "$numberInt": "20154"
+  },
+  "maleResident": {
+    "$numberInt": "9749"
+  },
+  "femaleResident": {
+    "$numberInt": "10405"
+  },
+  "age10Resident": {
+    "$numberInt": "2980"
+  },
+  "age20Resident": {
+    "$numberInt": "2660"
+  },
+  "age30Resident": {
+    "$numberInt": "3273"
+  },
+  "age40Resident": {
+    "$numberInt": "3563"
+  },
+  "age50Resident": {
+    "$numberInt": "3167"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4511"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1582"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1323"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1544"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1633"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1558"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2109"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1398"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1337"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1729"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1930"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1609"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2402"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9392"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9392"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020144"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710632"
+  },
+  "adstrdName": "가락2동",
+  "totalResident": {
+    "$numberInt": "31181"
+  },
+  "maleResident": {
+    "$numberInt": "15186"
+  },
+  "femaleResident": {
+    "$numberInt": "15995"
+  },
+  "age10Resident": {
+    "$numberInt": "5254"
+  },
+  "age20Resident": {
+    "$numberInt": "4005"
+  },
+  "age30Resident": {
+    "$numberInt": "4610"
+  },
+  "age40Resident": {
+    "$numberInt": "5066"
+  },
+  "age50Resident": {
+    "$numberInt": "5110"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7136"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2728"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1978"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2264"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2444"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2461"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3311"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2526"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2027"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2346"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2622"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2649"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3825"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12362"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12362"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020145"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680531"
+  },
+  "adstrdName": "논현2동",
+  "totalResident": {
+    "$numberInt": "20369"
+  },
+  "maleResident": {
+    "$numberInt": "9434"
+  },
+  "femaleResident": {
+    "$numberInt": "10935"
+  },
+  "age10Resident": {
+    "$numberInt": "2079"
+  },
+  "age20Resident": {
+    "$numberInt": "3161"
+  },
+  "age30Resident": {
+    "$numberInt": "4071"
+  },
+  "age40Resident": {
+    "$numberInt": "3605"
+  },
+  "age50Resident": {
+    "$numberInt": "3040"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4413"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1050"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1386"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1859"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1712"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1436"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1991"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1029"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1775"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2212"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1893"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1604"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2422"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11204"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11204"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020146"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650610"
+  },
+  "adstrdName": "방배2동",
+  "totalResident": {
+    "$numberInt": "18010"
+  },
+  "maleResident": {
+    "$numberInt": "8404"
+  },
+  "femaleResident": {
+    "$numberInt": "9606"
+  },
+  "age10Resident": {
+    "$numberInt": "2442"
+  },
+  "age20Resident": {
+    "$numberInt": "2281"
+  },
+  "age30Resident": {
+    "$numberInt": "2679"
+  },
+  "age40Resident": {
+    "$numberInt": "2744"
+  },
+  "age50Resident": {
+    "$numberInt": "2828"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5036"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1218"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1131"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1237"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1272"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1301"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2245"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1224"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1150"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1442"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1472"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1527"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2791"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7831"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7831"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020147"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305645"
+  },
+  "adstrdName": "우이동",
+  "totalResident": {
+    "$numberInt": "19766"
+  },
+  "maleResident": {
+    "$numberInt": "9445"
+  },
+  "femaleResident": {
+    "$numberInt": "10321"
+  },
+  "age10Resident": {
+    "$numberInt": "2065"
+  },
+  "age20Resident": {
+    "$numberInt": "2304"
+  },
+  "age30Resident": {
+    "$numberInt": "2383"
+  },
+  "age40Resident": {
+    "$numberInt": "2607"
+  },
+  "age50Resident": {
+    "$numberInt": "3519"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6888"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1050"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1073"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1244"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1355"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1697"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3026"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1015"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1231"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1139"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1252"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1822"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3862"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9518"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9518"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020148"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290760"
+  },
+  "adstrdName": "장위1동",
+  "totalResident": {
+    "$numberInt": "23354"
+  },
+  "maleResident": {
+    "$numberInt": "11327"
+  },
+  "femaleResident": {
+    "$numberInt": "12027"
+  },
+  "age10Resident": {
+    "$numberInt": "3194"
+  },
+  "age20Resident": {
+    "$numberInt": "3016"
+  },
+  "age30Resident": {
+    "$numberInt": "3150"
+  },
+  "age40Resident": {
+    "$numberInt": "3511"
+  },
+  "age50Resident": {
+    "$numberInt": "4103"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6380"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1585"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1488"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1621"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1808"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1948"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2877"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1609"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1528"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1529"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1703"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2155"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3503"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10588"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10588"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020149"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230730"
+  },
+  "adstrdName": "휘경2동",
+  "totalResident": {
+    "$numberInt": "24158"
+  },
+  "maleResident": {
+    "$numberInt": "12015"
+  },
+  "femaleResident": {
+    "$numberInt": "12143"
+  },
+  "age10Resident": {
+    "$numberInt": "2811"
+  },
+  "age20Resident": {
+    "$numberInt": "5838"
+  },
+  "age30Resident": {
+    "$numberInt": "3023"
+  },
+  "age40Resident": {
+    "$numberInt": "3127"
+  },
+  "age50Resident": {
+    "$numberInt": "3560"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5799"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1391"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3026"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1613"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1582"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1781"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2622"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1420"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2812"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1410"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1545"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1779"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3177"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12643"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12643"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002014a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350619"
+  },
+  "adstrdName": "중계본동",
+  "totalResident": {
+    "$numberInt": "23040"
+  },
+  "maleResident": {
+    "$numberInt": "11163"
+  },
+  "femaleResident": {
+    "$numberInt": "11877"
+  },
+  "age10Resident": {
+    "$numberInt": "5334"
+  },
+  "age20Resident": {
+    "$numberInt": "2899"
+  },
+  "age30Resident": {
+    "$numberInt": "1645"
+  },
+  "age40Resident": {
+    "$numberInt": "4258"
+  },
+  "age50Resident": {
+    "$numberInt": "4637"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4267"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2719"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1456"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "803"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1845"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2324"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2016"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2615"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1443"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "842"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2413"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2313"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2251"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8133"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8133"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002014b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380580"
+  },
+  "adstrdName": "응암1동",
+  "totalResident": {
+    "$numberInt": "32659"
+  },
+  "maleResident": {
+    "$numberInt": "15258"
+  },
+  "femaleResident": {
+    "$numberInt": "17401"
+  },
+  "age10Resident": {
+    "$numberInt": "4871"
+  },
+  "age20Resident": {
+    "$numberInt": "4200"
+  },
+  "age30Resident": {
+    "$numberInt": "5235"
+  },
+  "age40Resident": {
+    "$numberInt": "5463"
+  },
+  "age50Resident": {
+    "$numberInt": "5059"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7831"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2500"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1812"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2497"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2671"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2457"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3321"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2371"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2388"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2738"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2792"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2602"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4510"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15086"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15086"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002014c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305625"
+  },
+  "adstrdName": "수유2동",
+  "totalResident": {
+    "$numberInt": "20502"
+  },
+  "maleResident": {
+    "$numberInt": "9717"
+  },
+  "femaleResident": {
+    "$numberInt": "10785"
+  },
+  "age10Resident": {
+    "$numberInt": "2064"
+  },
+  "age20Resident": {
+    "$numberInt": "2590"
+  },
+  "age30Resident": {
+    "$numberInt": "2319"
+  },
+  "age40Resident": {
+    "$numberInt": "2733"
+  },
+  "age50Resident": {
+    "$numberInt": "3547"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7249"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1076"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1186"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1245"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1410"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1682"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3118"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "988"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1404"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1074"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1323"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1865"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4131"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9767"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9767"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002014d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320512"
+  },
+  "adstrdName": "창2동",
+  "totalResident": {
+    "$numberInt": "28172"
+  },
+  "maleResident": {
+    "$numberInt": "13658"
+  },
+  "femaleResident": {
+    "$numberInt": "14514"
+  },
+  "age10Resident": {
+    "$numberInt": "3392"
+  },
+  "age20Resident": {
+    "$numberInt": "3737"
+  },
+  "age30Resident": {
+    "$numberInt": "3782"
+  },
+  "age40Resident": {
+    "$numberInt": "4103"
+  },
+  "age50Resident": {
+    "$numberInt": "4947"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8211"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1737"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1841"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1919"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2095"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2330"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3736"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1655"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1896"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1863"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2008"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2617"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4475"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12509"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12509"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002014e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305535"
+  },
+  "adstrdName": "미아동",
+  "totalResident": {
+    "$numberInt": "20841"
+  },
+  "maleResident": {
+    "$numberInt": "9966"
+  },
+  "femaleResident": {
+    "$numberInt": "10875"
+  },
+  "age10Resident": {
+    "$numberInt": "1702"
+  },
+  "age20Resident": {
+    "$numberInt": "3520"
+  },
+  "age30Resident": {
+    "$numberInt": "2708"
+  },
+  "age40Resident": {
+    "$numberInt": "2628"
+  },
+  "age50Resident": {
+    "$numberInt": "3535"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6748"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "904"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1477"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1474"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1342"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1747"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3022"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "798"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2043"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1234"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1286"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1788"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3726"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11645"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11645"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002014f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230720"
+  },
+  "adstrdName": "휘경1동",
+  "totalResident": {
+    "$numberInt": "13580"
+  },
+  "maleResident": {
+    "$numberInt": "6428"
+  },
+  "femaleResident": {
+    "$numberInt": "7152"
+  },
+  "age10Resident": {
+    "$numberInt": "1420"
+  },
+  "age20Resident": {
+    "$numberInt": "3601"
+  },
+  "age30Resident": {
+    "$numberInt": "2055"
+  },
+  "age40Resident": {
+    "$numberInt": "1613"
+  },
+  "age50Resident": {
+    "$numberInt": "1886"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3005"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "698"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1505"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1093"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "827"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "907"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1398"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "722"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2096"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "962"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "786"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "979"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1607"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7552"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7552"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020150"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410700"
+  },
+  "adstrdName": "남가좌2동",
+  "totalResident": {
+    "$numberInt": "29083"
+  },
+  "maleResident": {
+    "$numberInt": "14033"
+  },
+  "femaleResident": {
+    "$numberInt": "15050"
+  },
+  "age10Resident": {
+    "$numberInt": "4681"
+  },
+  "age20Resident": {
+    "$numberInt": "4083"
+  },
+  "age30Resident": {
+    "$numberInt": "4081"
+  },
+  "age40Resident": {
+    "$numberInt": "4720"
+  },
+  "age50Resident": {
+    "$numberInt": "4487"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7031"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2367"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1986"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1979"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2379"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2203"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3119"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2314"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2097"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2102"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2341"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2284"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3912"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13349"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13349"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020151"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140670"
+  },
+  "adstrdName": "황학동",
+  "totalResident": {
+    "$numberInt": "12685"
+  },
+  "maleResident": {
+    "$numberInt": "5986"
+  },
+  "femaleResident": {
+    "$numberInt": "6699"
+  },
+  "age10Resident": {
+    "$numberInt": "1103"
+  },
+  "age20Resident": {
+    "$numberInt": "2172"
+  },
+  "age30Resident": {
+    "$numberInt": "2968"
+  },
+  "age40Resident": {
+    "$numberInt": "1817"
+  },
+  "age50Resident": {
+    "$numberInt": "1685"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2940"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "562"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "881"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1456"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "926"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "818"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1343"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "541"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1291"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1512"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "891"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "867"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1597"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7419"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7419"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020152"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560585"
+  },
+  "adstrdName": "도림동",
+  "totalResident": {
+    "$numberInt": "17562"
+  },
+  "maleResident": {
+    "$numberInt": "8900"
+  },
+  "femaleResident": {
+    "$numberInt": "8662"
+  },
+  "age10Resident": {
+    "$numberInt": "1605"
+  },
+  "age20Resident": {
+    "$numberInt": "2542"
+  },
+  "age30Resident": {
+    "$numberInt": "3250"
+  },
+  "age40Resident": {
+    "$numberInt": "2425"
+  },
+  "age50Resident": {
+    "$numberInt": "2902"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4838"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "834"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1234"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1723"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1293"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1533"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2283"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "771"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1308"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1527"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1132"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1369"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2555"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9621"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9621"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020153"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215730"
+  },
+  "adstrdName": "군자동",
+  "totalResident": {
+    "$numberInt": "19048"
+  },
+  "maleResident": {
+    "$numberInt": "9394"
+  },
+  "femaleResident": {
+    "$numberInt": "9654"
+  },
+  "age10Resident": {
+    "$numberInt": "1577"
+  },
+  "age20Resident": {
+    "$numberInt": "4259"
+  },
+  "age30Resident": {
+    "$numberInt": "3440"
+  },
+  "age40Resident": {
+    "$numberInt": "2476"
+  },
+  "age50Resident": {
+    "$numberInt": "2640"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4656"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "826"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2050"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1785"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1249"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1328"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2156"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "751"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2209"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1655"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1227"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1312"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2500"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11293"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11293"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020154"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11545510"
+  },
+  "adstrdName": "가산동",
+  "totalResident": {
+    "$numberInt": "24622"
+  },
+  "maleResident": {
+    "$numberInt": "13262"
+  },
+  "femaleResident": {
+    "$numberInt": "11360"
+  },
+  "age10Resident": {
+    "$numberInt": "1183"
+  },
+  "age20Resident": {
+    "$numberInt": "6982"
+  },
+  "age30Resident": {
+    "$numberInt": "6580"
+  },
+  "age40Resident": {
+    "$numberInt": "2804"
+  },
+  "age50Resident": {
+    "$numberInt": "2716"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4357"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "593"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3140"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3964"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1719"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1598"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2248"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "590"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3842"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2616"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1085"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1118"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2109"
+  },
+  "totalHouseholds": {
+    "$numberInt": "18077"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "18077"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020155"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380631"
+  },
+  "adstrdName": "신사1동",
+  "totalResident": {
+    "$numberInt": "26462"
+  },
+  "maleResident": {
+    "$numberInt": "12698"
+  },
+  "femaleResident": {
+    "$numberInt": "13764"
+  },
+  "age10Resident": {
+    "$numberInt": "2997"
+  },
+  "age20Resident": {
+    "$numberInt": "3592"
+  },
+  "age30Resident": {
+    "$numberInt": "3776"
+  },
+  "age40Resident": {
+    "$numberInt": "3864"
+  },
+  "age50Resident": {
+    "$numberInt": "4436"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7797"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1530"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1796"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1915"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1930"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2094"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3433"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1467"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1796"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1861"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1934"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2342"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4364"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12059"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12059"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020156"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215710"
+  },
+  "adstrdName": "화양동",
+  "totalResident": {
+    "$numberInt": "24821"
+  },
+  "maleResident": {
+    "$numberInt": "11760"
+  },
+  "femaleResident": {
+    "$numberInt": "13061"
+  },
+  "age10Resident": {
+    "$numberInt": "1242"
+  },
+  "age20Resident": {
+    "$numberInt": "10467"
+  },
+  "age30Resident": {
+    "$numberInt": "4995"
+  },
+  "age40Resident": {
+    "$numberInt": "2328"
+  },
+  "age50Resident": {
+    "$numberInt": "2294"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3495"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "569"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "4475"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2584"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1249"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1238"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1645"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "673"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "5992"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2411"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1079"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1056"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1850"
+  },
+  "totalHouseholds": {
+    "$numberInt": "18696"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "18696"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020157"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470650"
+  },
+  "adstrdName": "신정4동",
+  "totalResident": {
+    "$numberInt": "31687"
+  },
+  "maleResident": {
+    "$numberInt": "15407"
+  },
+  "femaleResident": {
+    "$numberInt": "16280"
+  },
+  "age10Resident": {
+    "$numberInt": "3158"
+  },
+  "age20Resident": {
+    "$numberInt": "4945"
+  },
+  "age30Resident": {
+    "$numberInt": "4794"
+  },
+  "age40Resident": {
+    "$numberInt": "4564"
+  },
+  "age50Resident": {
+    "$numberInt": "5229"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8997"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1622"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2327"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2520"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2311"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2538"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4089"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1536"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2618"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2274"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2253"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2691"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4908"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16216"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16216"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020158"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170685"
+  },
+  "adstrdName": "한남동",
+  "totalResident": {
+    "$numberInt": "17711"
+  },
+  "maleResident": {
+    "$numberInt": "8532"
+  },
+  "femaleResident": {
+    "$numberInt": "9179"
+  },
+  "age10Resident": {
+    "$numberInt": "2037"
+  },
+  "age20Resident": {
+    "$numberInt": "2037"
+  },
+  "age30Resident": {
+    "$numberInt": "3193"
+  },
+  "age40Resident": {
+    "$numberInt": "2924"
+  },
+  "age50Resident": {
+    "$numberInt": "2831"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4689"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1059"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1018"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1548"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1469"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1337"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2101"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "978"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1019"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1645"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1455"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1494"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2588"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9323"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9323"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020159"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110650"
+  },
+  "adstrdName": "혜화동",
+  "totalResident": {
+    "$numberInt": "15833"
+  },
+  "maleResident": {
+    "$numberInt": "7605"
+  },
+  "femaleResident": {
+    "$numberInt": "8228"
+  },
+  "age10Resident": {
+    "$numberInt": "1689"
+  },
+  "age20Resident": {
+    "$numberInt": "4273"
+  },
+  "age30Resident": {
+    "$numberInt": "2038"
+  },
+  "age40Resident": {
+    "$numberInt": "1904"
+  },
+  "age50Resident": {
+    "$numberInt": "2304"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3625"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "833"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2111"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1077"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "919"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1094"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1571"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "856"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2162"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "961"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "985"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1210"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2054"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9092"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9092"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002015a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320513"
+  },
+  "adstrdName": "창3동",
+  "totalResident": {
+    "$numberInt": "13163"
+  },
+  "maleResident": {
+    "$numberInt": "6549"
+  },
+  "femaleResident": {
+    "$numberInt": "6614"
+  },
+  "age10Resident": {
+    "$numberInt": "1407"
+  },
+  "age20Resident": {
+    "$numberInt": "1487"
+  },
+  "age30Resident": {
+    "$numberInt": "1503"
+  },
+  "age40Resident": {
+    "$numberInt": "1893"
+  },
+  "age50Resident": {
+    "$numberInt": "2437"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4436"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "758"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "776"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "813"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "984"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1209"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2009"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "649"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "711"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "690"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "909"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1228"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2427"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6402"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6402"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002015b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410555"
+  },
+  "adstrdName": "북아현동",
+  "totalResident": {
+    "$numberInt": "15401"
+  },
+  "maleResident": {
+    "$numberInt": "7379"
+  },
+  "femaleResident": {
+    "$numberInt": "8022"
+  },
+  "age10Resident": {
+    "$numberInt": "2242"
+  },
+  "age20Resident": {
+    "$numberInt": "1925"
+  },
+  "age30Resident": {
+    "$numberInt": "2786"
+  },
+  "age40Resident": {
+    "$numberInt": "2525"
+  },
+  "age50Resident": {
+    "$numberInt": "2474"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3449"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1157"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "851"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1325"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1302"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1197"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1547"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1085"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1074"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1461"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1223"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1277"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1902"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7031"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7031"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002015c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470630"
+  },
+  "adstrdName": "신정2동",
+  "totalResident": {
+    "$numberInt": "18773"
+  },
+  "maleResident": {
+    "$numberInt": "9207"
+  },
+  "femaleResident": {
+    "$numberInt": "9566"
+  },
+  "age10Resident": {
+    "$numberInt": "3948"
+  },
+  "age20Resident": {
+    "$numberInt": "2123"
+  },
+  "age30Resident": {
+    "$numberInt": "1564"
+  },
+  "age40Resident": {
+    "$numberInt": "3465"
+  },
+  "age50Resident": {
+    "$numberInt": "3405"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4268"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2034"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1087"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "737"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1561"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1781"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2007"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1914"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1036"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "827"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1904"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1624"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2261"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6828"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6828"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002015d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200650"
+  },
+  "adstrdName": "성수1가1동",
+  "totalResident": {
+    "$numberInt": "15394"
+  },
+  "maleResident": {
+    "$numberInt": "7652"
+  },
+  "femaleResident": {
+    "$numberInt": "7742"
+  },
+  "age10Resident": {
+    "$numberInt": "1722"
+  },
+  "age20Resident": {
+    "$numberInt": "2196"
+  },
+  "age30Resident": {
+    "$numberInt": "2841"
+  },
+  "age40Resident": {
+    "$numberInt": "2013"
+  },
+  "age50Resident": {
+    "$numberInt": "2745"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3877"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "901"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1102"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1424"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1008"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1329"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1888"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "821"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1094"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1417"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1005"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1416"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1989"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7434"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7434"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002015e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320660"
+  },
+  "adstrdName": "쌍문1동",
+  "totalResident": {
+    "$numberInt": "20484"
+  },
+  "maleResident": {
+    "$numberInt": "9807"
+  },
+  "femaleResident": {
+    "$numberInt": "10677"
+  },
+  "age10Resident": {
+    "$numberInt": "2281"
+  },
+  "age20Resident": {
+    "$numberInt": "2632"
+  },
+  "age30Resident": {
+    "$numberInt": "2371"
+  },
+  "age40Resident": {
+    "$numberInt": "2743"
+  },
+  "age50Resident": {
+    "$numberInt": "3678"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6779"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1143"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1198"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1234"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1400"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1792"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3040"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1138"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1434"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1137"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1343"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1886"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3739"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9257"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9257"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002015f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740685"
+  },
+  "adstrdName": "길동",
+  "totalResident": {
+    "$numberInt": "44395"
+  },
+  "maleResident": {
+    "$numberInt": "21594"
+  },
+  "femaleResident": {
+    "$numberInt": "22801"
+  },
+  "age10Resident": {
+    "$numberInt": "4611"
+  },
+  "age20Resident": {
+    "$numberInt": "6297"
+  },
+  "age30Resident": {
+    "$numberInt": "7127"
+  },
+  "age40Resident": {
+    "$numberInt": "6419"
+  },
+  "age50Resident": {
+    "$numberInt": "7099"
+  },
+  "age60PlusResident": {
+    "$numberInt": "12842"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2411"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2946"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3637"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3290"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3428"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "5882"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2200"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3351"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3490"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3129"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3671"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "6960"
+  },
+  "totalHouseholds": {
+    "$numberInt": "21799"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "21799"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020160"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11545690"
+  },
+  "adstrdName": "시흥3동",
+  "totalResident": {
+    "$numberInt": "10153"
+  },
+  "maleResident": {
+    "$numberInt": "5020"
+  },
+  "femaleResident": {
+    "$numberInt": "5133"
+  },
+  "age10Resident": {
+    "$numberInt": "1022"
+  },
+  "age20Resident": {
+    "$numberInt": "1164"
+  },
+  "age30Resident": {
+    "$numberInt": "1276"
+  },
+  "age40Resident": {
+    "$numberInt": "1264"
+  },
+  "age50Resident": {
+    "$numberInt": "1831"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3596"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "519"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "599"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "691"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "659"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "888"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1664"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "503"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "565"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "585"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "605"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "943"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1932"
+  },
+  "totalHouseholds": {
+    "$numberInt": "4581"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "4581"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020161"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320511"
+  },
+  "adstrdName": "창1동",
+  "totalResident": {
+    "$numberInt": "23774"
+  },
+  "maleResident": {
+    "$numberInt": "11340"
+  },
+  "femaleResident": {
+    "$numberInt": "12434"
+  },
+  "age10Resident": {
+    "$numberInt": "3055"
+  },
+  "age20Resident": {
+    "$numberInt": "2927"
+  },
+  "age30Resident": {
+    "$numberInt": "3114"
+  },
+  "age40Resident": {
+    "$numberInt": "3534"
+  },
+  "age50Resident": {
+    "$numberInt": "4185"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6959"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1565"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1436"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1615"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1721"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1965"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3038"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1490"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1491"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1499"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1813"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2220"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3921"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10766"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10766"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020162"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290725"
+  },
+  "adstrdName": "월곡2동",
+  "totalResident": {
+    "$numberInt": "18900"
+  },
+  "maleResident": {
+    "$numberInt": "8965"
+  },
+  "femaleResident": {
+    "$numberInt": "9935"
+  },
+  "age10Resident": {
+    "$numberInt": "2131"
+  },
+  "age20Resident": {
+    "$numberInt": "3483"
+  },
+  "age30Resident": {
+    "$numberInt": "2565"
+  },
+  "age40Resident": {
+    "$numberInt": "2489"
+  },
+  "age50Resident": {
+    "$numberInt": "2953"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5279"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1111"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1367"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1337"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1250"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1491"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2409"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1020"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2116"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1228"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1239"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1462"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2870"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9649"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9649"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020163"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215760"
+  },
+  "adstrdName": "중곡3동",
+  "totalResident": {
+    "$numberInt": "15681"
+  },
+  "maleResident": {
+    "$numberInt": "7737"
+  },
+  "femaleResident": {
+    "$numberInt": "7944"
+  },
+  "age10Resident": {
+    "$numberInt": "1436"
+  },
+  "age20Resident": {
+    "$numberInt": "2305"
+  },
+  "age30Resident": {
+    "$numberInt": "2714"
+  },
+  "age40Resident": {
+    "$numberInt": "2050"
+  },
+  "age50Resident": {
+    "$numberInt": "2676"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4500"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "741"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1106"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1417"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1078"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1317"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2078"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "695"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1199"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1297"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "972"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1359"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2422"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8495"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8495"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020164"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710510"
+  },
+  "adstrdName": "풍납1동",
+  "totalResident": {
+    "$numberInt": "11750"
+  },
+  "maleResident": {
+    "$numberInt": "5769"
+  },
+  "femaleResident": {
+    "$numberInt": "5981"
+  },
+  "age10Resident": {
+    "$numberInt": "1225"
+  },
+  "age20Resident": {
+    "$numberInt": "1267"
+  },
+  "age30Resident": {
+    "$numberInt": "1627"
+  },
+  "age40Resident": {
+    "$numberInt": "1584"
+  },
+  "age50Resident": {
+    "$numberInt": "1988"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4059"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "678"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "652"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "855"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "801"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "967"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1816"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "547"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "615"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "772"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "783"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1021"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2243"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5572"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5572"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020165"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440610"
+  },
+  "adstrdName": "염리동",
+  "totalResident": {
+    "$numberInt": "16719"
+  },
+  "maleResident": {
+    "$numberInt": "7963"
+  },
+  "femaleResident": {
+    "$numberInt": "8756"
+  },
+  "age10Resident": {
+    "$numberInt": "2922"
+  },
+  "age20Resident": {
+    "$numberInt": "2412"
+  },
+  "age30Resident": {
+    "$numberInt": "2746"
+  },
+  "age40Resident": {
+    "$numberInt": "3054"
+  },
+  "age50Resident": {
+    "$numberInt": "2505"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3080"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1465"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1091"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1321"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1477"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1269"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1340"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1457"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1321"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1425"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1577"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1236"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1740"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7762"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7762"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020166"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200670"
+  },
+  "adstrdName": "성수2가1동",
+  "totalResident": {
+    "$numberInt": "14544"
+  },
+  "maleResident": {
+    "$numberInt": "7539"
+  },
+  "femaleResident": {
+    "$numberInt": "7005"
+  },
+  "age10Resident": {
+    "$numberInt": "1301"
+  },
+  "age20Resident": {
+    "$numberInt": "1837"
+  },
+  "age30Resident": {
+    "$numberInt": "2399"
+  },
+  "age40Resident": {
+    "$numberInt": "1889"
+  },
+  "age50Resident": {
+    "$numberInt": "2557"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4561"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "659"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "949"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1295"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1018"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1355"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2263"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "642"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "888"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1104"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "871"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1202"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2298"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7587"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7587"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020167"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500560"
+  },
+  "adstrdName": "화곡3동",
+  "totalResident": {
+    "$numberInt": "21093"
+  },
+  "maleResident": {
+    "$numberInt": "10044"
+  },
+  "femaleResident": {
+    "$numberInt": "11049"
+  },
+  "age10Resident": {
+    "$numberInt": "2563"
+  },
+  "age20Resident": {
+    "$numberInt": "2979"
+  },
+  "age30Resident": {
+    "$numberInt": "3092"
+  },
+  "age40Resident": {
+    "$numberInt": "3065"
+  },
+  "age50Resident": {
+    "$numberInt": "3165"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6229"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1353"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1342"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1515"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1497"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1486"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2851"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1210"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1637"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1577"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1568"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1679"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3378"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9685"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9685"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020168"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680510"
+  },
+  "adstrdName": "신사동",
+  "totalResident": {
+    "$numberInt": "15436"
+  },
+  "maleResident": {
+    "$numberInt": "7204"
+  },
+  "femaleResident": {
+    "$numberInt": "8232"
+  },
+  "age10Resident": {
+    "$numberInt": "2348"
+  },
+  "age20Resident": {
+    "$numberInt": "1899"
+  },
+  "age30Resident": {
+    "$numberInt": "2022"
+  },
+  "age40Resident": {
+    "$numberInt": "2506"
+  },
+  "age50Resident": {
+    "$numberInt": "2568"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4093"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1199"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "878"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "914"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1115"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1255"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1843"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1149"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1021"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1108"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1391"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1313"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2250"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6717"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6717"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020169"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170590"
+  },
+  "adstrdName": "용문동",
+  "totalResident": {
+    "$numberInt": "11380"
+  },
+  "maleResident": {
+    "$numberInt": "5423"
+  },
+  "femaleResident": {
+    "$numberInt": "5957"
+  },
+  "age10Resident": {
+    "$numberInt": "1264"
+  },
+  "age20Resident": {
+    "$numberInt": "1613"
+  },
+  "age30Resident": {
+    "$numberInt": "1939"
+  },
+  "age40Resident": {
+    "$numberInt": "1576"
+  },
+  "age50Resident": {
+    "$numberInt": "1846"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3142"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "631"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "762"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "981"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "793"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "893"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1363"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "633"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "851"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "958"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "783"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "953"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1779"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5307"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5307"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002016a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590670"
+  },
+  "adstrdName": "신대방1동",
+  "totalResident": {
+    "$numberInt": "23282"
+  },
+  "maleResident": {
+    "$numberInt": "11152"
+  },
+  "femaleResident": {
+    "$numberInt": "12130"
+  },
+  "age10Resident": {
+    "$numberInt": "3513"
+  },
+  "age20Resident": {
+    "$numberInt": "3325"
+  },
+  "age30Resident": {
+    "$numberInt": "3095"
+  },
+  "age40Resident": {
+    "$numberInt": "3612"
+  },
+  "age50Resident": {
+    "$numberInt": "3868"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5869"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1727"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1572"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1552"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1714"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1915"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2672"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1786"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1753"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1543"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1898"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1953"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3197"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10423"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10423"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002016b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740570"
+  },
+  "adstrdName": "암사1동",
+  "totalResident": {
+    "$numberInt": "33825"
+  },
+  "maleResident": {
+    "$numberInt": "16775"
+  },
+  "femaleResident": {
+    "$numberInt": "17050"
+  },
+  "age10Resident": {
+    "$numberInt": "4027"
+  },
+  "age20Resident": {
+    "$numberInt": "4289"
+  },
+  "age30Resident": {
+    "$numberInt": "4876"
+  },
+  "age40Resident": {
+    "$numberInt": "5160"
+  },
+  "age50Resident": {
+    "$numberInt": "5816"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9657"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2023"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2232"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2550"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2678"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2857"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4435"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2004"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2057"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2326"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2482"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2959"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5222"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16155"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16155"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002016c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200560"
+  },
+  "adstrdName": "행당1동",
+  "totalResident": {
+    "$numberInt": "13629"
+  },
+  "maleResident": {
+    "$numberInt": "6526"
+  },
+  "femaleResident": {
+    "$numberInt": "7103"
+  },
+  "age10Resident": {
+    "$numberInt": "1824"
+  },
+  "age20Resident": {
+    "$numberInt": "2164"
+  },
+  "age30Resident": {
+    "$numberInt": "2212"
+  },
+  "age40Resident": {
+    "$numberInt": "2056"
+  },
+  "age50Resident": {
+    "$numberInt": "2161"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3212"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "898"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "995"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1102"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1011"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1023"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1497"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "926"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1169"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1110"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1045"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1138"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1715"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6397"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6397"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002016d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200620"
+  },
+  "adstrdName": "금호4가동",
+  "totalResident": {
+    "$numberInt": "14142"
+  },
+  "maleResident": {
+    "$numberInt": "6694"
+  },
+  "femaleResident": {
+    "$numberInt": "7448"
+  },
+  "age10Resident": {
+    "$numberInt": "2116"
+  },
+  "age20Resident": {
+    "$numberInt": "1311"
+  },
+  "age30Resident": {
+    "$numberInt": "2308"
+  },
+  "age40Resident": {
+    "$numberInt": "2621"
+  },
+  "age50Resident": {
+    "$numberInt": "2123"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3663"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1098"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "661"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1063"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1289"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1045"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1538"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1018"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "650"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1245"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1332"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1078"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2125"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6398"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6398"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002016e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680655"
+  },
+  "adstrdName": "도곡1동",
+  "totalResident": {
+    "$numberInt": "20005"
+  },
+  "maleResident": {
+    "$numberInt": "9502"
+  },
+  "femaleResident": {
+    "$numberInt": "10503"
+  },
+  "age10Resident": {
+    "$numberInt": "3672"
+  },
+  "age20Resident": {
+    "$numberInt": "2411"
+  },
+  "age30Resident": {
+    "$numberInt": "2742"
+  },
+  "age40Resident": {
+    "$numberInt": "3513"
+  },
+  "age50Resident": {
+    "$numberInt": "3246"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4421"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1738"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1167"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1256"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1631"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1620"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2090"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1934"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1244"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1486"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1882"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1626"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2331"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8034"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8034"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002016f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110670"
+  },
+  "adstrdName": "창신1동",
+  "totalResident": {
+    "$numberInt": "4523"
+  },
+  "maleResident": {
+    "$numberInt": "2397"
+  },
+  "femaleResident": {
+    "$numberInt": "2126"
+  },
+  "age10Resident": {
+    "$numberInt": "280"
+  },
+  "age20Resident": {
+    "$numberInt": "522"
+  },
+  "age30Resident": {
+    "$numberInt": "621"
+  },
+  "age40Resident": {
+    "$numberInt": "501"
+  },
+  "age50Resident": {
+    "$numberInt": "840"
+  },
+  "age60PlusResident": {
+    "$numberInt": "1759"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "149"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "271"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "355"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "273"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "441"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "908"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "131"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "251"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "266"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "228"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "399"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "851"
+  },
+  "totalHouseholds": {
+    "$numberInt": "2628"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "2628"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020170"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710670"
+  },
+  "adstrdName": "잠실2동",
+  "totalResident": {
+    "$numberInt": "34909"
+  },
+  "maleResident": {
+    "$numberInt": "16705"
+  },
+  "femaleResident": {
+    "$numberInt": "18204"
+  },
+  "age10Resident": {
+    "$numberInt": "9113"
+  },
+  "age20Resident": {
+    "$numberInt": "3341"
+  },
+  "age30Resident": {
+    "$numberInt": "3220"
+  },
+  "age40Resident": {
+    "$numberInt": "8042"
+  },
+  "age50Resident": {
+    "$numberInt": "5660"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5533"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "4653"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1533"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1304"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3688"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3000"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2527"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "4460"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1808"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1916"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "4354"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2660"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3006"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11542"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11542"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020171"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740660"
+  },
+  "adstrdName": "성내3동",
+  "totalResident": {
+    "$numberInt": "22433"
+  },
+  "maleResident": {
+    "$numberInt": "10963"
+  },
+  "femaleResident": {
+    "$numberInt": "11470"
+  },
+  "age10Resident": {
+    "$numberInt": "2471"
+  },
+  "age20Resident": {
+    "$numberInt": "3268"
+  },
+  "age30Resident": {
+    "$numberInt": "3311"
+  },
+  "age40Resident": {
+    "$numberInt": "3357"
+  },
+  "age50Resident": {
+    "$numberInt": "3800"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6226"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1392"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1667"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1703"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1625"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1817"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2759"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1079"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1601"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1608"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1732"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1983"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3467"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10645"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10645"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020172"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650620"
+  },
+  "adstrdName": "방배3동",
+  "totalResident": {
+    "$numberInt": "15757"
+  },
+  "maleResident": {
+    "$numberInt": "7500"
+  },
+  "femaleResident": {
+    "$numberInt": "8257"
+  },
+  "age10Resident": {
+    "$numberInt": "2670"
+  },
+  "age20Resident": {
+    "$numberInt": "1800"
+  },
+  "age30Resident": {
+    "$numberInt": "1874"
+  },
+  "age40Resident": {
+    "$numberInt": "2500"
+  },
+  "age50Resident": {
+    "$numberInt": "2602"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4311"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1335"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "894"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "849"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1141"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1243"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2038"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1335"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "906"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1025"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1359"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1359"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2273"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5855"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5855"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020173"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11545680"
+  },
+  "adstrdName": "시흥2동",
+  "totalResident": {
+    "$numberInt": "20564"
+  },
+  "maleResident": {
+    "$numberInt": "9831"
+  },
+  "femaleResident": {
+    "$numberInt": "10733"
+  },
+  "age10Resident": {
+    "$numberInt": "3156"
+  },
+  "age20Resident": {
+    "$numberInt": "2108"
+  },
+  "age30Resident": {
+    "$numberInt": "2230"
+  },
+  "age40Resident": {
+    "$numberInt": "2999"
+  },
+  "age50Resident": {
+    "$numberInt": "3655"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6416"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1549"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1075"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1111"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1432"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1737"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2927"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1607"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1033"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1119"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1567"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1918"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3489"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8238"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8238"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020174"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350695"
+  },
+  "adstrdName": "상계6?7동",
+  "totalResident": {
+    "$numberInt": "31400"
+  },
+  "maleResident": {
+    "$numberInt": "14467"
+  },
+  "femaleResident": {
+    "$numberInt": "16933"
+  },
+  "age10Resident": {
+    "$numberInt": "4531"
+  },
+  "age20Resident": {
+    "$numberInt": "4011"
+  },
+  "age30Resident": {
+    "$numberInt": "4657"
+  },
+  "age40Resident": {
+    "$numberInt": "4833"
+  },
+  "age50Resident": {
+    "$numberInt": "5511"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7857"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2328"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1908"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2248"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2223"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2475"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3285"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2203"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2103"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2409"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2610"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3036"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4572"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13887"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13887"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020175"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680740"
+  },
+  "adstrdName": "일원2동",
+  "totalResident": {
+    "$numberInt": "16833"
+  },
+  "maleResident": {
+    "$numberInt": "8153"
+  },
+  "femaleResident": {
+    "$numberInt": "8680"
+  },
+  "age10Resident": {
+    "$numberInt": "2624"
+  },
+  "age20Resident": {
+    "$numberInt": "1629"
+  },
+  "age30Resident": {
+    "$numberInt": "2392"
+  },
+  "age40Resident": {
+    "$numberInt": "2921"
+  },
+  "age50Resident": {
+    "$numberInt": "2447"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4820"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1590"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "869"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1165"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1377"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1194"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1958"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1034"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "760"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1227"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1544"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1253"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2862"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7377"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7377"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020176"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680660"
+  },
+  "adstrdName": "개포1동",
+  "totalResident": {
+    "$numberInt": "6765"
+  },
+  "maleResident": {
+    "$numberInt": "3265"
+  },
+  "femaleResident": {
+    "$numberInt": "3500"
+  },
+  "age10Resident": {
+    "$numberInt": "1151"
+  },
+  "age20Resident": {
+    "$numberInt": "649"
+  },
+  "age30Resident": {
+    "$numberInt": "638"
+  },
+  "age40Resident": {
+    "$numberInt": "1068"
+  },
+  "age50Resident": {
+    "$numberInt": "1017"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2242"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "559"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "319"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "289"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "499"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "510"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1089"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "592"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "330"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "349"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "569"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "507"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1153"
+  },
+  "totalHouseholds": {
+    "$numberInt": "2547"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "2547"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020177"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305615"
+  },
+  "adstrdName": "수유1동",
+  "totalResident": {
+    "$numberInt": "19842"
+  },
+  "maleResident": {
+    "$numberInt": "9710"
+  },
+  "femaleResident": {
+    "$numberInt": "10132"
+  },
+  "age10Resident": {
+    "$numberInt": "1918"
+  },
+  "age20Resident": {
+    "$numberInt": "2797"
+  },
+  "age30Resident": {
+    "$numberInt": "2644"
+  },
+  "age40Resident": {
+    "$numberInt": "2591"
+  },
+  "age50Resident": {
+    "$numberInt": "3325"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6567"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "967"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1300"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1448"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1389"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1649"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2957"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "951"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1497"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1196"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1202"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1676"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3610"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10418"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10418"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020178"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410565"
+  },
+  "adstrdName": "충현동",
+  "totalResident": {
+    "$numberInt": "19682"
+  },
+  "maleResident": {
+    "$numberInt": "9454"
+  },
+  "femaleResident": {
+    "$numberInt": "10228"
+  },
+  "age10Resident": {
+    "$numberInt": "2309"
+  },
+  "age20Resident": {
+    "$numberInt": "3004"
+  },
+  "age30Resident": {
+    "$numberInt": "3356"
+  },
+  "age40Resident": {
+    "$numberInt": "2797"
+  },
+  "age50Resident": {
+    "$numberInt": "3158"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5058"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1143"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1369"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1646"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1413"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1560"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2323"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1166"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1635"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1710"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1384"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1598"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2735"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10070"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10070"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020179"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590620"
+  },
+  "adstrdName": "사당1동",
+  "totalResident": {
+    "$numberInt": "22415"
+  },
+  "maleResident": {
+    "$numberInt": "10798"
+  },
+  "femaleResident": {
+    "$numberInt": "11617"
+  },
+  "age10Resident": {
+    "$numberInt": "1388"
+  },
+  "age20Resident": {
+    "$numberInt": "5074"
+  },
+  "age30Resident": {
+    "$numberInt": "4744"
+  },
+  "age40Resident": {
+    "$numberInt": "2832"
+  },
+  "age50Resident": {
+    "$numberInt": "2807"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5570"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "740"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2283"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2484"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1498"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1312"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2481"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "648"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2791"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2260"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1334"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1495"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3089"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13773"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13773"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002017a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680650"
+  },
+  "adstrdName": "역삼2동",
+  "totalResident": {
+    "$numberInt": "36348"
+  },
+  "maleResident": {
+    "$numberInt": "16944"
+  },
+  "femaleResident": {
+    "$numberInt": "19404"
+  },
+  "age10Resident": {
+    "$numberInt": "7981"
+  },
+  "age20Resident": {
+    "$numberInt": "4370"
+  },
+  "age30Resident": {
+    "$numberInt": "4509"
+  },
+  "age40Resident": {
+    "$numberInt": "8338"
+  },
+  "age50Resident": {
+    "$numberInt": "5910"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5240"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3733"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1871"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2047"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3684"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3231"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2378"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "4248"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2499"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2462"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "4654"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2679"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2862"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15611"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15611"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002017b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740700"
+  },
+  "adstrdName": "둔촌2동",
+  "totalResident": {
+    "$numberInt": "24228"
+  },
+  "maleResident": {
+    "$numberInt": "11861"
+  },
+  "femaleResident": {
+    "$numberInt": "12367"
+  },
+  "age10Resident": {
+    "$numberInt": "3360"
+  },
+  "age20Resident": {
+    "$numberInt": "3110"
+  },
+  "age30Resident": {
+    "$numberInt": "3688"
+  },
+  "age40Resident": {
+    "$numberInt": "3495"
+  },
+  "age50Resident": {
+    "$numberInt": "3911"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6664"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1764"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1532"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1874"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1752"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1868"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3071"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1596"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1578"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1814"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1743"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2043"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3593"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10426"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10426"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002017c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350665"
+  },
+  "adstrdName": "상계3?4동",
+  "totalResident": {
+    "$numberInt": "27489"
+  },
+  "maleResident": {
+    "$numberInt": "13675"
+  },
+  "femaleResident": {
+    "$numberInt": "13814"
+  },
+  "age10Resident": {
+    "$numberInt": "3585"
+  },
+  "age20Resident": {
+    "$numberInt": "3100"
+  },
+  "age30Resident": {
+    "$numberInt": "2909"
+  },
+  "age40Resident": {
+    "$numberInt": "3876"
+  },
+  "age50Resident": {
+    "$numberInt": "4953"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9066"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1887"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1634"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1567"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1965"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2469"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4153"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1698"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1466"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1342"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1911"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2484"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4913"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12412"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12412"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002017d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305545"
+  },
+  "adstrdName": "송중동",
+  "totalResident": {
+    "$numberInt": "28576"
+  },
+  "maleResident": {
+    "$numberInt": "13737"
+  },
+  "femaleResident": {
+    "$numberInt": "14839"
+  },
+  "age10Resident": {
+    "$numberInt": "3126"
+  },
+  "age20Resident": {
+    "$numberInt": "3770"
+  },
+  "age30Resident": {
+    "$numberInt": "3735"
+  },
+  "age40Resident": {
+    "$numberInt": "4089"
+  },
+  "age50Resident": {
+    "$numberInt": "4933"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8923"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1540"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1822"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1902"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2089"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2365"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4019"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1586"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1948"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1833"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2000"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2568"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4904"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13802"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13802"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002017e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260680"
+  },
+  "adstrdName": "신내1동",
+  "totalResident": {
+    "$numberInt": "37757"
+  },
+  "maleResident": {
+    "$numberInt": "18186"
+  },
+  "femaleResident": {
+    "$numberInt": "19571"
+  },
+  "age10Resident": {
+    "$numberInt": "6092"
+  },
+  "age20Resident": {
+    "$numberInt": "4249"
+  },
+  "age30Resident": {
+    "$numberInt": "4537"
+  },
+  "age40Resident": {
+    "$numberInt": "5613"
+  },
+  "age50Resident": {
+    "$numberInt": "6197"
+  },
+  "age60PlusResident": {
+    "$numberInt": "11069"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3123"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2172"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2232"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2746"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2917"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4996"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2969"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2077"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2305"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2867"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3280"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "6073"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14887"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14887"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002017f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590530"
+  },
+  "adstrdName": "상도1동",
+  "totalResident": {
+    "$numberInt": "44464"
+  },
+  "maleResident": {
+    "$numberInt": "21556"
+  },
+  "femaleResident": {
+    "$numberInt": "22908"
+  },
+  "age10Resident": {
+    "$numberInt": "5282"
+  },
+  "age20Resident": {
+    "$numberInt": "10237"
+  },
+  "age30Resident": {
+    "$numberInt": "5927"
+  },
+  "age40Resident": {
+    "$numberInt": "5858"
+  },
+  "age50Resident": {
+    "$numberInt": "6511"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10649"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2652"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "5321"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2989"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2814"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3092"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4688"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2630"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "4916"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2938"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3044"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3419"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5961"
+  },
+  "totalHouseholds": {
+    "$numberInt": "22704"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "22704"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020180"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590520"
+  },
+  "adstrdName": "노량진2동",
+  "totalResident": {
+    "$numberInt": "10181"
+  },
+  "maleResident": {
+    "$numberInt": "5312"
+  },
+  "femaleResident": {
+    "$numberInt": "4869"
+  },
+  "age10Resident": {
+    "$numberInt": "556"
+  },
+  "age20Resident": {
+    "$numberInt": "1990"
+  },
+  "age30Resident": {
+    "$numberInt": "1838"
+  },
+  "age40Resident": {
+    "$numberInt": "1163"
+  },
+  "age50Resident": {
+    "$numberInt": "1466"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3168"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "274"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1025"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1095"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "672"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "786"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1460"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "282"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "965"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "743"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "491"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "680"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1708"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6725"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6725"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020181"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620630"
+  },
+  "adstrdName": "남현동",
+  "totalResident": {
+    "$numberInt": "17668"
+  },
+  "maleResident": {
+    "$numberInt": "8549"
+  },
+  "femaleResident": {
+    "$numberInt": "9119"
+  },
+  "age10Resident": {
+    "$numberInt": "1419"
+  },
+  "age20Resident": {
+    "$numberInt": "3785"
+  },
+  "age30Resident": {
+    "$numberInt": "3659"
+  },
+  "age40Resident": {
+    "$numberInt": "2115"
+  },
+  "age50Resident": {
+    "$numberInt": "2398"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4292"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "719"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1752"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1971"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1069"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1113"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1925"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "700"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2033"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1688"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1046"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1285"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2367"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9874"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9874"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020182"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710620"
+  },
+  "adstrdName": "가락본동",
+  "totalResident": {
+    "$numberInt": "25171"
+  },
+  "maleResident": {
+    "$numberInt": "12461"
+  },
+  "femaleResident": {
+    "$numberInt": "12710"
+  },
+  "age10Resident": {
+    "$numberInt": "2965"
+  },
+  "age20Resident": {
+    "$numberInt": "3485"
+  },
+  "age30Resident": {
+    "$numberInt": "4476"
+  },
+  "age40Resident": {
+    "$numberInt": "3545"
+  },
+  "age50Resident": {
+    "$numberInt": "4192"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6508"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1512"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1737"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2282"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1800"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1984"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3146"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1453"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1748"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2194"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1745"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2208"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3362"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11567"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11567"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020183"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230560"
+  },
+  "adstrdName": "전농1동",
+  "totalResident": {
+    "$numberInt": "32107"
+  },
+  "maleResident": {
+    "$numberInt": "15979"
+  },
+  "femaleResident": {
+    "$numberInt": "16128"
+  },
+  "age10Resident": {
+    "$numberInt": "4034"
+  },
+  "age20Resident": {
+    "$numberInt": "4839"
+  },
+  "age30Resident": {
+    "$numberInt": "4460"
+  },
+  "age40Resident": {
+    "$numberInt": "4730"
+  },
+  "age50Resident": {
+    "$numberInt": "5311"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8733"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2037"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2340"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2296"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2466"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2739"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4101"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1997"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2499"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2164"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2264"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2572"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4632"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16020"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16020"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020184"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650531"
+  },
+  "adstrdName": "서초4동",
+  "totalResident": {
+    "$numberInt": "30281"
+  },
+  "maleResident": {
+    "$numberInt": "14804"
+  },
+  "femaleResident": {
+    "$numberInt": "15477"
+  },
+  "age10Resident": {
+    "$numberInt": "6584"
+  },
+  "age20Resident": {
+    "$numberInt": "3448"
+  },
+  "age30Resident": {
+    "$numberInt": "3064"
+  },
+  "age40Resident": {
+    "$numberInt": "5826"
+  },
+  "age50Resident": {
+    "$numberInt": "5248"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6111"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3449"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1710"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1331"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2710"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2676"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2928"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3135"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1738"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1733"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3116"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2572"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3183"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10706"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10706"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020185"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680670"
+  },
+  "adstrdName": "개포2동",
+  "totalResident": {
+    "$numberInt": "41708"
+  },
+  "maleResident": {
+    "$numberInt": "20173"
+  },
+  "femaleResident": {
+    "$numberInt": "21535"
+  },
+  "age10Resident": {
+    "$numberInt": "8783"
+  },
+  "age20Resident": {
+    "$numberInt": "4683"
+  },
+  "age30Resident": {
+    "$numberInt": "6170"
+  },
+  "age40Resident": {
+    "$numberInt": "7516"
+  },
+  "age50Resident": {
+    "$numberInt": "6679"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7877"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "4470"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2293"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2841"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3485"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3295"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3789"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "4313"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2390"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3329"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "4031"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3384"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4088"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14821"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14821"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020186"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290630"
+  },
+  "adstrdName": "정릉2동",
+  "totalResident": {
+    "$numberInt": "22510"
+  },
+  "maleResident": {
+    "$numberInt": "10838"
+  },
+  "femaleResident": {
+    "$numberInt": "11672"
+  },
+  "age10Resident": {
+    "$numberInt": "2837"
+  },
+  "age20Resident": {
+    "$numberInt": "3023"
+  },
+  "age30Resident": {
+    "$numberInt": "2989"
+  },
+  "age40Resident": {
+    "$numberInt": "3163"
+  },
+  "age50Resident": {
+    "$numberInt": "3828"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6670"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1473"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1502"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1484"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1602"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1836"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2941"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1364"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1521"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1505"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1561"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1992"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3729"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9902"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9902"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020187"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230740"
+  },
+  "adstrdName": "이문1동",
+  "totalResident": {
+    "$numberInt": "17724"
+  },
+  "maleResident": {
+    "$numberInt": "8739"
+  },
+  "femaleResident": {
+    "$numberInt": "8985"
+  },
+  "age10Resident": {
+    "$numberInt": "1705"
+  },
+  "age20Resident": {
+    "$numberInt": "5173"
+  },
+  "age30Resident": {
+    "$numberInt": "2026"
+  },
+  "age40Resident": {
+    "$numberInt": "1959"
+  },
+  "age50Resident": {
+    "$numberInt": "2472"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4389"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "861"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2456"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1156"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1006"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1278"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1982"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "844"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2717"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "870"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "953"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1194"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2407"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10654"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10654"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020188"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620585"
+  },
+  "adstrdName": "낙성대동",
+  "totalResident": {
+    "$numberInt": "17211"
+  },
+  "maleResident": {
+    "$numberInt": "8618"
+  },
+  "femaleResident": {
+    "$numberInt": "8593"
+  },
+  "age10Resident": {
+    "$numberInt": "1292"
+  },
+  "age20Resident": {
+    "$numberInt": "5749"
+  },
+  "age30Resident": {
+    "$numberInt": "3833"
+  },
+  "age40Resident": {
+    "$numberInt": "1853"
+  },
+  "age50Resident": {
+    "$numberInt": "1665"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2819"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "641"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2714"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2115"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "999"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "881"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1268"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "651"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3035"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1718"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "854"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "784"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1551"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11903"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11903"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020189"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710531"
+  },
+  "adstrdName": "거여1동",
+  "totalResident": {
+    "$numberInt": "12011"
+  },
+  "maleResident": {
+    "$numberInt": "6013"
+  },
+  "femaleResident": {
+    "$numberInt": "5998"
+  },
+  "age10Resident": {
+    "$numberInt": "1339"
+  },
+  "age20Resident": {
+    "$numberInt": "1588"
+  },
+  "age30Resident": {
+    "$numberInt": "1640"
+  },
+  "age40Resident": {
+    "$numberInt": "1595"
+  },
+  "age50Resident": {
+    "$numberInt": "2163"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3686"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "704"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "811"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "863"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "812"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1096"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1727"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "635"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "777"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "777"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "783"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1067"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1959"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5558"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5558"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002018a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710650"
+  },
+  "adstrdName": "잠실본동",
+  "totalResident": {
+    "$numberInt": "27731"
+  },
+  "maleResident": {
+    "$numberInt": "13208"
+  },
+  "femaleResident": {
+    "$numberInt": "14523"
+  },
+  "age10Resident": {
+    "$numberInt": "2445"
+  },
+  "age20Resident": {
+    "$numberInt": "4952"
+  },
+  "age30Resident": {
+    "$numberInt": "6226"
+  },
+  "age40Resident": {
+    "$numberInt": "4164"
+  },
+  "age50Resident": {
+    "$numberInt": "3970"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5974"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1245"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2180"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3103"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2048"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1922"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2710"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1200"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2772"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3123"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2116"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2048"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3264"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16073"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16073"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002018b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680580"
+  },
+  "adstrdName": "삼성1동",
+  "totalResident": {
+    "$numberInt": "12134"
+  },
+  "maleResident": {
+    "$numberInt": "5938"
+  },
+  "femaleResident": {
+    "$numberInt": "6196"
+  },
+  "age10Resident": {
+    "$numberInt": "1774"
+  },
+  "age20Resident": {
+    "$numberInt": "1553"
+  },
+  "age30Resident": {
+    "$numberInt": "1712"
+  },
+  "age40Resident": {
+    "$numberInt": "1917"
+  },
+  "age50Resident": {
+    "$numberInt": "2050"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3128"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "949"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "838"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "826"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "882"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "984"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1459"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "825"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "715"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "886"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1035"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1066"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1669"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5230"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5230"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002018c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680610"
+  },
+  "adstrdName": "대치2동",
+  "totalResident": {
+    "$numberInt": "38212"
+  },
+  "maleResident": {
+    "$numberInt": "19396"
+  },
+  "femaleResident": {
+    "$numberInt": "18816"
+  },
+  "age10Resident": {
+    "$numberInt": "8922"
+  },
+  "age20Resident": {
+    "$numberInt": "4008"
+  },
+  "age30Resident": {
+    "$numberInt": "3306"
+  },
+  "age40Resident": {
+    "$numberInt": "7349"
+  },
+  "age50Resident": {
+    "$numberInt": "6670"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7957"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "5235"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2160"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1541"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3164"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3430"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3866"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3687"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1848"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1765"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "4185"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3240"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4091"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13293"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13293"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002018d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530550"
+  },
+  "adstrdName": "구로4동",
+  "totalResident": {
+    "$numberInt": "18646"
+  },
+  "maleResident": {
+    "$numberInt": "8980"
+  },
+  "femaleResident": {
+    "$numberInt": "9666"
+  },
+  "age10Resident": {
+    "$numberInt": "1480"
+  },
+  "age20Resident": {
+    "$numberInt": "2506"
+  },
+  "age30Resident": {
+    "$numberInt": "2746"
+  },
+  "age40Resident": {
+    "$numberInt": "2349"
+  },
+  "age50Resident": {
+    "$numberInt": "3122"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6443"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "763"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1189"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1412"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1235"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1543"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2838"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "717"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1317"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1334"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1114"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1579"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3605"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10345"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10345"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002018e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350624"
+  },
+  "adstrdName": "중계4동",
+  "totalResident": {
+    "$numberInt": "19114"
+  },
+  "maleResident": {
+    "$numberInt": "9151"
+  },
+  "femaleResident": {
+    "$numberInt": "9963"
+  },
+  "age10Resident": {
+    "$numberInt": "2800"
+  },
+  "age20Resident": {
+    "$numberInt": "2288"
+  },
+  "age30Resident": {
+    "$numberInt": "1812"
+  },
+  "age40Resident": {
+    "$numberInt": "2878"
+  },
+  "age50Resident": {
+    "$numberInt": "3591"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5745"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1472"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1192"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "916"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1357"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1778"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2436"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1328"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1096"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "896"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1521"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1813"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3309"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8209"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8209"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002018f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350640"
+  },
+  "adstrdName": "상계2동",
+  "totalResident": {
+    "$numberInt": "19105"
+  },
+  "maleResident": {
+    "$numberInt": "9426"
+  },
+  "femaleResident": {
+    "$numberInt": "9679"
+  },
+  "age10Resident": {
+    "$numberInt": "2261"
+  },
+  "age20Resident": {
+    "$numberInt": "2910"
+  },
+  "age30Resident": {
+    "$numberInt": "2133"
+  },
+  "age40Resident": {
+    "$numberInt": "2514"
+  },
+  "age50Resident": {
+    "$numberInt": "3737"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5550"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1105"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1496"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1122"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1253"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1834"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2616"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1156"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1414"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1011"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1261"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1903"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2934"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8558"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8558"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020190"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215860"
+  },
+  "adstrdName": "구의2동",
+  "totalResident": {
+    "$numberInt": "25468"
+  },
+  "maleResident": {
+    "$numberInt": "12150"
+  },
+  "femaleResident": {
+    "$numberInt": "13318"
+  },
+  "age10Resident": {
+    "$numberInt": "3443"
+  },
+  "age20Resident": {
+    "$numberInt": "3280"
+  },
+  "age30Resident": {
+    "$numberInt": "3587"
+  },
+  "age40Resident": {
+    "$numberInt": "3950"
+  },
+  "age50Resident": {
+    "$numberInt": "4410"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6798"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1753"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1577"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1763"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1923"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2085"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3049"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1690"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1703"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1824"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2027"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2325"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3749"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11380"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11380"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020191"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470611"
+  },
+  "adstrdName": "신월7동",
+  "totalResident": {
+    "$numberInt": "18588"
+  },
+  "maleResident": {
+    "$numberInt": "9029"
+  },
+  "femaleResident": {
+    "$numberInt": "9559"
+  },
+  "age10Resident": {
+    "$numberInt": "1852"
+  },
+  "age20Resident": {
+    "$numberInt": "2130"
+  },
+  "age30Resident": {
+    "$numberInt": "2501"
+  },
+  "age40Resident": {
+    "$numberInt": "2418"
+  },
+  "age50Resident": {
+    "$numberInt": "3218"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6469"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "961"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1092"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1338"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1272"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1561"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2805"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "891"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1038"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1163"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1146"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1657"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3664"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8930"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8930"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020192"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500520"
+  },
+  "adstrdName": "등촌1동",
+  "totalResident": {
+    "$numberInt": "24933"
+  },
+  "maleResident": {
+    "$numberInt": "11521"
+  },
+  "femaleResident": {
+    "$numberInt": "13412"
+  },
+  "age10Resident": {
+    "$numberInt": "2379"
+  },
+  "age20Resident": {
+    "$numberInt": "4735"
+  },
+  "age30Resident": {
+    "$numberInt": "6640"
+  },
+  "age40Resident": {
+    "$numberInt": "3456"
+  },
+  "age50Resident": {
+    "$numberInt": "3071"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4652"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1282"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1883"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3074"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1772"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1444"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2066"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1097"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2852"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3566"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1684"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1627"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2586"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14262"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14262"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020193"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110540"
+  },
+  "adstrdName": "삼청동",
+  "totalResident": {
+    "$numberInt": "2247"
+  },
+  "maleResident": {
+    "$numberInt": "1075"
+  },
+  "femaleResident": {
+    "$numberInt": "1172"
+  },
+  "age10Resident": {
+    "$numberInt": "248"
+  },
+  "age20Resident": {
+    "$numberInt": "238"
+  },
+  "age30Resident": {
+    "$numberInt": "283"
+  },
+  "age40Resident": {
+    "$numberInt": "316"
+  },
+  "age50Resident": {
+    "$numberInt": "351"
+  },
+  "age60PlusResident": {
+    "$numberInt": "811"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "133"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "121"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "131"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "153"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "171"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "366"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "115"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "117"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "152"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "163"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "180"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "445"
+  },
+  "totalHouseholds": {
+    "$numberInt": "1120"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "1120"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020194"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380560"
+  },
+  "adstrdName": "구산동",
+  "totalResident": {
+    "$numberInt": "31429"
+  },
+  "maleResident": {
+    "$numberInt": "15279"
+  },
+  "femaleResident": {
+    "$numberInt": "16150"
+  },
+  "age10Resident": {
+    "$numberInt": "3813"
+  },
+  "age20Resident": {
+    "$numberInt": "4234"
+  },
+  "age30Resident": {
+    "$numberInt": "3793"
+  },
+  "age40Resident": {
+    "$numberInt": "4530"
+  },
+  "age50Resident": {
+    "$numberInt": "5645"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9414"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1895"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1984"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1896"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2313"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2740"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4451"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1918"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2250"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1897"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2217"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2905"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4963"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13477"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13477"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020195"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140650"
+  },
+  "adstrdName": "신당5동",
+  "totalResident": {
+    "$numberInt": "10151"
+  },
+  "maleResident": {
+    "$numberInt": "4914"
+  },
+  "femaleResident": {
+    "$numberInt": "5237"
+  },
+  "age10Resident": {
+    "$numberInt": "966"
+  },
+  "age20Resident": {
+    "$numberInt": "1494"
+  },
+  "age30Resident": {
+    "$numberInt": "1791"
+  },
+  "age40Resident": {
+    "$numberInt": "1397"
+  },
+  "age50Resident": {
+    "$numberInt": "1757"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2746"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "462"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "664"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "898"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "727"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "910"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1253"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "504"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "830"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "893"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "670"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "847"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1493"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5385"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5385"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020196"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215830"
+  },
+  "adstrdName": "자양2동",
+  "totalResident": {
+    "$numberInt": "23591"
+  },
+  "maleResident": {
+    "$numberInt": "11450"
+  },
+  "femaleResident": {
+    "$numberInt": "12141"
+  },
+  "age10Resident": {
+    "$numberInt": "2882"
+  },
+  "age20Resident": {
+    "$numberInt": "3208"
+  },
+  "age30Resident": {
+    "$numberInt": "3682"
+  },
+  "age40Resident": {
+    "$numberInt": "3540"
+  },
+  "age50Resident": {
+    "$numberInt": "3903"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6376"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1468"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1588"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1859"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1734"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1849"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2952"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1414"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1620"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1823"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1806"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2054"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3424"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10890"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10890"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020197"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740550"
+  },
+  "adstrdName": "고덕1동",
+  "totalResident": {
+    "$numberInt": "23932"
+  },
+  "maleResident": {
+    "$numberInt": "12182"
+  },
+  "femaleResident": {
+    "$numberInt": "11750"
+  },
+  "age10Resident": {
+    "$numberInt": "6073"
+  },
+  "age20Resident": {
+    "$numberInt": "1949"
+  },
+  "age30Resident": {
+    "$numberInt": "2426"
+  },
+  "age40Resident": {
+    "$numberInt": "5297"
+  },
+  "age50Resident": {
+    "$numberInt": "3431"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4756"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3392"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1057"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1132"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2557"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1813"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2231"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2681"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "892"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1294"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2740"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1618"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2525"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8155"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8155"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020198"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470620"
+  },
+  "adstrdName": "신정1동",
+  "totalResident": {
+    "$numberInt": "19716"
+  },
+  "maleResident": {
+    "$numberInt": "9582"
+  },
+  "femaleResident": {
+    "$numberInt": "10134"
+  },
+  "age10Resident": {
+    "$numberInt": "4413"
+  },
+  "age20Resident": {
+    "$numberInt": "2061"
+  },
+  "age30Resident": {
+    "$numberInt": "1765"
+  },
+  "age40Resident": {
+    "$numberInt": "3859"
+  },
+  "age50Resident": {
+    "$numberInt": "3370"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4248"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2279"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1053"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "814"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1774"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1702"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1960"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2134"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1008"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "951"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2085"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1668"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2288"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6958"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6958"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020199"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290650"
+  },
+  "adstrdName": "정릉4동",
+  "totalResident": {
+    "$numberInt": "24009"
+  },
+  "maleResident": {
+    "$numberInt": "11457"
+  },
+  "femaleResident": {
+    "$numberInt": "12552"
+  },
+  "age10Resident": {
+    "$numberInt": "3160"
+  },
+  "age20Resident": {
+    "$numberInt": "3050"
+  },
+  "age30Resident": {
+    "$numberInt": "2863"
+  },
+  "age40Resident": {
+    "$numberInt": "3583"
+  },
+  "age50Resident": {
+    "$numberInt": "4243"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7110"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1633"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1504"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1431"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1747"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2059"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3083"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1527"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1546"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1432"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1836"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2184"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4027"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10737"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10737"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002019a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140520"
+  },
+  "adstrdName": "소공동",
+  "totalResident": {
+    "$numberInt": "2178"
+  },
+  "maleResident": {
+    "$numberInt": "1027"
+  },
+  "femaleResident": {
+    "$numberInt": "1151"
+  },
+  "age10Resident": {
+    "$numberInt": "289"
+  },
+  "age20Resident": {
+    "$numberInt": "218"
+  },
+  "age30Resident": {
+    "$numberInt": "442"
+  },
+  "age40Resident": {
+    "$numberInt": "514"
+  },
+  "age50Resident": {
+    "$numberInt": "320"
+  },
+  "age60PlusResident": {
+    "$numberInt": "395"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "130"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "79"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "205"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "250"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "170"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "193"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "159"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "139"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "237"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "264"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "150"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "202"
+  },
+  "totalHouseholds": {
+    "$numberInt": "1231"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "1231"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002019b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440565"
+  },
+  "adstrdName": "공덕동",
+  "totalResident": {
+    "$numberInt": "36426"
+  },
+  "maleResident": {
+    "$numberInt": "16993"
+  },
+  "femaleResident": {
+    "$numberInt": "19433"
+  },
+  "age10Resident": {
+    "$numberInt": "4002"
+  },
+  "age20Resident": {
+    "$numberInt": "5749"
+  },
+  "age30Resident": {
+    "$numberInt": "6487"
+  },
+  "age40Resident": {
+    "$numberInt": "4980"
+  },
+  "age50Resident": {
+    "$numberInt": "6129"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9079"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2074"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2349"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3100"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2501"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2951"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4018"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1928"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3400"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3387"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2479"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3178"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5061"
+  },
+  "totalHouseholds": {
+    "$numberInt": "18559"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "18559"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002019c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560720"
+  },
+  "adstrdName": "대림3동",
+  "totalResident": {
+    "$numberInt": "21488"
+  },
+  "maleResident": {
+    "$numberInt": "10727"
+  },
+  "femaleResident": {
+    "$numberInt": "10761"
+  },
+  "age10Resident": {
+    "$numberInt": "2133"
+  },
+  "age20Resident": {
+    "$numberInt": "2698"
+  },
+  "age30Resident": {
+    "$numberInt": "3121"
+  },
+  "age40Resident": {
+    "$numberInt": "2678"
+  },
+  "age50Resident": {
+    "$numberInt": "3864"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6994"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1068"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1431"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1681"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1388"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1889"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3270"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1065"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1267"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1440"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1290"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1975"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3724"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10303"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10303"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002019d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260540"
+  },
+  "adstrdName": "면목4동",
+  "totalResident": {
+    "$numberInt": "18121"
+  },
+  "maleResident": {
+    "$numberInt": "9021"
+  },
+  "femaleResident": {
+    "$numberInt": "9100"
+  },
+  "age10Resident": {
+    "$numberInt": "1938"
+  },
+  "age20Resident": {
+    "$numberInt": "2212"
+  },
+  "age30Resident": {
+    "$numberInt": "2460"
+  },
+  "age40Resident": {
+    "$numberInt": "2636"
+  },
+  "age50Resident": {
+    "$numberInt": "3198"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5677"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1015"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1143"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1274"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1399"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1637"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2553"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "923"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1069"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1186"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1237"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1561"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3124"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8928"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8928"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002019e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410690"
+  },
+  "adstrdName": "남가좌1동",
+  "totalResident": {
+    "$numberInt": "16699"
+  },
+  "maleResident": {
+    "$numberInt": "7994"
+  },
+  "femaleResident": {
+    "$numberInt": "8705"
+  },
+  "age10Resident": {
+    "$numberInt": "3810"
+  },
+  "age20Resident": {
+    "$numberInt": "1559"
+  },
+  "age30Resident": {
+    "$numberInt": "2235"
+  },
+  "age40Resident": {
+    "$numberInt": "3430"
+  },
+  "age50Resident": {
+    "$numberInt": "2364"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3301"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1914"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "728"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "970"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1742"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1171"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1469"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1896"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "831"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1265"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1688"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1193"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1832"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6161"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6161"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002019f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110630"
+  },
+  "adstrdName": "종로5?6가동",
+  "totalResident": {
+    "$numberInt": "5376"
+  },
+  "maleResident": {
+    "$numberInt": "2824"
+  },
+  "femaleResident": {
+    "$numberInt": "2552"
+  },
+  "age10Resident": {
+    "$numberInt": "359"
+  },
+  "age20Resident": {
+    "$numberInt": "1180"
+  },
+  "age30Resident": {
+    "$numberInt": "886"
+  },
+  "age40Resident": {
+    "$numberInt": "571"
+  },
+  "age50Resident": {
+    "$numberInt": "855"
+  },
+  "age60PlusResident": {
+    "$numberInt": "1525"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "161"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "546"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "493"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "322"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "494"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "808"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "198"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "634"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "393"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "249"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "361"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "717"
+  },
+  "totalHouseholds": {
+    "$numberInt": "3576"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "3576"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201a0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200520"
+  },
+  "adstrdName": "왕십리2동",
+  "totalResident": {
+    "$numberInt": "15974"
+  },
+  "maleResident": {
+    "$numberInt": "7663"
+  },
+  "femaleResident": {
+    "$numberInt": "8311"
+  },
+  "age10Resident": {
+    "$numberInt": "2097"
+  },
+  "age20Resident": {
+    "$numberInt": "2174"
+  },
+  "age30Resident": {
+    "$numberInt": "2781"
+  },
+  "age40Resident": {
+    "$numberInt": "2315"
+  },
+  "age50Resident": {
+    "$numberInt": "2596"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4011"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1065"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1012"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1354"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1158"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1260"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1814"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1032"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1162"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1427"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1157"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1336"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2197"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7303"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7303"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201a1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140580"
+  },
+  "adstrdName": "장충동",
+  "totalResident": {
+    "$numberInt": "4549"
+  },
+  "maleResident": {
+    "$numberInt": "2371"
+  },
+  "femaleResident": {
+    "$numberInt": "2178"
+  },
+  "age10Resident": {
+    "$numberInt": "389"
+  },
+  "age20Resident": {
+    "$numberInt": "1271"
+  },
+  "age30Resident": {
+    "$numberInt": "663"
+  },
+  "age40Resident": {
+    "$numberInt": "499"
+  },
+  "age50Resident": {
+    "$numberInt": "578"
+  },
+  "age60PlusResident": {
+    "$numberInt": "1149"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "201"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "707"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "374"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "262"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "303"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "524"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "188"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "564"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "289"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "237"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "275"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "625"
+  },
+  "totalHouseholds": {
+    "$numberInt": "2833"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "2833"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201a2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710631"
+  },
+  "adstrdName": "가락1동",
+  "totalResident": {
+    "$numberInt": "27469"
+  },
+  "maleResident": {
+    "$numberInt": "13286"
+  },
+  "femaleResident": {
+    "$numberInt": "14183"
+  },
+  "age10Resident": {
+    "$numberInt": "5719"
+  },
+  "age20Resident": {
+    "$numberInt": "2571"
+  },
+  "age30Resident": {
+    "$numberInt": "4733"
+  },
+  "age40Resident": {
+    "$numberInt": "4925"
+  },
+  "age50Resident": {
+    "$numberInt": "3631"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5890"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2940"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1266"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2134"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2441"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1684"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2821"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2779"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1305"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2599"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2484"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1947"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3069"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9799"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9799"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201a3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200580"
+  },
+  "adstrdName": "응봉동",
+  "totalResident": {
+    "$numberInt": "14940"
+  },
+  "maleResident": {
+    "$numberInt": "7088"
+  },
+  "femaleResident": {
+    "$numberInt": "7852"
+  },
+  "age10Resident": {
+    "$numberInt": "2460"
+  },
+  "age20Resident": {
+    "$numberInt": "1666"
+  },
+  "age30Resident": {
+    "$numberInt": "2031"
+  },
+  "age40Resident": {
+    "$numberInt": "2607"
+  },
+  "age50Resident": {
+    "$numberInt": "2508"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3668"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1275"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "779"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "973"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1230"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1227"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1604"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1185"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "887"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1058"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1377"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1281"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2064"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5949"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5949"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201a4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470670"
+  },
+  "adstrdName": "신정6동",
+  "totalResident": {
+    "$numberInt": "23959"
+  },
+  "maleResident": {
+    "$numberInt": "11598"
+  },
+  "femaleResident": {
+    "$numberInt": "12361"
+  },
+  "age10Resident": {
+    "$numberInt": "5302"
+  },
+  "age20Resident": {
+    "$numberInt": "2631"
+  },
+  "age30Resident": {
+    "$numberInt": "2449"
+  },
+  "age40Resident": {
+    "$numberInt": "4474"
+  },
+  "age50Resident": {
+    "$numberInt": "4245"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4858"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2727"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1336"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1137"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1998"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2058"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2342"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2575"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1295"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1312"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2476"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2187"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2516"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8185"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8185"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201a5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650520"
+  },
+  "adstrdName": "서초2동",
+  "totalResident": {
+    "$numberInt": "24636"
+  },
+  "maleResident": {
+    "$numberInt": "11631"
+  },
+  "femaleResident": {
+    "$numberInt": "13005"
+  },
+  "age10Resident": {
+    "$numberInt": "4292"
+  },
+  "age20Resident": {
+    "$numberInt": "3376"
+  },
+  "age30Resident": {
+    "$numberInt": "4799"
+  },
+  "age40Resident": {
+    "$numberInt": "4571"
+  },
+  "age50Resident": {
+    "$numberInt": "3206"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4392"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2197"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1428"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2184"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2145"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1610"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2067"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2095"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1948"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2615"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2426"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1596"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2325"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11340"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11340"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201a6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560690"
+  },
+  "adstrdName": "신길7동",
+  "totalResident": {
+    "$numberInt": "19779"
+  },
+  "maleResident": {
+    "$numberInt": "9835"
+  },
+  "femaleResident": {
+    "$numberInt": "9944"
+  },
+  "age10Resident": {
+    "$numberInt": "3668"
+  },
+  "age20Resident": {
+    "$numberInt": "2416"
+  },
+  "age30Resident": {
+    "$numberInt": "3282"
+  },
+  "age40Resident": {
+    "$numberInt": "3383"
+  },
+  "age50Resident": {
+    "$numberInt": "2949"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4081"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1923"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1236"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1634"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1715"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1402"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1925"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1745"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1180"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1648"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1668"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1547"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2156"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7880"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7880"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201a7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710710"
+  },
+  "adstrdName": "잠실6동",
+  "totalResident": {
+    "$numberInt": "16514"
+  },
+  "maleResident": {
+    "$numberInt": "7825"
+  },
+  "femaleResident": {
+    "$numberInt": "8689"
+  },
+  "age10Resident": {
+    "$numberInt": "2948"
+  },
+  "age20Resident": {
+    "$numberInt": "1768"
+  },
+  "age30Resident": {
+    "$numberInt": "1981"
+  },
+  "age40Resident": {
+    "$numberInt": "2777"
+  },
+  "age50Resident": {
+    "$numberInt": "2606"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4434"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1498"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "849"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "896"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1280"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1210"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2092"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1450"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "919"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1085"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1497"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1396"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2342"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5834"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5834"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201a8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305660"
+  },
+  "adstrdName": "인수동",
+  "totalResident": {
+    "$numberInt": "29069"
+  },
+  "maleResident": {
+    "$numberInt": "14019"
+  },
+  "femaleResident": {
+    "$numberInt": "15050"
+  },
+  "age10Resident": {
+    "$numberInt": "3074"
+  },
+  "age20Resident": {
+    "$numberInt": "3468"
+  },
+  "age30Resident": {
+    "$numberInt": "3443"
+  },
+  "age40Resident": {
+    "$numberInt": "3874"
+  },
+  "age50Resident": {
+    "$numberInt": "4989"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10221"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1558"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1693"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1814"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2007"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2413"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4534"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1516"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1775"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1629"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1867"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2576"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5687"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14159"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14159"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201a9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290580"
+  },
+  "adstrdName": "돈암1동",
+  "totalResident": {
+    "$numberInt": "14260"
+  },
+  "maleResident": {
+    "$numberInt": "6652"
+  },
+  "femaleResident": {
+    "$numberInt": "7608"
+  },
+  "age10Resident": {
+    "$numberInt": "1740"
+  },
+  "age20Resident": {
+    "$numberInt": "1842"
+  },
+  "age30Resident": {
+    "$numberInt": "1866"
+  },
+  "age40Resident": {
+    "$numberInt": "1829"
+  },
+  "age50Resident": {
+    "$numberInt": "2593"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4390"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "863"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "839"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "920"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "884"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1225"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1921"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "877"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1003"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "946"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "945"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1368"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2469"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6052"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6052"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201aa"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650560"
+  },
+  "adstrdName": "반포1동",
+  "totalResident": {
+    "$numberInt": "33740"
+  },
+  "maleResident": {
+    "$numberInt": "16468"
+  },
+  "femaleResident": {
+    "$numberInt": "17272"
+  },
+  "age10Resident": {
+    "$numberInt": "6962"
+  },
+  "age20Resident": {
+    "$numberInt": "3952"
+  },
+  "age30Resident": {
+    "$numberInt": "5028"
+  },
+  "age40Resident": {
+    "$numberInt": "7041"
+  },
+  "age50Resident": {
+    "$numberInt": "4810"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5947"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3526"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1859"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2391"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3421"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2586"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2685"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3436"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2093"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2637"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3620"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2224"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3262"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14637"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14637"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ab"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620525"
+  },
+  "adstrdName": "보라매동",
+  "totalResident": {
+    "$numberInt": "23092"
+  },
+  "maleResident": {
+    "$numberInt": "11443"
+  },
+  "femaleResident": {
+    "$numberInt": "11649"
+  },
+  "age10Resident": {
+    "$numberInt": "2135"
+  },
+  "age20Resident": {
+    "$numberInt": "4351"
+  },
+  "age30Resident": {
+    "$numberInt": "4053"
+  },
+  "age40Resident": {
+    "$numberInt": "2939"
+  },
+  "age50Resident": {
+    "$numberInt": "3266"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6348"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1108"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2104"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2267"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1535"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1611"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2818"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1027"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2247"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1786"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1404"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1655"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3530"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12670"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12670"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ac"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620575"
+  },
+  "adstrdName": "행운동",
+  "totalResident": {
+    "$numberInt": "28758"
+  },
+  "maleResident": {
+    "$numberInt": "13926"
+  },
+  "femaleResident": {
+    "$numberInt": "14832"
+  },
+  "age10Resident": {
+    "$numberInt": "2079"
+  },
+  "age20Resident": {
+    "$numberInt": "7607"
+  },
+  "age30Resident": {
+    "$numberInt": "5942"
+  },
+  "age40Resident": {
+    "$numberInt": "3444"
+  },
+  "age50Resident": {
+    "$numberInt": "3392"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6294"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1032"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3393"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3181"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1793"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1694"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2833"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1047"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "4214"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2761"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1651"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1698"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3461"
+  },
+  "totalHouseholds": {
+    "$numberInt": "18159"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "18159"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ad"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620625"
+  },
+  "adstrdName": "인헌동",
+  "totalResident": {
+    "$numberInt": "25385"
+  },
+  "maleResident": {
+    "$numberInt": "12283"
+  },
+  "femaleResident": {
+    "$numberInt": "13102"
+  },
+  "age10Resident": {
+    "$numberInt": "2133"
+  },
+  "age20Resident": {
+    "$numberInt": "5807"
+  },
+  "age30Resident": {
+    "$numberInt": "4960"
+  },
+  "age40Resident": {
+    "$numberInt": "3141"
+  },
+  "age50Resident": {
+    "$numberInt": "3495"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5849"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1113"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2693"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2564"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1628"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1664"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2621"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1020"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3114"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2396"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1513"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1831"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3228"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14772"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14772"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ae"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620615"
+  },
+  "adstrdName": "중앙동",
+  "totalResident": {
+    "$numberInt": "15126"
+  },
+  "maleResident": {
+    "$numberInt": "7305"
+  },
+  "femaleResident": {
+    "$numberInt": "7821"
+  },
+  "age10Resident": {
+    "$numberInt": "856"
+  },
+  "age20Resident": {
+    "$numberInt": "4374"
+  },
+  "age30Resident": {
+    "$numberInt": "3231"
+  },
+  "age40Resident": {
+    "$numberInt": "1662"
+  },
+  "age50Resident": {
+    "$numberInt": "1659"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3344"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "428"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1901"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1723"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "885"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "843"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1525"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "428"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2473"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1508"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "777"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "816"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1819"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10136"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10136"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201af"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290640"
+  },
+  "adstrdName": "정릉3동",
+  "totalResident": {
+    "$numberInt": "14934"
+  },
+  "maleResident": {
+    "$numberInt": "7431"
+  },
+  "femaleResident": {
+    "$numberInt": "7503"
+  },
+  "age10Resident": {
+    "$numberInt": "1346"
+  },
+  "age20Resident": {
+    "$numberInt": "3370"
+  },
+  "age30Resident": {
+    "$numberInt": "1799"
+  },
+  "age40Resident": {
+    "$numberInt": "1548"
+  },
+  "age50Resident": {
+    "$numberInt": "2287"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4584"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "727"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1866"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1016"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "789"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1107"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1926"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "619"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1504"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "783"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "759"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1180"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2658"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8201"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8201"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201b0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350611"
+  },
+  "adstrdName": "하계1동",
+  "totalResident": {
+    "$numberInt": "26128"
+  },
+  "maleResident": {
+    "$numberInt": "12492"
+  },
+  "femaleResident": {
+    "$numberInt": "13636"
+  },
+  "age10Resident": {
+    "$numberInt": "3719"
+  },
+  "age20Resident": {
+    "$numberInt": "4532"
+  },
+  "age30Resident": {
+    "$numberInt": "2631"
+  },
+  "age40Resident": {
+    "$numberInt": "3348"
+  },
+  "age50Resident": {
+    "$numberInt": "4814"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7084"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2010"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2414"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1350"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1483"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2327"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2908"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1709"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2118"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1281"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1865"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2487"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4176"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12129"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12129"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201b1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380552"
+  },
+  "adstrdName": "갈현2동",
+  "totalResident": {
+    "$numberInt": "27415"
+  },
+  "maleResident": {
+    "$numberInt": "12947"
+  },
+  "femaleResident": {
+    "$numberInt": "14468"
+  },
+  "age10Resident": {
+    "$numberInt": "3291"
+  },
+  "age20Resident": {
+    "$numberInt": "3884"
+  },
+  "age30Resident": {
+    "$numberInt": "3568"
+  },
+  "age40Resident": {
+    "$numberInt": "4064"
+  },
+  "age50Resident": {
+    "$numberInt": "4876"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7732"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1668"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1830"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1798"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1990"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2289"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3372"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1623"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2054"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1770"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2074"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2587"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4360"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12523"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12523"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201b2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380600"
+  },
+  "adstrdName": "응암3동",
+  "totalResident": {
+    "$numberInt": "23429"
+  },
+  "maleResident": {
+    "$numberInt": "11287"
+  },
+  "femaleResident": {
+    "$numberInt": "12142"
+  },
+  "age10Resident": {
+    "$numberInt": "1971"
+  },
+  "age20Resident": {
+    "$numberInt": "3287"
+  },
+  "age30Resident": {
+    "$numberInt": "3255"
+  },
+  "age40Resident": {
+    "$numberInt": "3038"
+  },
+  "age50Resident": {
+    "$numberInt": "3863"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8015"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1007"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1608"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1710"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1566"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1944"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3452"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "964"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1679"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1545"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1472"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1919"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4563"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12504"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12504"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201b3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650652"
+  },
+  "adstrdName": "양재2동",
+  "totalResident": {
+    "$numberInt": "21157"
+  },
+  "maleResident": {
+    "$numberInt": "10608"
+  },
+  "femaleResident": {
+    "$numberInt": "10549"
+  },
+  "age10Resident": {
+    "$numberInt": "2407"
+  },
+  "age20Resident": {
+    "$numberInt": "3148"
+  },
+  "age30Resident": {
+    "$numberInt": "4068"
+  },
+  "age40Resident": {
+    "$numberInt": "3407"
+  },
+  "age50Resident": {
+    "$numberInt": "3370"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4757"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1287"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1596"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2135"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1731"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1659"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2200"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1120"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1552"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1933"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1676"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1711"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2557"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10943"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10943"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201b4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710562"
+  },
+  "adstrdName": "방이2동",
+  "totalResident": {
+    "$numberInt": "26094"
+  },
+  "maleResident": {
+    "$numberInt": "11878"
+  },
+  "femaleResident": {
+    "$numberInt": "14216"
+  },
+  "age10Resident": {
+    "$numberInt": "2020"
+  },
+  "age20Resident": {
+    "$numberInt": "5130"
+  },
+  "age30Resident": {
+    "$numberInt": "6448"
+  },
+  "age40Resident": {
+    "$numberInt": "3632"
+  },
+  "age50Resident": {
+    "$numberInt": "3345"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5519"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1095"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1992"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2941"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1815"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1528"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2507"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "925"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3138"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3507"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1817"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1817"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3012"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15656"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15656"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201b5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620695"
+  },
+  "adstrdName": "신림동",
+  "totalResident": {
+    "$numberInt": "22622"
+  },
+  "maleResident": {
+    "$numberInt": "12090"
+  },
+  "femaleResident": {
+    "$numberInt": "10532"
+  },
+  "age10Resident": {
+    "$numberInt": "681"
+  },
+  "age20Resident": {
+    "$numberInt": "8720"
+  },
+  "age30Resident": {
+    "$numberInt": "6189"
+  },
+  "age40Resident": {
+    "$numberInt": "2449"
+  },
+  "age50Resident": {
+    "$numberInt": "1806"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2777"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "339"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "4196"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3697"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1470"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1065"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1323"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "342"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "4524"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2492"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "979"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "741"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1454"
+  },
+  "totalHouseholds": {
+    "$numberInt": "18724"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "18724"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201b6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620565"
+  },
+  "adstrdName": "성현동",
+  "totalResident": {
+    "$numberInt": "28222"
+  },
+  "maleResident": {
+    "$numberInt": "13577"
+  },
+  "femaleResident": {
+    "$numberInt": "14645"
+  },
+  "age10Resident": {
+    "$numberInt": "4164"
+  },
+  "age20Resident": {
+    "$numberInt": "3618"
+  },
+  "age30Resident": {
+    "$numberInt": "3398"
+  },
+  "age40Resident": {
+    "$numberInt": "4450"
+  },
+  "age50Resident": {
+    "$numberInt": "4782"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7810"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2139"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1817"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1711"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2188"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2379"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3343"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2025"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1801"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1687"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2262"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2403"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4467"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12187"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12187"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201b7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410685"
+  },
+  "adstrdName": "홍은2동",
+  "totalResident": {
+    "$numberInt": "28505"
+  },
+  "maleResident": {
+    "$numberInt": "13661"
+  },
+  "femaleResident": {
+    "$numberInt": "14844"
+  },
+  "age10Resident": {
+    "$numberInt": "3665"
+  },
+  "age20Resident": {
+    "$numberInt": "4137"
+  },
+  "age30Resident": {
+    "$numberInt": "3981"
+  },
+  "age40Resident": {
+    "$numberInt": "4039"
+  },
+  "age50Resident": {
+    "$numberInt": "4803"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7880"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1842"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2036"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2064"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1977"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2303"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3439"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1823"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2101"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1917"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2062"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2500"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4441"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13166"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13166"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201b8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740600"
+  },
+  "adstrdName": "천호1동",
+  "totalResident": {
+    "$numberInt": "25942"
+  },
+  "maleResident": {
+    "$numberInt": "12735"
+  },
+  "femaleResident": {
+    "$numberInt": "13207"
+  },
+  "age10Resident": {
+    "$numberInt": "2644"
+  },
+  "age20Resident": {
+    "$numberInt": "3280"
+  },
+  "age30Resident": {
+    "$numberInt": "3850"
+  },
+  "age40Resident": {
+    "$numberInt": "3678"
+  },
+  "age50Resident": {
+    "$numberInt": "4341"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8149"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1336"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1635"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2042"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1904"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2121"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3697"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1308"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1645"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1808"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1774"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2220"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4452"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12929"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12929"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201b9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200535"
+  },
+  "adstrdName": "왕십리도선동",
+  "totalResident": {
+    "$numberInt": "26181"
+  },
+  "maleResident": {
+    "$numberInt": "12283"
+  },
+  "femaleResident": {
+    "$numberInt": "13898"
+  },
+  "age10Resident": {
+    "$numberInt": "3603"
+  },
+  "age20Resident": {
+    "$numberInt": "4013"
+  },
+  "age30Resident": {
+    "$numberInt": "4411"
+  },
+  "age40Resident": {
+    "$numberInt": "3895"
+  },
+  "age50Resident": {
+    "$numberInt": "4311"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5948"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1870"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1726"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1993"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1935"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2031"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2728"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1733"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2287"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2418"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1960"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2280"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3220"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12111"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12111"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ba"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560515"
+  },
+  "adstrdName": "영등포본동",
+  "totalResident": {
+    "$numberInt": "20784"
+  },
+  "maleResident": {
+    "$numberInt": "10610"
+  },
+  "femaleResident": {
+    "$numberInt": "10174"
+  },
+  "age10Resident": {
+    "$numberInt": "2250"
+  },
+  "age20Resident": {
+    "$numberInt": "2779"
+  },
+  "age30Resident": {
+    "$numberInt": "3244"
+  },
+  "age40Resident": {
+    "$numberInt": "2796"
+  },
+  "age50Resident": {
+    "$numberInt": "3528"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6187"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1146"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1447"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1720"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1487"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1811"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2999"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1104"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1332"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1524"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1309"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1717"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3188"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10407"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10407"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201bb"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290575"
+  },
+  "adstrdName": "동선동",
+  "totalResident": {
+    "$numberInt": "14977"
+  },
+  "maleResident": {
+    "$numberInt": "6196"
+  },
+  "femaleResident": {
+    "$numberInt": "8781"
+  },
+  "age10Resident": {
+    "$numberInt": "1236"
+  },
+  "age20Resident": {
+    "$numberInt": "4651"
+  },
+  "age30Resident": {
+    "$numberInt": "2419"
+  },
+  "age40Resident": {
+    "$numberInt": "1762"
+  },
+  "age50Resident": {
+    "$numberInt": "1909"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3000"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "530"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1380"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1182"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "862"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "929"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1313"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "706"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3271"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1237"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "900"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "980"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1687"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9625"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9625"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201bc"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560605"
+  },
+  "adstrdName": "문래동",
+  "totalResident": {
+    "$numberInt": "32022"
+  },
+  "maleResident": {
+    "$numberInt": "15577"
+  },
+  "femaleResident": {
+    "$numberInt": "16445"
+  },
+  "age10Resident": {
+    "$numberInt": "5830"
+  },
+  "age20Resident": {
+    "$numberInt": "3503"
+  },
+  "age30Resident": {
+    "$numberInt": "5493"
+  },
+  "age40Resident": {
+    "$numberInt": "5961"
+  },
+  "age50Resident": {
+    "$numberInt": "4494"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6741"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3011"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1666"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2607"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2973"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2241"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3079"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2819"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1837"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2886"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2988"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2253"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3662"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13095"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13095"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201bd"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500620"
+  },
+  "adstrdName": "공항동",
+  "totalResident": {
+    "$numberInt": "29436"
+  },
+  "maleResident": {
+    "$numberInt": "14868"
+  },
+  "femaleResident": {
+    "$numberInt": "14568"
+  },
+  "age10Resident": {
+    "$numberInt": "5076"
+  },
+  "age20Resident": {
+    "$numberInt": "3657"
+  },
+  "age30Resident": {
+    "$numberInt": "4857"
+  },
+  "age40Resident": {
+    "$numberInt": "5192"
+  },
+  "age50Resident": {
+    "$numberInt": "4101"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6553"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2565"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1882"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2527"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2788"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2080"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3026"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2511"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1775"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2330"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2404"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2021"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3527"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13691"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13691"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201be"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500510"
+  },
+  "adstrdName": "염창동",
+  "totalResident": {
+    "$numberInt": "41250"
+  },
+  "maleResident": {
+    "$numberInt": "19807"
+  },
+  "femaleResident": {
+    "$numberInt": "21443"
+  },
+  "age10Resident": {
+    "$numberInt": "7769"
+  },
+  "age20Resident": {
+    "$numberInt": "5314"
+  },
+  "age30Resident": {
+    "$numberInt": "7231"
+  },
+  "age40Resident": {
+    "$numberInt": "7299"
+  },
+  "age50Resident": {
+    "$numberInt": "6159"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7478"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3977"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2438"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3285"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3558"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3052"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3497"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3792"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2876"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3946"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3741"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3107"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3981"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16592"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16592"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201bf"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560630"
+  },
+  "adstrdName": "신길1동",
+  "totalResident": {
+    "$numberInt": "19314"
+  },
+  "maleResident": {
+    "$numberInt": "9780"
+  },
+  "femaleResident": {
+    "$numberInt": "9534"
+  },
+  "age10Resident": {
+    "$numberInt": "1597"
+  },
+  "age20Resident": {
+    "$numberInt": "3601"
+  },
+  "age30Resident": {
+    "$numberInt": "3596"
+  },
+  "age40Resident": {
+    "$numberInt": "2448"
+  },
+  "age50Resident": {
+    "$numberInt": "2904"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5168"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "795"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1732"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2004"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1361"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1525"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2363"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "802"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1869"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1592"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1087"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1379"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2805"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11605"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11605"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201c0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380640"
+  },
+  "adstrdName": "증산동",
+  "totalResident": {
+    "$numberInt": "18240"
+  },
+  "maleResident": {
+    "$numberInt": "8840"
+  },
+  "femaleResident": {
+    "$numberInt": "9400"
+  },
+  "age10Resident": {
+    "$numberInt": "2403"
+  },
+  "age20Resident": {
+    "$numberInt": "2357"
+  },
+  "age30Resident": {
+    "$numberInt": "2626"
+  },
+  "age40Resident": {
+    "$numberInt": "2570"
+  },
+  "age50Resident": {
+    "$numberInt": "3089"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5195"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1238"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1129"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1287"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1288"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1522"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2376"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1165"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1228"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1339"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1282"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1567"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2819"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7933"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7933"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201c1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530740"
+  },
+  "adstrdName": "개봉1동",
+  "totalResident": {
+    "$numberInt": "33122"
+  },
+  "maleResident": {
+    "$numberInt": "16420"
+  },
+  "femaleResident": {
+    "$numberInt": "16702"
+  },
+  "age10Resident": {
+    "$numberInt": "4134"
+  },
+  "age20Resident": {
+    "$numberInt": "3960"
+  },
+  "age30Resident": {
+    "$numberInt": "5015"
+  },
+  "age40Resident": {
+    "$numberInt": "4572"
+  },
+  "age50Resident": {
+    "$numberInt": "5483"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9958"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2116"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2009"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2567"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2341"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2714"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4673"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2018"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1951"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2448"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2231"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2769"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5285"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14958"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14958"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201c2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11545620"
+  },
+  "adstrdName": "독산2동",
+  "totalResident": {
+    "$numberInt": "17737"
+  },
+  "maleResident": {
+    "$numberInt": "8915"
+  },
+  "femaleResident": {
+    "$numberInt": "8822"
+  },
+  "age10Resident": {
+    "$numberInt": "1694"
+  },
+  "age20Resident": {
+    "$numberInt": "2337"
+  },
+  "age30Resident": {
+    "$numberInt": "2512"
+  },
+  "age40Resident": {
+    "$numberInt": "2178"
+  },
+  "age50Resident": {
+    "$numberInt": "3358"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5658"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "895"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1171"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1380"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1144"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1658"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2667"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "799"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1166"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1132"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1034"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1700"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2991"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9282"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9282"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201c3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350630"
+  },
+  "adstrdName": "상계1동",
+  "totalResident": {
+    "$numberInt": "36834"
+  },
+  "maleResident": {
+    "$numberInt": "17688"
+  },
+  "femaleResident": {
+    "$numberInt": "19146"
+  },
+  "age10Resident": {
+    "$numberInt": "4724"
+  },
+  "age20Resident": {
+    "$numberInt": "4544"
+  },
+  "age30Resident": {
+    "$numberInt": "4401"
+  },
+  "age40Resident": {
+    "$numberInt": "5069"
+  },
+  "age50Resident": {
+    "$numberInt": "6715"
+  },
+  "age60PlusResident": {
+    "$numberInt": "11381"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2412"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2270"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2211"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2455"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3143"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "5197"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2312"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2274"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2190"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2614"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3572"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "6184"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15534"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15534"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201c4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500570"
+  },
+  "adstrdName": "화곡4동",
+  "totalResident": {
+    "$numberInt": "19720"
+  },
+  "maleResident": {
+    "$numberInt": "9668"
+  },
+  "femaleResident": {
+    "$numberInt": "10052"
+  },
+  "age10Resident": {
+    "$numberInt": "2041"
+  },
+  "age20Resident": {
+    "$numberInt": "2499"
+  },
+  "age30Resident": {
+    "$numberInt": "2933"
+  },
+  "age40Resident": {
+    "$numberInt": "3042"
+  },
+  "age50Resident": {
+    "$numberInt": "3276"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5929"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1090"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1274"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1541"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1580"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1568"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2615"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "951"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1225"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1392"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1462"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1708"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3314"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9641"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9641"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201c5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200690"
+  },
+  "adstrdName": "성수2가3동",
+  "totalResident": {
+    "$numberInt": "10021"
+  },
+  "maleResident": {
+    "$numberInt": "4999"
+  },
+  "femaleResident": {
+    "$numberInt": "5022"
+  },
+  "age10Resident": {
+    "$numberInt": "940"
+  },
+  "age20Resident": {
+    "$numberInt": "1628"
+  },
+  "age30Resident": {
+    "$numberInt": "1835"
+  },
+  "age40Resident": {
+    "$numberInt": "1322"
+  },
+  "age50Resident": {
+    "$numberInt": "1581"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2715"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "499"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "769"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "880"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "688"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "811"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1352"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "441"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "859"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "955"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "634"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "770"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1363"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5211"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5211"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201c6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170700"
+  },
+  "adstrdName": "보광동",
+  "totalResident": {
+    "$numberInt": "11134"
+  },
+  "maleResident": {
+    "$numberInt": "5572"
+  },
+  "femaleResident": {
+    "$numberInt": "5562"
+  },
+  "age10Resident": {
+    "$numberInt": "801"
+  },
+  "age20Resident": {
+    "$numberInt": "1494"
+  },
+  "age30Resident": {
+    "$numberInt": "1758"
+  },
+  "age40Resident": {
+    "$numberInt": "1493"
+  },
+  "age50Resident": {
+    "$numberInt": "2011"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3577"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "465"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "846"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1015"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "771"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "992"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1483"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "336"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "648"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "743"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "722"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1019"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2094"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6270"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6270"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201c7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170690"
+  },
+  "adstrdName": "서빙고동",
+  "totalResident": {
+    "$numberInt": "12443"
+  },
+  "maleResident": {
+    "$numberInt": "5999"
+  },
+  "femaleResident": {
+    "$numberInt": "6444"
+  },
+  "age10Resident": {
+    "$numberInt": "2037"
+  },
+  "age20Resident": {
+    "$numberInt": "1557"
+  },
+  "age30Resident": {
+    "$numberInt": "1436"
+  },
+  "age40Resident": {
+    "$numberInt": "2157"
+  },
+  "age50Resident": {
+    "$numberInt": "2147"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3109"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1026"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "794"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "705"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1045"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1016"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1413"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1011"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "763"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "731"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1112"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1131"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1696"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5097"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5097"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201c8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170625"
+  },
+  "adstrdName": "한강로동",
+  "totalResident": {
+    "$numberInt": "20977"
+  },
+  "maleResident": {
+    "$numberInt": "9895"
+  },
+  "femaleResident": {
+    "$numberInt": "11082"
+  },
+  "age10Resident": {
+    "$numberInt": "2206"
+  },
+  "age20Resident": {
+    "$numberInt": "3206"
+  },
+  "age30Resident": {
+    "$numberInt": "4813"
+  },
+  "age40Resident": {
+    "$numberInt": "2844"
+  },
+  "age50Resident": {
+    "$numberInt": "3197"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4711"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1136"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1360"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2240"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1369"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1507"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2283"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1070"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1846"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2573"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1475"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1690"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2428"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11229"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11229"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201c9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230705"
+  },
+  "adstrdName": "청량리동",
+  "totalResident": {
+    "$numberInt": "18688"
+  },
+  "maleResident": {
+    "$numberInt": "9202"
+  },
+  "femaleResident": {
+    "$numberInt": "9486"
+  },
+  "age10Resident": {
+    "$numberInt": "1546"
+  },
+  "age20Resident": {
+    "$numberInt": "2215"
+  },
+  "age30Resident": {
+    "$numberInt": "2135"
+  },
+  "age40Resident": {
+    "$numberInt": "2155"
+  },
+  "age50Resident": {
+    "$numberInt": "3063"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7574"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "790"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1110"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1148"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1138"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1553"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3463"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "756"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1105"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "987"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1017"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1510"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4111"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10043"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10043"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ca"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170580"
+  },
+  "adstrdName": "효창동",
+  "totalResident": {
+    "$numberInt": "10665"
+  },
+  "maleResident": {
+    "$numberInt": "5044"
+  },
+  "femaleResident": {
+    "$numberInt": "5621"
+  },
+  "age10Resident": {
+    "$numberInt": "1426"
+  },
+  "age20Resident": {
+    "$numberInt": "1614"
+  },
+  "age30Resident": {
+    "$numberInt": "1969"
+  },
+  "age40Resident": {
+    "$numberInt": "1591"
+  },
+  "age50Resident": {
+    "$numberInt": "1728"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2337"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "728"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "741"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "958"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "778"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "798"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1041"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "698"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "873"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1011"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "813"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "930"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1296"
+  },
+  "totalHouseholds": {
+    "$numberInt": "4718"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "4718"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201cb"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710580"
+  },
+  "adstrdName": "송파1동",
+  "totalResident": {
+    "$numberInt": "23353"
+  },
+  "maleResident": {
+    "$numberInt": "10821"
+  },
+  "femaleResident": {
+    "$numberInt": "12532"
+  },
+  "age10Resident": {
+    "$numberInt": "2098"
+  },
+  "age20Resident": {
+    "$numberInt": "4019"
+  },
+  "age30Resident": {
+    "$numberInt": "5392"
+  },
+  "age40Resident": {
+    "$numberInt": "3349"
+  },
+  "age50Resident": {
+    "$numberInt": "3167"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5328"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1026"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1767"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2648"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1564"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1387"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2429"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1072"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2252"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2744"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1785"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1780"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2899"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12486"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12486"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201cc"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470510"
+  },
+  "adstrdName": "목1동",
+  "totalResident": {
+    "$numberInt": "30276"
+  },
+  "maleResident": {
+    "$numberInt": "14544"
+  },
+  "femaleResident": {
+    "$numberInt": "15732"
+  },
+  "age10Resident": {
+    "$numberInt": "7467"
+  },
+  "age20Resident": {
+    "$numberInt": "2982"
+  },
+  "age30Resident": {
+    "$numberInt": "2754"
+  },
+  "age40Resident": {
+    "$numberInt": "6476"
+  },
+  "age50Resident": {
+    "$numberInt": "5153"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5444"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3731"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1465"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1184"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2933"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2662"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2569"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3736"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1517"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1570"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3543"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2491"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2875"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10349"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10349"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201cd"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470680"
+  },
+  "adstrdName": "신정7동",
+  "totalResident": {
+    "$numberInt": "28275"
+  },
+  "maleResident": {
+    "$numberInt": "13546"
+  },
+  "femaleResident": {
+    "$numberInt": "14729"
+  },
+  "age10Resident": {
+    "$numberInt": "4859"
+  },
+  "age20Resident": {
+    "$numberInt": "2968"
+  },
+  "age30Resident": {
+    "$numberInt": "2931"
+  },
+  "age40Resident": {
+    "$numberInt": "4625"
+  },
+  "age50Resident": {
+    "$numberInt": "4979"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7913"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2510"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1529"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1444"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2189"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2445"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3429"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2349"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1439"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1487"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2436"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2534"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4484"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11507"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11507"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ce"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620715"
+  },
+  "adstrdName": "난향동",
+  "totalResident": {
+    "$numberInt": "14726"
+  },
+  "maleResident": {
+    "$numberInt": "7199"
+  },
+  "femaleResident": {
+    "$numberInt": "7527"
+  },
+  "age10Resident": {
+    "$numberInt": "2213"
+  },
+  "age20Resident": {
+    "$numberInt": "1623"
+  },
+  "age30Resident": {
+    "$numberInt": "1548"
+  },
+  "age40Resident": {
+    "$numberInt": "2518"
+  },
+  "age50Resident": {
+    "$numberInt": "2694"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4130"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1114"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "843"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "759"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1245"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1391"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1847"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1099"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "780"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "789"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1273"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1303"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2283"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6175"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6175"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201cf"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560560"
+  },
+  "adstrdName": "당산2동",
+  "totalResident": {
+    "$numberInt": "36667"
+  },
+  "maleResident": {
+    "$numberInt": "17117"
+  },
+  "femaleResident": {
+    "$numberInt": "19550"
+  },
+  "age10Resident": {
+    "$numberInt": "4697"
+  },
+  "age20Resident": {
+    "$numberInt": "6732"
+  },
+  "age30Resident": {
+    "$numberInt": "8189"
+  },
+  "age40Resident": {
+    "$numberInt": "5239"
+  },
+  "age50Resident": {
+    "$numberInt": "4671"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7139"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2397"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2651"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3855"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2603"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2248"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3363"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2300"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "4081"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "4334"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2636"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2423"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3776"
+  },
+  "totalHouseholds": {
+    "$numberInt": "18864"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "18864"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201d0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140540"
+  },
+  "adstrdName": "회현동",
+  "totalResident": {
+    "$numberInt": "4380"
+  },
+  "maleResident": {
+    "$numberInt": "2304"
+  },
+  "femaleResident": {
+    "$numberInt": "2076"
+  },
+  "age10Resident": {
+    "$numberInt": "365"
+  },
+  "age20Resident": {
+    "$numberInt": "418"
+  },
+  "age30Resident": {
+    "$numberInt": "528"
+  },
+  "age40Resident": {
+    "$numberInt": "531"
+  },
+  "age50Resident": {
+    "$numberInt": "793"
+  },
+  "age60PlusResident": {
+    "$numberInt": "1745"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "186"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "209"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "260"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "285"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "427"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "937"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "179"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "209"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "268"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "246"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "366"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "808"
+  },
+  "totalHouseholds": {
+    "$numberInt": "2491"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "2491"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201d1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500640"
+  },
+  "adstrdName": "방화2동",
+  "totalResident": {
+    "$numberInt": "22596"
+  },
+  "maleResident": {
+    "$numberInt": "11171"
+  },
+  "femaleResident": {
+    "$numberInt": "11425"
+  },
+  "age10Resident": {
+    "$numberInt": "2247"
+  },
+  "age20Resident": {
+    "$numberInt": "3015"
+  },
+  "age30Resident": {
+    "$numberInt": "3725"
+  },
+  "age40Resident": {
+    "$numberInt": "3014"
+  },
+  "age50Resident": {
+    "$numberInt": "3425"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7170"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1196"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1443"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1977"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1576"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1789"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3190"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1051"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1572"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1748"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1438"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1636"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3980"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12052"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12052"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201d2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440600"
+  },
+  "adstrdName": "대흥동",
+  "totalResident": {
+    "$numberInt": "14719"
+  },
+  "maleResident": {
+    "$numberInt": "7124"
+  },
+  "femaleResident": {
+    "$numberInt": "7595"
+  },
+  "age10Resident": {
+    "$numberInt": "1471"
+  },
+  "age20Resident": {
+    "$numberInt": "3656"
+  },
+  "age30Resident": {
+    "$numberInt": "2555"
+  },
+  "age40Resident": {
+    "$numberInt": "2017"
+  },
+  "age50Resident": {
+    "$numberInt": "2108"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2912"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "764"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1618"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1311"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1011"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1077"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1343"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "707"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2038"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1244"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1006"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1031"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1569"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8823"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8823"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201d3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410620"
+  },
+  "adstrdName": "홍제1동",
+  "totalResident": {
+    "$numberInt": "24704"
+  },
+  "maleResident": {
+    "$numberInt": "11553"
+  },
+  "femaleResident": {
+    "$numberInt": "13151"
+  },
+  "age10Resident": {
+    "$numberInt": "3208"
+  },
+  "age20Resident": {
+    "$numberInt": "3100"
+  },
+  "age30Resident": {
+    "$numberInt": "3607"
+  },
+  "age40Resident": {
+    "$numberInt": "3586"
+  },
+  "age50Resident": {
+    "$numberInt": "4205"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6998"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1566"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1502"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1708"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1740"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1984"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3053"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1642"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1598"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1899"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1846"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2221"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3945"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11038"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11038"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201d4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11545610"
+  },
+  "adstrdName": "독산1동",
+  "totalResident": {
+    "$numberInt": "45720"
+  },
+  "maleResident": {
+    "$numberInt": "23242"
+  },
+  "femaleResident": {
+    "$numberInt": "22478"
+  },
+  "age10Resident": {
+    "$numberInt": "5294"
+  },
+  "age20Resident": {
+    "$numberInt": "7802"
+  },
+  "age30Resident": {
+    "$numberInt": "10015"
+  },
+  "age40Resident": {
+    "$numberInt": "6606"
+  },
+  "age50Resident": {
+    "$numberInt": "6356"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9647"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2682"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3606"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "5435"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3661"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3232"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4626"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2612"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "4196"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "4580"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2945"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3124"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5021"
+  },
+  "totalHouseholds": {
+    "$numberInt": "24569"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "24569"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201d5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110560"
+  },
+  "adstrdName": "평창동",
+  "totalResident": {
+    "$numberInt": "17366"
+  },
+  "maleResident": {
+    "$numberInt": "8092"
+  },
+  "femaleResident": {
+    "$numberInt": "9274"
+  },
+  "age10Resident": {
+    "$numberInt": "2533"
+  },
+  "age20Resident": {
+    "$numberInt": "1997"
+  },
+  "age30Resident": {
+    "$numberInt": "2057"
+  },
+  "age40Resident": {
+    "$numberInt": "2484"
+  },
+  "age50Resident": {
+    "$numberInt": "3156"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5139"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1281"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "993"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "972"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1124"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1415"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2307"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1252"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1004"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1085"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1360"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1741"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2832"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7124"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7124"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201d6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230750"
+  },
+  "adstrdName": "이문2동",
+  "totalResident": {
+    "$numberInt": "19385"
+  },
+  "maleResident": {
+    "$numberInt": "9319"
+  },
+  "femaleResident": {
+    "$numberInt": "10066"
+  },
+  "age10Resident": {
+    "$numberInt": "2578"
+  },
+  "age20Resident": {
+    "$numberInt": "2642"
+  },
+  "age30Resident": {
+    "$numberInt": "2322"
+  },
+  "age40Resident": {
+    "$numberInt": "2758"
+  },
+  "age50Resident": {
+    "$numberInt": "3345"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5740"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1331"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1188"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1157"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1404"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1648"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2591"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1247"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1454"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1165"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1354"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1697"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3149"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8656"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8656"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201d7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710540"
+  },
+  "adstrdName": "마천1동",
+  "totalResident": {
+    "$numberInt": "17982"
+  },
+  "maleResident": {
+    "$numberInt": "9215"
+  },
+  "femaleResident": {
+    "$numberInt": "8767"
+  },
+  "age10Resident": {
+    "$numberInt": "2021"
+  },
+  "age20Resident": {
+    "$numberInt": "1988"
+  },
+  "age30Resident": {
+    "$numberInt": "1982"
+  },
+  "age40Resident": {
+    "$numberInt": "2356"
+  },
+  "age50Resident": {
+    "$numberInt": "3374"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6261"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1062"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1028"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1095"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1248"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1782"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3000"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "959"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "960"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "887"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1108"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1592"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3261"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8567"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8567"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201d8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380590"
+  },
+  "adstrdName": "응암2동",
+  "totalResident": {
+    "$numberInt": "27329"
+  },
+  "maleResident": {
+    "$numberInt": "13188"
+  },
+  "femaleResident": {
+    "$numberInt": "14141"
+  },
+  "age10Resident": {
+    "$numberInt": "5321"
+  },
+  "age20Resident": {
+    "$numberInt": "2477"
+  },
+  "age30Resident": {
+    "$numberInt": "4191"
+  },
+  "age40Resident": {
+    "$numberInt": "5549"
+  },
+  "age50Resident": {
+    "$numberInt": "3913"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5878"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2764"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1222"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1924"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2764"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1945"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2569"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2557"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1255"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2267"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2785"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1968"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3309"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11014"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11014"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201d9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500535"
+  },
+  "adstrdName": "등촌3동",
+  "totalResident": {
+    "$numberInt": "29390"
+  },
+  "maleResident": {
+    "$numberInt": "13848"
+  },
+  "femaleResident": {
+    "$numberInt": "15542"
+  },
+  "age10Resident": {
+    "$numberInt": "3050"
+  },
+  "age20Resident": {
+    "$numberInt": "3235"
+  },
+  "age30Resident": {
+    "$numberInt": "4582"
+  },
+  "age40Resident": {
+    "$numberInt": "3612"
+  },
+  "age50Resident": {
+    "$numberInt": "4479"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10432"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1562"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1614"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2308"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1779"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2022"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4563"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1488"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1621"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2274"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1833"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2457"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5869"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15092"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15092"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201da"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140625"
+  },
+  "adstrdName": "다산동",
+  "totalResident": {
+    "$numberInt": "13221"
+  },
+  "maleResident": {
+    "$numberInt": "6412"
+  },
+  "femaleResident": {
+    "$numberInt": "6809"
+  },
+  "age10Resident": {
+    "$numberInt": "1114"
+  },
+  "age20Resident": {
+    "$numberInt": "2079"
+  },
+  "age30Resident": {
+    "$numberInt": "2167"
+  },
+  "age40Resident": {
+    "$numberInt": "1719"
+  },
+  "age50Resident": {
+    "$numberInt": "2138"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4004"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "600"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "986"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1118"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "888"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1047"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1773"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "514"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1093"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1049"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "831"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1091"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2231"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6767"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6767"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201db"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470640"
+  },
+  "adstrdName": "신정3동",
+  "totalResident": {
+    "$numberInt": "49523"
+  },
+  "maleResident": {
+    "$numberInt": "23946"
+  },
+  "femaleResident": {
+    "$numberInt": "25577"
+  },
+  "age10Resident": {
+    "$numberInt": "8452"
+  },
+  "age20Resident": {
+    "$numberInt": "6003"
+  },
+  "age30Resident": {
+    "$numberInt": "5992"
+  },
+  "age40Resident": {
+    "$numberInt": "7797"
+  },
+  "age50Resident": {
+    "$numberInt": "8974"
+  },
+  "age60PlusResident": {
+    "$numberInt": "12305"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "4327"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3061"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2973"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3729"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "4325"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "5531"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "4125"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2942"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3019"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "4068"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "4649"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "6774"
+  },
+  "totalHouseholds": {
+    "$numberInt": "19703"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "19703"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201dc"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200570"
+  },
+  "adstrdName": "행당2동",
+  "totalResident": {
+    "$numberInt": "22851"
+  },
+  "maleResident": {
+    "$numberInt": "10656"
+  },
+  "femaleResident": {
+    "$numberInt": "12195"
+  },
+  "age10Resident": {
+    "$numberInt": "3436"
+  },
+  "age20Resident": {
+    "$numberInt": "2579"
+  },
+  "age30Resident": {
+    "$numberInt": "3426"
+  },
+  "age40Resident": {
+    "$numberInt": "3583"
+  },
+  "age50Resident": {
+    "$numberInt": "3971"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5856"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1612"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1198"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1631"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1718"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1915"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2582"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1824"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1381"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1795"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1865"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2056"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3274"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9226"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9226"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201dd"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530520"
+  },
+  "adstrdName": "구로1동",
+  "totalResident": {
+    "$numberInt": "20519"
+  },
+  "maleResident": {
+    "$numberInt": "10005"
+  },
+  "femaleResident": {
+    "$numberInt": "10514"
+  },
+  "age10Resident": {
+    "$numberInt": "3469"
+  },
+  "age20Resident": {
+    "$numberInt": "2418"
+  },
+  "age30Resident": {
+    "$numberInt": "3563"
+  },
+  "age40Resident": {
+    "$numberInt": "3529"
+  },
+  "age50Resident": {
+    "$numberInt": "3000"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4540"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1796"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1149"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1785"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1744"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1449"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2082"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1673"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1269"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1778"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1785"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1551"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2458"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8356"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8356"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201de"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590540"
+  },
+  "adstrdName": "상도2동",
+  "totalResident": {
+    "$numberInt": "27084"
+  },
+  "maleResident": {
+    "$numberInt": "12936"
+  },
+  "femaleResident": {
+    "$numberInt": "14148"
+  },
+  "age10Resident": {
+    "$numberInt": "4095"
+  },
+  "age20Resident": {
+    "$numberInt": "3942"
+  },
+  "age30Resident": {
+    "$numberInt": "4326"
+  },
+  "age40Resident": {
+    "$numberInt": "4416"
+  },
+  "age50Resident": {
+    "$numberInt": "4034"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6271"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2124"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1819"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2060"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2193"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1933"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2807"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1971"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2123"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2266"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2223"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2101"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3464"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12299"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12299"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201df"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710720"
+  },
+  "adstrdName": "잠실7동",
+  "totalResident": {
+    "$numberInt": "9419"
+  },
+  "maleResident": {
+    "$numberInt": "4382"
+  },
+  "femaleResident": {
+    "$numberInt": "5037"
+  },
+  "age10Resident": {
+    "$numberInt": "1435"
+  },
+  "age20Resident": {
+    "$numberInt": "1103"
+  },
+  "age30Resident": {
+    "$numberInt": "943"
+  },
+  "age40Resident": {
+    "$numberInt": "1245"
+  },
+  "age50Resident": {
+    "$numberInt": "1640"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3053"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "655"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "540"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "418"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "546"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "766"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1457"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "780"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "563"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "525"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "699"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "874"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1596"
+  },
+  "totalHouseholds": {
+    "$numberInt": "3365"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "3365"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201e0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650621"
+  },
+  "adstrdName": "방배4동",
+  "totalResident": {
+    "$numberInt": "22754"
+  },
+  "maleResident": {
+    "$numberInt": "10319"
+  },
+  "femaleResident": {
+    "$numberInt": "12435"
+  },
+  "age10Resident": {
+    "$numberInt": "3880"
+  },
+  "age20Resident": {
+    "$numberInt": "2825"
+  },
+  "age30Resident": {
+    "$numberInt": "3126"
+  },
+  "age40Resident": {
+    "$numberInt": "4033"
+  },
+  "age50Resident": {
+    "$numberInt": "3755"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5135"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1781"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1248"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1407"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1758"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1803"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2322"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2099"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1577"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1719"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2275"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1952"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2813"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9556"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9556"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201e1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290590"
+  },
+  "adstrdName": "돈암2동",
+  "totalResident": {
+    "$numberInt": "23417"
+  },
+  "maleResident": {
+    "$numberInt": "11070"
+  },
+  "femaleResident": {
+    "$numberInt": "12347"
+  },
+  "age10Resident": {
+    "$numberInt": "4248"
+  },
+  "age20Resident": {
+    "$numberInt": "2683"
+  },
+  "age30Resident": {
+    "$numberInt": "2749"
+  },
+  "age40Resident": {
+    "$numberInt": "3857"
+  },
+  "age50Resident": {
+    "$numberInt": "4362"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5518"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2135"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1337"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1297"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1772"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2082"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2447"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2113"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1346"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1452"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2085"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2280"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3071"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8521"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8521"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201e2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170630"
+  },
+  "adstrdName": "이촌1동",
+  "totalResident": {
+    "$numberInt": "24933"
+  },
+  "maleResident": {
+    "$numberInt": "11719"
+  },
+  "femaleResident": {
+    "$numberInt": "13214"
+  },
+  "age10Resident": {
+    "$numberInt": "4809"
+  },
+  "age20Resident": {
+    "$numberInt": "2548"
+  },
+  "age30Resident": {
+    "$numberInt": "2939"
+  },
+  "age40Resident": {
+    "$numberInt": "4157"
+  },
+  "age50Resident": {
+    "$numberInt": "4378"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6102"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2482"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1260"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1288"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1898"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2066"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2725"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2327"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1288"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1651"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2259"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2312"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3377"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9125"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9125"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201e3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740690"
+  },
+  "adstrdName": "둔촌1동",
+  "totalResident": {
+    "$numberInt": "16"
+  },
+  "maleResident": {
+    "$numberInt": "10"
+  },
+  "femaleResident": {
+    "$numberInt": "6"
+  },
+  "age10Resident": {
+    "$numberInt": "2"
+  },
+  "age20Resident": {
+    "$numberInt": "0"
+  },
+  "age30Resident": {
+    "$numberInt": "1"
+  },
+  "age40Resident": {
+    "$numberInt": "5"
+  },
+  "age50Resident": {
+    "$numberInt": "1"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "0"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "0"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "5"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "0"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "0"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "0"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201e4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320515"
+  },
+  "adstrdName": "창5동",
+  "totalResident": {
+    "$numberInt": "23884"
+  },
+  "maleResident": {
+    "$numberInt": "11392"
+  },
+  "femaleResident": {
+    "$numberInt": "12492"
+  },
+  "age10Resident": {
+    "$numberInt": "2882"
+  },
+  "age20Resident": {
+    "$numberInt": "3199"
+  },
+  "age30Resident": {
+    "$numberInt": "3393"
+  },
+  "age40Resident": {
+    "$numberInt": "3183"
+  },
+  "age50Resident": {
+    "$numberInt": "4238"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6989"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1480"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1555"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1690"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1530"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1944"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3193"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1402"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1644"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1703"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1653"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2294"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3796"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10262"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10262"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201e5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500605"
+  },
+  "adstrdName": "가양3동",
+  "totalResident": {
+    "$numberInt": "14189"
+  },
+  "maleResident": {
+    "$numberInt": "6504"
+  },
+  "femaleResident": {
+    "$numberInt": "7685"
+  },
+  "age10Resident": {
+    "$numberInt": "1059"
+  },
+  "age20Resident": {
+    "$numberInt": "1248"
+  },
+  "age30Resident": {
+    "$numberInt": "2945"
+  },
+  "age40Resident": {
+    "$numberInt": "1794"
+  },
+  "age50Resident": {
+    "$numberInt": "1889"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5254"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "537"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "564"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1429"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "938"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "914"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2122"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "522"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "684"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1516"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "856"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "975"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3132"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7735"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7735"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201e6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650550"
+  },
+  "adstrdName": "반포본동",
+  "totalResident": {
+    "$numberInt": "117"
+  },
+  "maleResident": {
+    "$numberInt": "49"
+  },
+  "femaleResident": {
+    "$numberInt": "68"
+  },
+  "age10Resident": {
+    "$numberInt": "17"
+  },
+  "age20Resident": {
+    "$numberInt": "21"
+  },
+  "age30Resident": {
+    "$numberInt": "6"
+  },
+  "age40Resident": {
+    "$numberInt": "22"
+  },
+  "age50Resident": {
+    "$numberInt": "21"
+  },
+  "age60PlusResident": {
+    "$numberInt": "30"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "7"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "8"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "8"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "9"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "14"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "10"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "13"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "14"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "12"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "16"
+  },
+  "totalHouseholds": {
+    "$numberInt": "44"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "44"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201e7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305635"
+  },
+  "adstrdName": "수유3동",
+  "totalResident": {
+    "$numberInt": "22988"
+  },
+  "maleResident": {
+    "$numberInt": "11301"
+  },
+  "femaleResident": {
+    "$numberInt": "11687"
+  },
+  "age10Resident": {
+    "$numberInt": "1593"
+  },
+  "age20Resident": {
+    "$numberInt": "4229"
+  },
+  "age30Resident": {
+    "$numberInt": "3326"
+  },
+  "age40Resident": {
+    "$numberInt": "2913"
+  },
+  "age50Resident": {
+    "$numberInt": "3923"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7004"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "802"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1938"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1813"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1586"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1992"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3170"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "791"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2291"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1513"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1327"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1931"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3834"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13528"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13528"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201e8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230570"
+  },
+  "adstrdName": "전농2동",
+  "totalResident": {
+    "$numberInt": "17954"
+  },
+  "maleResident": {
+    "$numberInt": "8555"
+  },
+  "femaleResident": {
+    "$numberInt": "9399"
+  },
+  "age10Resident": {
+    "$numberInt": "2542"
+  },
+  "age20Resident": {
+    "$numberInt": "2005"
+  },
+  "age30Resident": {
+    "$numberInt": "2090"
+  },
+  "age40Resident": {
+    "$numberInt": "2664"
+  },
+  "age50Resident": {
+    "$numberInt": "3152"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5501"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1275"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "968"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1069"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1309"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1513"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2421"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1267"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1037"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1021"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1355"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1639"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3080"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7541"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7541"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201e9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410660"
+  },
+  "adstrdName": "홍은1동",
+  "totalResident": {
+    "$numberInt": "22158"
+  },
+  "maleResident": {
+    "$numberInt": "10677"
+  },
+  "femaleResident": {
+    "$numberInt": "11481"
+  },
+  "age10Resident": {
+    "$numberInt": "2755"
+  },
+  "age20Resident": {
+    "$numberInt": "2645"
+  },
+  "age30Resident": {
+    "$numberInt": "2973"
+  },
+  "age40Resident": {
+    "$numberInt": "3146"
+  },
+  "age50Resident": {
+    "$numberInt": "3932"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6707"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1378"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1319"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1494"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1595"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1908"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2983"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1377"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1326"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1479"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1551"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2024"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3724"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9694"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9694"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ea"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590660"
+  },
+  "adstrdName": "대방동",
+  "totalResident": {
+    "$numberInt": "35620"
+  },
+  "maleResident": {
+    "$numberInt": "16775"
+  },
+  "femaleResident": {
+    "$numberInt": "18845"
+  },
+  "age10Resident": {
+    "$numberInt": "5172"
+  },
+  "age20Resident": {
+    "$numberInt": "6087"
+  },
+  "age30Resident": {
+    "$numberInt": "4944"
+  },
+  "age40Resident": {
+    "$numberInt": "5581"
+  },
+  "age50Resident": {
+    "$numberInt": "5718"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8118"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2530"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2762"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2441"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2637"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2851"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3554"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2642"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3325"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2503"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2944"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2867"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4564"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16664"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16664"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201eb"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590630"
+  },
+  "adstrdName": "사당2동",
+  "totalResident": {
+    "$numberInt": "27151"
+  },
+  "maleResident": {
+    "$numberInt": "13012"
+  },
+  "femaleResident": {
+    "$numberInt": "14139"
+  },
+  "age10Resident": {
+    "$numberInt": "3253"
+  },
+  "age20Resident": {
+    "$numberInt": "3366"
+  },
+  "age30Resident": {
+    "$numberInt": "4288"
+  },
+  "age40Resident": {
+    "$numberInt": "3936"
+  },
+  "age50Resident": {
+    "$numberInt": "4344"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7964"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1763"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1625"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2088"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1945"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2078"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3513"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1490"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1741"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2200"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1991"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2266"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4451"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12176"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12176"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ec"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260575"
+  },
+  "adstrdName": "면목3?8동",
+  "totalResident": {
+    "$numberInt": "24375"
+  },
+  "maleResident": {
+    "$numberInt": "12017"
+  },
+  "femaleResident": {
+    "$numberInt": "12358"
+  },
+  "age10Resident": {
+    "$numberInt": "2142"
+  },
+  "age20Resident": {
+    "$numberInt": "3312"
+  },
+  "age30Resident": {
+    "$numberInt": "3569"
+  },
+  "age40Resident": {
+    "$numberInt": "3169"
+  },
+  "age50Resident": {
+    "$numberInt": "4356"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7827"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1079"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1649"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1881"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1701"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2150"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3557"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1063"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1663"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1688"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1468"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2206"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4270"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12782"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12782"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ed"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440710"
+  },
+  "adstrdName": "연남동",
+  "totalResident": {
+    "$numberInt": "14202"
+  },
+  "maleResident": {
+    "$numberInt": "6690"
+  },
+  "femaleResident": {
+    "$numberInt": "7512"
+  },
+  "age10Resident": {
+    "$numberInt": "1131"
+  },
+  "age20Resident": {
+    "$numberInt": "2880"
+  },
+  "age30Resident": {
+    "$numberInt": "2925"
+  },
+  "age40Resident": {
+    "$numberInt": "2106"
+  },
+  "age50Resident": {
+    "$numberInt": "1935"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3225"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "567"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1312"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1448"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1055"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "911"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1397"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "564"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1568"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1477"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1051"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1024"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1828"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8339"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8339"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ee"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590605"
+  },
+  "adstrdName": "흑석동",
+  "totalResident": {
+    "$numberInt": "29907"
+  },
+  "maleResident": {
+    "$numberInt": "14490"
+  },
+  "femaleResident": {
+    "$numberInt": "15417"
+  },
+  "age10Resident": {
+    "$numberInt": "4507"
+  },
+  "age20Resident": {
+    "$numberInt": "4506"
+  },
+  "age30Resident": {
+    "$numberInt": "4057"
+  },
+  "age40Resident": {
+    "$numberInt": "4648"
+  },
+  "age50Resident": {
+    "$numberInt": "4932"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7257"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2291"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2283"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1959"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2335"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2359"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3263"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2216"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2223"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2098"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2313"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2573"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3994"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12930"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12930"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ef"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620685"
+  },
+  "adstrdName": "신사동",
+  "totalResident": {
+    "$numberInt": "21969"
+  },
+  "maleResident": {
+    "$numberInt": "11050"
+  },
+  "femaleResident": {
+    "$numberInt": "10919"
+  },
+  "age10Resident": {
+    "$numberInt": "1437"
+  },
+  "age20Resident": {
+    "$numberInt": "5696"
+  },
+  "age30Resident": {
+    "$numberInt": "4113"
+  },
+  "age40Resident": {
+    "$numberInt": "2543"
+  },
+  "age50Resident": {
+    "$numberInt": "2980"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5200"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "774"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2700"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2341"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1343"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1481"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2411"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "663"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2996"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1772"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1200"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1499"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2789"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14144"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14144"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201f0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260630"
+  },
+  "adstrdName": "묵2동",
+  "totalResident": {
+    "$numberInt": "18004"
+  },
+  "maleResident": {
+    "$numberInt": "8791"
+  },
+  "femaleResident": {
+    "$numberInt": "9213"
+  },
+  "age10Resident": {
+    "$numberInt": "1811"
+  },
+  "age20Resident": {
+    "$numberInt": "2385"
+  },
+  "age30Resident": {
+    "$numberInt": "2649"
+  },
+  "age40Resident": {
+    "$numberInt": "2549"
+  },
+  "age50Resident": {
+    "$numberInt": "3090"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5520"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "933"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1160"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1356"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1307"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1520"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2515"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "878"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1225"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1293"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1242"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1570"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3005"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9142"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9142"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201f1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230650"
+  },
+  "adstrdName": "장안1동",
+  "totalResident": {
+    "$numberInt": "37191"
+  },
+  "maleResident": {
+    "$numberInt": "18358"
+  },
+  "femaleResident": {
+    "$numberInt": "18833"
+  },
+  "age10Resident": {
+    "$numberInt": "4598"
+  },
+  "age20Resident": {
+    "$numberInt": "4828"
+  },
+  "age30Resident": {
+    "$numberInt": "5838"
+  },
+  "age40Resident": {
+    "$numberInt": "6095"
+  },
+  "age50Resident": {
+    "$numberInt": "5762"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10070"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2356"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2242"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3033"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3148"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2889"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4690"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2242"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2586"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2805"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2947"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2873"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5380"
+  },
+  "totalHouseholds": {
+    "$numberInt": "18136"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "18136"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201f2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620745"
+  },
+  "adstrdName": "삼성동",
+  "totalResident": {
+    "$numberInt": "19970"
+  },
+  "maleResident": {
+    "$numberInt": "9928"
+  },
+  "femaleResident": {
+    "$numberInt": "10042"
+  },
+  "age10Resident": {
+    "$numberInt": "1726"
+  },
+  "age20Resident": {
+    "$numberInt": "2177"
+  },
+  "age30Resident": {
+    "$numberInt": "2180"
+  },
+  "age40Resident": {
+    "$numberInt": "2482"
+  },
+  "age50Resident": {
+    "$numberInt": "3630"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7775"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "935"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1117"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1241"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1325"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1836"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3474"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "791"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1060"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "939"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1157"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1794"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4301"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9681"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9681"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201f3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410585"
+  },
+  "adstrdName": "신촌동",
+  "totalResident": {
+    "$numberInt": "20135"
+  },
+  "maleResident": {
+    "$numberInt": "8693"
+  },
+  "femaleResident": {
+    "$numberInt": "11442"
+  },
+  "age10Resident": {
+    "$numberInt": "1336"
+  },
+  "age20Resident": {
+    "$numberInt": "8441"
+  },
+  "age30Resident": {
+    "$numberInt": "3650"
+  },
+  "age40Resident": {
+    "$numberInt": "1859"
+  },
+  "age50Resident": {
+    "$numberInt": "1895"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2954"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "638"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3121"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1798"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "896"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "924"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1316"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "698"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "5320"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1852"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "963"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "971"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1638"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14750"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14750"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201f4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710647"
+  },
+  "adstrdName": "위례동",
+  "totalResident": {
+    "$numberInt": "44857"
+  },
+  "maleResident": {
+    "$numberInt": "21874"
+  },
+  "femaleResident": {
+    "$numberInt": "22983"
+  },
+  "age10Resident": {
+    "$numberInt": "12586"
+  },
+  "age20Resident": {
+    "$numberInt": "4244"
+  },
+  "age30Resident": {
+    "$numberInt": "6785"
+  },
+  "age40Resident": {
+    "$numberInt": "9367"
+  },
+  "age50Resident": {
+    "$numberInt": "5881"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5994"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "6484"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2092"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3079"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "4600"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2926"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2693"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "6102"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2152"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3706"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "4767"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2955"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3301"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14702"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14702"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201f5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260570"
+  },
+  "adstrdName": "면목7동",
+  "totalResident": {
+    "$numberInt": "21190"
+  },
+  "maleResident": {
+    "$numberInt": "10543"
+  },
+  "femaleResident": {
+    "$numberInt": "10647"
+  },
+  "age10Resident": {
+    "$numberInt": "2094"
+  },
+  "age20Resident": {
+    "$numberInt": "2678"
+  },
+  "age30Resident": {
+    "$numberInt": "3284"
+  },
+  "age40Resident": {
+    "$numberInt": "2861"
+  },
+  "age50Resident": {
+    "$numberInt": "3592"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6681"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1118"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1293"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1667"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1548"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1812"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3105"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "976"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1385"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1617"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1313"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1780"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3576"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10540"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10540"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201f6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320521"
+  },
+  "adstrdName": "도봉1동",
+  "totalResident": {
+    "$numberInt": "20030"
+  },
+  "maleResident": {
+    "$numberInt": "9993"
+  },
+  "femaleResident": {
+    "$numberInt": "10037"
+  },
+  "age10Resident": {
+    "$numberInt": "1627"
+  },
+  "age20Resident": {
+    "$numberInt": "2142"
+  },
+  "age30Resident": {
+    "$numberInt": "2046"
+  },
+  "age40Resident": {
+    "$numberInt": "2499"
+  },
+  "age50Resident": {
+    "$numberInt": "3524"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8192"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "827"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1105"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1098"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1372"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1771"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3820"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "800"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1037"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "948"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1127"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1753"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4372"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10228"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10228"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201f7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320710"
+  },
+  "adstrdName": "방학3동",
+  "totalResident": {
+    "$numberInt": "26077"
+  },
+  "maleResident": {
+    "$numberInt": "12624"
+  },
+  "femaleResident": {
+    "$numberInt": "13453"
+  },
+  "age10Resident": {
+    "$numberInt": "4026"
+  },
+  "age20Resident": {
+    "$numberInt": "2742"
+  },
+  "age30Resident": {
+    "$numberInt": "2845"
+  },
+  "age40Resident": {
+    "$numberInt": "3723"
+  },
+  "age50Resident": {
+    "$numberInt": "4468"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8273"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2182"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1483"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1465"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1778"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2040"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3676"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1844"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1259"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1380"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1945"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2428"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4597"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9923"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9923"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201f8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200540"
+  },
+  "adstrdName": "마장동",
+  "totalResident": {
+    "$numberInt": "21556"
+  },
+  "maleResident": {
+    "$numberInt": "10610"
+  },
+  "femaleResident": {
+    "$numberInt": "10946"
+  },
+  "age10Resident": {
+    "$numberInt": "2385"
+  },
+  "age20Resident": {
+    "$numberInt": "4066"
+  },
+  "age30Resident": {
+    "$numberInt": "3159"
+  },
+  "age40Resident": {
+    "$numberInt": "2625"
+  },
+  "age50Resident": {
+    "$numberInt": "3419"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5902"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1203"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2027"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1646"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1335"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1661"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2738"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1182"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2039"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1513"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1290"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1758"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3164"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10844"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10844"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201f9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200550"
+  },
+  "adstrdName": "사근동",
+  "totalResident": {
+    "$numberInt": "11936"
+  },
+  "maleResident": {
+    "$numberInt": "6247"
+  },
+  "femaleResident": {
+    "$numberInt": "5689"
+  },
+  "age10Resident": {
+    "$numberInt": "987"
+  },
+  "age20Resident": {
+    "$numberInt": "4917"
+  },
+  "age30Resident": {
+    "$numberInt": "1611"
+  },
+  "age40Resident": {
+    "$numberInt": "1041"
+  },
+  "age50Resident": {
+    "$numberInt": "1286"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2094"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "475"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2713"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "929"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "553"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "622"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "955"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "512"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2204"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "682"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "488"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "664"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1139"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8185"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8185"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201fa"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350560"
+  },
+  "adstrdName": "월계1동",
+  "totalResident": {
+    "$numberInt": "20526"
+  },
+  "maleResident": {
+    "$numberInt": "10528"
+  },
+  "femaleResident": {
+    "$numberInt": "9998"
+  },
+  "age10Resident": {
+    "$numberInt": "2380"
+  },
+  "age20Resident": {
+    "$numberInt": "3591"
+  },
+  "age30Resident": {
+    "$numberInt": "2369"
+  },
+  "age40Resident": {
+    "$numberInt": "2836"
+  },
+  "age50Resident": {
+    "$numberInt": "3322"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6028"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1259"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2094"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1290"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1441"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1677"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2767"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1121"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1497"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1079"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1395"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1645"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3261"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9969"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9969"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201fb"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560610"
+  },
+  "adstrdName": "양평1동",
+  "totalResident": {
+    "$numberInt": "18114"
+  },
+  "maleResident": {
+    "$numberInt": "8709"
+  },
+  "femaleResident": {
+    "$numberInt": "9405"
+  },
+  "age10Resident": {
+    "$numberInt": "2154"
+  },
+  "age20Resident": {
+    "$numberInt": "2938"
+  },
+  "age30Resident": {
+    "$numberInt": "4516"
+  },
+  "age40Resident": {
+    "$numberInt": "2950"
+  },
+  "age50Resident": {
+    "$numberInt": "2150"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3406"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1110"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1174"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2251"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1539"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1131"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1504"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1044"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1764"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2265"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1411"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1019"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1902"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9893"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9893"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201fc"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560650"
+  },
+  "adstrdName": "신길3동",
+  "totalResident": {
+    "$numberInt": "15950"
+  },
+  "maleResident": {
+    "$numberInt": "7852"
+  },
+  "femaleResident": {
+    "$numberInt": "8098"
+  },
+  "age10Resident": {
+    "$numberInt": "2044"
+  },
+  "age20Resident": {
+    "$numberInt": "1875"
+  },
+  "age30Resident": {
+    "$numberInt": "2360"
+  },
+  "age40Resident": {
+    "$numberInt": "2308"
+  },
+  "age50Resident": {
+    "$numberInt": "2655"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4708"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1033"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "936"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1204"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1220"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1335"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2124"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1011"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "939"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1156"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1088"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1320"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2584"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7486"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7486"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201fd"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680630"
+  },
+  "adstrdName": "대치4동",
+  "totalResident": {
+    "$numberInt": "18614"
+  },
+  "maleResident": {
+    "$numberInt": "8869"
+  },
+  "femaleResident": {
+    "$numberInt": "9745"
+  },
+  "age10Resident": {
+    "$numberInt": "2804"
+  },
+  "age20Resident": {
+    "$numberInt": "2971"
+  },
+  "age30Resident": {
+    "$numberInt": "3067"
+  },
+  "age40Resident": {
+    "$numberInt": "3410"
+  },
+  "age50Resident": {
+    "$numberInt": "3345"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3017"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1529"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1449"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1455"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1450"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1639"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1347"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1275"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1522"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1612"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1960"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1706"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1670"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9730"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9730"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201fe"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215850"
+  },
+  "adstrdName": "구의1동",
+  "totalResident": {
+    "$numberInt": "21448"
+  },
+  "maleResident": {
+    "$numberInt": "10252"
+  },
+  "femaleResident": {
+    "$numberInt": "11196"
+  },
+  "age10Resident": {
+    "$numberInt": "1689"
+  },
+  "age20Resident": {
+    "$numberInt": "4498"
+  },
+  "age30Resident": {
+    "$numberInt": "4386"
+  },
+  "age40Resident": {
+    "$numberInt": "2917"
+  },
+  "age50Resident": {
+    "$numberInt": "3119"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4839"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "839"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2008"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2240"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1493"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1505"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2167"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "850"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2490"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2146"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1424"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1614"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2672"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12519"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12519"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00201ff"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11545710"
+  },
+  "adstrdName": "시흥5동",
+  "totalResident": {
+    "$numberInt": "18167"
+  },
+  "maleResident": {
+    "$numberInt": "9067"
+  },
+  "femaleResident": {
+    "$numberInt": "9100"
+  },
+  "age10Resident": {
+    "$numberInt": "1876"
+  },
+  "age20Resident": {
+    "$numberInt": "2073"
+  },
+  "age30Resident": {
+    "$numberInt": "2144"
+  },
+  "age40Resident": {
+    "$numberInt": "2296"
+  },
+  "age50Resident": {
+    "$numberInt": "3311"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6467"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "956"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1075"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1184"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1215"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1710"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2927"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "920"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "998"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "960"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1081"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1601"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3540"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9143"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9143"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020200"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440690"
+  },
+  "adstrdName": "망원1동",
+  "totalResident": {
+    "$numberInt": "19151"
+  },
+  "maleResident": {
+    "$numberInt": "8899"
+  },
+  "femaleResident": {
+    "$numberInt": "10252"
+  },
+  "age10Resident": {
+    "$numberInt": "1831"
+  },
+  "age20Resident": {
+    "$numberInt": "3093"
+  },
+  "age30Resident": {
+    "$numberInt": "3611"
+  },
+  "age40Resident": {
+    "$numberInt": "2937"
+  },
+  "age50Resident": {
+    "$numberInt": "2888"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4791"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "909"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1404"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1717"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1425"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1403"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2041"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "922"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1689"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1894"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1512"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1485"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2750"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10174"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10174"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020201"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350595"
+  },
+  "adstrdName": "공릉1동",
+  "totalResident": {
+    "$numberInt": "35959"
+  },
+  "maleResident": {
+    "$numberInt": "17381"
+  },
+  "femaleResident": {
+    "$numberInt": "18578"
+  },
+  "age10Resident": {
+    "$numberInt": "3930"
+  },
+  "age20Resident": {
+    "$numberInt": "6593"
+  },
+  "age30Resident": {
+    "$numberInt": "4943"
+  },
+  "age40Resident": {
+    "$numberInt": "4951"
+  },
+  "age50Resident": {
+    "$numberInt": "5445"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10097"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2028"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3169"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2510"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2495"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2673"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4506"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1902"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3424"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2433"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2456"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2772"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5591"
+  },
+  "totalHouseholds": {
+    "$numberInt": "18517"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "18517"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020202"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500641"
+  },
+  "adstrdName": "방화3동",
+  "totalResident": {
+    "$numberInt": "21991"
+  },
+  "maleResident": {
+    "$numberInt": "10634"
+  },
+  "femaleResident": {
+    "$numberInt": "11357"
+  },
+  "age10Resident": {
+    "$numberInt": "2422"
+  },
+  "age20Resident": {
+    "$numberInt": "1964"
+  },
+  "age30Resident": {
+    "$numberInt": "3367"
+  },
+  "age40Resident": {
+    "$numberInt": "3227"
+  },
+  "age50Resident": {
+    "$numberInt": "3271"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7740"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1255"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1011"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1720"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1638"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1625"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3385"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1167"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "953"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1647"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1589"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1646"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4355"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11216"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11216"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020203"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500530"
+  },
+  "adstrdName": "등촌2동",
+  "totalResident": {
+    "$numberInt": "19312"
+  },
+  "maleResident": {
+    "$numberInt": "9398"
+  },
+  "femaleResident": {
+    "$numberInt": "9914"
+  },
+  "age10Resident": {
+    "$numberInt": "2375"
+  },
+  "age20Resident": {
+    "$numberInt": "2697"
+  },
+  "age30Resident": {
+    "$numberInt": "3298"
+  },
+  "age40Resident": {
+    "$numberInt": "2778"
+  },
+  "age50Resident": {
+    "$numberInt": "2997"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5167"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1313"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1328"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1653"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1373"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1366"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2365"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1062"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1369"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1645"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1405"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1631"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2802"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8505"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8505"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020204"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110600"
+  },
+  "adstrdName": "가회동",
+  "totalResident": {
+    "$numberInt": "3849"
+  },
+  "maleResident": {
+    "$numberInt": "1787"
+  },
+  "femaleResident": {
+    "$numberInt": "2062"
+  },
+  "age10Resident": {
+    "$numberInt": "459"
+  },
+  "age20Resident": {
+    "$numberInt": "406"
+  },
+  "age30Resident": {
+    "$numberInt": "499"
+  },
+  "age40Resident": {
+    "$numberInt": "633"
+  },
+  "age50Resident": {
+    "$numberInt": "687"
+  },
+  "age60PlusResident": {
+    "$numberInt": "1165"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "247"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "188"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "228"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "295"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "331"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "498"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "212"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "218"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "271"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "338"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "356"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "667"
+  },
+  "totalHouseholds": {
+    "$numberInt": "1903"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "1903"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020205"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140645"
+  },
+  "adstrdName": "청구동",
+  "totalResident": {
+    "$numberInt": "12955"
+  },
+  "maleResident": {
+    "$numberInt": "6117"
+  },
+  "femaleResident": {
+    "$numberInt": "6838"
+  },
+  "age10Resident": {
+    "$numberInt": "1365"
+  },
+  "age20Resident": {
+    "$numberInt": "1575"
+  },
+  "age30Resident": {
+    "$numberInt": "2127"
+  },
+  "age40Resident": {
+    "$numberInt": "1648"
+  },
+  "age50Resident": {
+    "$numberInt": "2147"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4093"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "687"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "761"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1047"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "815"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1015"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1792"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "678"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "814"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1080"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "833"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1132"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2301"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6139"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6139"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020206"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680700"
+  },
+  "adstrdName": "세곡동",
+  "totalResident": {
+    "$numberInt": "45513"
+  },
+  "maleResident": {
+    "$numberInt": "21325"
+  },
+  "femaleResident": {
+    "$numberInt": "24188"
+  },
+  "age10Resident": {
+    "$numberInt": "8706"
+  },
+  "age20Resident": {
+    "$numberInt": "5330"
+  },
+  "age30Resident": {
+    "$numberInt": "7034"
+  },
+  "age40Resident": {
+    "$numberInt": "8065"
+  },
+  "age50Resident": {
+    "$numberInt": "6259"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10119"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "4379"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2341"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3273"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3883"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3042"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4407"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "4327"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2989"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3761"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "4182"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3217"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5712"
+  },
+  "totalHouseholds": {
+    "$numberInt": "19381"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "19381"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020207"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110700"
+  },
+  "adstrdName": "숭인1동",
+  "totalResident": {
+    "$numberInt": "5768"
+  },
+  "maleResident": {
+    "$numberInt": "2797"
+  },
+  "femaleResident": {
+    "$numberInt": "2971"
+  },
+  "age10Resident": {
+    "$numberInt": "531"
+  },
+  "age20Resident": {
+    "$numberInt": "721"
+  },
+  "age30Resident": {
+    "$numberInt": "792"
+  },
+  "age40Resident": {
+    "$numberInt": "805"
+  },
+  "age50Resident": {
+    "$numberInt": "1099"
+  },
+  "age60PlusResident": {
+    "$numberInt": "1820"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "267"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "341"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "404"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "420"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "557"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "808"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "264"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "380"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "388"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "385"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "542"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1012"
+  },
+  "totalHouseholds": {
+    "$numberInt": "2990"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "2990"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020208"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110550"
+  },
+  "adstrdName": "부암동",
+  "totalResident": {
+    "$numberInt": "9034"
+  },
+  "maleResident": {
+    "$numberInt": "4284"
+  },
+  "femaleResident": {
+    "$numberInt": "4750"
+  },
+  "age10Resident": {
+    "$numberInt": "1191"
+  },
+  "age20Resident": {
+    "$numberInt": "1096"
+  },
+  "age30Resident": {
+    "$numberInt": "1158"
+  },
+  "age40Resident": {
+    "$numberInt": "1374"
+  },
+  "age50Resident": {
+    "$numberInt": "1626"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2589"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "629"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "563"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "566"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "611"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "752"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1163"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "562"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "533"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "592"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "763"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "874"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1426"
+  },
+  "totalHouseholds": {
+    "$numberInt": "4096"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "4096"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020209"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110680"
+  },
+  "adstrdName": "창신2동",
+  "totalResident": {
+    "$numberInt": "7511"
+  },
+  "maleResident": {
+    "$numberInt": "3880"
+  },
+  "femaleResident": {
+    "$numberInt": "3631"
+  },
+  "age10Resident": {
+    "$numberInt": "498"
+  },
+  "age20Resident": {
+    "$numberInt": "954"
+  },
+  "age30Resident": {
+    "$numberInt": "881"
+  },
+  "age40Resident": {
+    "$numberInt": "818"
+  },
+  "age50Resident": {
+    "$numberInt": "1665"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2695"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "263"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "498"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "514"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "454"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "861"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1290"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "235"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "456"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "367"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "364"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "804"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1405"
+  },
+  "totalHouseholds": {
+    "$numberInt": "3983"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "3983"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002020a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11545700"
+  },
+  "adstrdName": "시흥4동",
+  "totalResident": {
+    "$numberInt": "19366"
+  },
+  "maleResident": {
+    "$numberInt": "9586"
+  },
+  "femaleResident": {
+    "$numberInt": "9780"
+  },
+  "age10Resident": {
+    "$numberInt": "2035"
+  },
+  "age20Resident": {
+    "$numberInt": "2302"
+  },
+  "age30Resident": {
+    "$numberInt": "2358"
+  },
+  "age40Resident": {
+    "$numberInt": "2452"
+  },
+  "age50Resident": {
+    "$numberInt": "3576"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6643"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1027"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1187"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1258"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1243"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1712"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3159"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1008"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1115"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1100"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1209"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1864"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3484"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9011"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9011"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002020b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740515"
+  },
+  "adstrdName": "강일동",
+  "totalResident": {
+    "$numberInt": "44257"
+  },
+  "maleResident": {
+    "$numberInt": "21047"
+  },
+  "femaleResident": {
+    "$numberInt": "23210"
+  },
+  "age10Resident": {
+    "$numberInt": "8773"
+  },
+  "age20Resident": {
+    "$numberInt": "4901"
+  },
+  "age30Resident": {
+    "$numberInt": "5797"
+  },
+  "age40Resident": {
+    "$numberInt": "7171"
+  },
+  "age50Resident": {
+    "$numberInt": "6561"
+  },
+  "age60PlusResident": {
+    "$numberInt": "11054"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "4522"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2397"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2690"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3476"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3173"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4789"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "4251"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2504"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3107"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3695"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3388"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "6265"
+  },
+  "totalHouseholds": {
+    "$numberInt": "17658"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "17658"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002020c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215840"
+  },
+  "adstrdName": "자양3동",
+  "totalResident": {
+    "$numberInt": "27193"
+  },
+  "maleResident": {
+    "$numberInt": "12991"
+  },
+  "femaleResident": {
+    "$numberInt": "14202"
+  },
+  "age10Resident": {
+    "$numberInt": "4362"
+  },
+  "age20Resident": {
+    "$numberInt": "3434"
+  },
+  "age30Resident": {
+    "$numberInt": "3864"
+  },
+  "age40Resident": {
+    "$numberInt": "4233"
+  },
+  "age50Resident": {
+    "$numberInt": "4540"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6760"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2185"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1714"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1809"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1976"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2183"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3124"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2177"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1720"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2055"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2257"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2357"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3636"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10951"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10951"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002020d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530720"
+  },
+  "adstrdName": "고척1동",
+  "totalResident": {
+    "$numberInt": "26314"
+  },
+  "maleResident": {
+    "$numberInt": "13106"
+  },
+  "femaleResident": {
+    "$numberInt": "13208"
+  },
+  "age10Resident": {
+    "$numberInt": "3502"
+  },
+  "age20Resident": {
+    "$numberInt": "3309"
+  },
+  "age30Resident": {
+    "$numberInt": "5100"
+  },
+  "age40Resident": {
+    "$numberInt": "3600"
+  },
+  "age50Resident": {
+    "$numberInt": "4025"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6778"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1809"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1668"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2610"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1872"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1970"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3177"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1693"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1641"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2490"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1728"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2055"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3601"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11516"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11516"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002020e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200790"
+  },
+  "adstrdName": "용답동",
+  "totalResident": {
+    "$numberInt": "11809"
+  },
+  "maleResident": {
+    "$numberInt": "6118"
+  },
+  "femaleResident": {
+    "$numberInt": "5691"
+  },
+  "age10Resident": {
+    "$numberInt": "818"
+  },
+  "age20Resident": {
+    "$numberInt": "2551"
+  },
+  "age30Resident": {
+    "$numberInt": "1989"
+  },
+  "age40Resident": {
+    "$numberInt": "1397"
+  },
+  "age50Resident": {
+    "$numberInt": "1892"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3162"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "423"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1141"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1057"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "793"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1122"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1582"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "395"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1410"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "932"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "604"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "770"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1580"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7515"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7515"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002020f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500603"
+  },
+  "adstrdName": "가양1동",
+  "totalResident": {
+    "$numberInt": "33880"
+  },
+  "maleResident": {
+    "$numberInt": "15206"
+  },
+  "femaleResident": {
+    "$numberInt": "18674"
+  },
+  "age10Resident": {
+    "$numberInt": "3024"
+  },
+  "age20Resident": {
+    "$numberInt": "7788"
+  },
+  "age30Resident": {
+    "$numberInt": "8937"
+  },
+  "age40Resident": {
+    "$numberInt": "4444"
+  },
+  "age50Resident": {
+    "$numberInt": "4089"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5598"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1562"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2560"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "4210"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2239"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2005"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2630"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1462"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "5228"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "4727"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2205"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2084"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2968"
+  },
+  "totalHouseholds": {
+    "$numberInt": "20930"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "20930"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020210"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650581"
+  },
+  "adstrdName": "반포4동",
+  "totalResident": {
+    "$numberInt": "18474"
+  },
+  "maleResident": {
+    "$numberInt": "8654"
+  },
+  "femaleResident": {
+    "$numberInt": "9820"
+  },
+  "age10Resident": {
+    "$numberInt": "3522"
+  },
+  "age20Resident": {
+    "$numberInt": "2071"
+  },
+  "age30Resident": {
+    "$numberInt": "2343"
+  },
+  "age40Resident": {
+    "$numberInt": "3241"
+  },
+  "age50Resident": {
+    "$numberInt": "3078"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4219"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1824"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1001"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1032"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1431"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1463"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1903"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1698"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1070"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1311"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1810"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1615"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2316"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7024"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7024"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020211"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305603"
+  },
+  "adstrdName": "번2동",
+  "totalResident": {
+    "$numberInt": "14866"
+  },
+  "maleResident": {
+    "$numberInt": "7134"
+  },
+  "femaleResident": {
+    "$numberInt": "7732"
+  },
+  "age10Resident": {
+    "$numberInt": "1327"
+  },
+  "age20Resident": {
+    "$numberInt": "1830"
+  },
+  "age30Resident": {
+    "$numberInt": "1585"
+  },
+  "age40Resident": {
+    "$numberInt": "1928"
+  },
+  "age50Resident": {
+    "$numberInt": "2530"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5666"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "704"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "929"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "841"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1017"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1251"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2392"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "623"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "901"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "744"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "911"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1279"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3274"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7425"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7425"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020212"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140635"
+  },
+  "adstrdName": "약수동",
+  "totalResident": {
+    "$numberInt": "16086"
+  },
+  "maleResident": {
+    "$numberInt": "7419"
+  },
+  "femaleResident": {
+    "$numberInt": "8667"
+  },
+  "age10Resident": {
+    "$numberInt": "1717"
+  },
+  "age20Resident": {
+    "$numberInt": "1772"
+  },
+  "age30Resident": {
+    "$numberInt": "2258"
+  },
+  "age40Resident": {
+    "$numberInt": "2206"
+  },
+  "age50Resident": {
+    "$numberInt": "2653"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5480"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "857"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "847"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1092"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1072"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1215"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2336"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "860"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "925"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1166"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1134"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1438"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3144"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7737"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7737"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020213"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620545"
+  },
+  "adstrdName": "청림동",
+  "totalResident": {
+    "$numberInt": "14726"
+  },
+  "maleResident": {
+    "$numberInt": "7103"
+  },
+  "femaleResident": {
+    "$numberInt": "7623"
+  },
+  "age10Resident": {
+    "$numberInt": "2130"
+  },
+  "age20Resident": {
+    "$numberInt": "1620"
+  },
+  "age30Resident": {
+    "$numberInt": "2373"
+  },
+  "age40Resident": {
+    "$numberInt": "2293"
+  },
+  "age50Resident": {
+    "$numberInt": "2285"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4025"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1097"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "803"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1211"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1152"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1111"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1729"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1033"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "817"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1162"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1141"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1174"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2296"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6408"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6408"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020214"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680565"
+  },
+  "adstrdName": "청담동",
+  "totalResident": {
+    "$numberInt": "24535"
+  },
+  "maleResident": {
+    "$numberInt": "11449"
+  },
+  "femaleResident": {
+    "$numberInt": "13086"
+  },
+  "age10Resident": {
+    "$numberInt": "3849"
+  },
+  "age20Resident": {
+    "$numberInt": "3131"
+  },
+  "age30Resident": {
+    "$numberInt": "3696"
+  },
+  "age40Resident": {
+    "$numberInt": "4401"
+  },
+  "age50Resident": {
+    "$numberInt": "3973"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5485"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2074"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1435"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1595"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1986"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1847"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2512"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1775"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1696"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2101"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2415"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2126"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2973"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10790"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10790"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020215"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740530"
+  },
+  "adstrdName": "명일1동",
+  "totalResident": {
+    "$numberInt": "25279"
+  },
+  "maleResident": {
+    "$numberInt": "12363"
+  },
+  "femaleResident": {
+    "$numberInt": "12916"
+  },
+  "age10Resident": {
+    "$numberInt": "4369"
+  },
+  "age20Resident": {
+    "$numberInt": "2720"
+  },
+  "age30Resident": {
+    "$numberInt": "3749"
+  },
+  "age40Resident": {
+    "$numberInt": "4145"
+  },
+  "age50Resident": {
+    "$numberInt": "3901"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6395"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2302"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1410"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1845"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1996"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1890"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2920"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2067"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1310"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1904"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2149"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2011"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3475"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10027"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10027"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020216"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710690"
+  },
+  "adstrdName": "잠실4동",
+  "totalResident": {
+    "$numberInt": "21192"
+  },
+  "maleResident": {
+    "$numberInt": "10213"
+  },
+  "femaleResident": {
+    "$numberInt": "10979"
+  },
+  "age10Resident": {
+    "$numberInt": "4930"
+  },
+  "age20Resident": {
+    "$numberInt": "1852"
+  },
+  "age30Resident": {
+    "$numberInt": "2399"
+  },
+  "age40Resident": {
+    "$numberInt": "4442"
+  },
+  "age50Resident": {
+    "$numberInt": "3132"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4437"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2566"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "916"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1000"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2108"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1542"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2081"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2364"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "936"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1399"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2334"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1590"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2356"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7231"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7231"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020217"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350710"
+  },
+  "adstrdName": "상계9동",
+  "totalResident": {
+    "$numberInt": "19664"
+  },
+  "maleResident": {
+    "$numberInt": "9212"
+  },
+  "femaleResident": {
+    "$numberInt": "10452"
+  },
+  "age10Resident": {
+    "$numberInt": "2759"
+  },
+  "age20Resident": {
+    "$numberInt": "2386"
+  },
+  "age30Resident": {
+    "$numberInt": "2669"
+  },
+  "age40Resident": {
+    "$numberInt": "2975"
+  },
+  "age50Resident": {
+    "$numberInt": "3517"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5358"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1424"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1221"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1335"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1386"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1595"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2251"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1335"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1165"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1334"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1589"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1922"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3107"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8358"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8358"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020218"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305608"
+  },
+  "adstrdName": "번3동",
+  "totalResident": {
+    "$numberInt": "16356"
+  },
+  "maleResident": {
+    "$numberInt": "7614"
+  },
+  "femaleResident": {
+    "$numberInt": "8742"
+  },
+  "age10Resident": {
+    "$numberInt": "1795"
+  },
+  "age20Resident": {
+    "$numberInt": "1693"
+  },
+  "age30Resident": {
+    "$numberInt": "1605"
+  },
+  "age40Resident": {
+    "$numberInt": "2139"
+  },
+  "age50Resident": {
+    "$numberInt": "2765"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6359"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "903"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "865"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "821"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1065"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1370"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2590"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "892"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "828"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "784"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1074"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1395"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3769"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7665"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7665"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020219"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530540"
+  },
+  "adstrdName": "구로3동",
+  "totalResident": {
+    "$numberInt": "23287"
+  },
+  "maleResident": {
+    "$numberInt": "12033"
+  },
+  "femaleResident": {
+    "$numberInt": "11254"
+  },
+  "age10Resident": {
+    "$numberInt": "2277"
+  },
+  "age20Resident": {
+    "$numberInt": "4387"
+  },
+  "age30Resident": {
+    "$numberInt": "4623"
+  },
+  "age40Resident": {
+    "$numberInt": "3707"
+  },
+  "age50Resident": {
+    "$numberInt": "3168"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5125"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1182"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2176"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2624"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2014"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1717"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2320"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1095"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2211"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1999"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1693"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1451"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2805"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13633"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13633"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002021a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710590"
+  },
+  "adstrdName": "송파2동",
+  "totalResident": {
+    "$numberInt": "18476"
+  },
+  "maleResident": {
+    "$numberInt": "8909"
+  },
+  "femaleResident": {
+    "$numberInt": "9567"
+  },
+  "age10Resident": {
+    "$numberInt": "2965"
+  },
+  "age20Resident": {
+    "$numberInt": "2336"
+  },
+  "age30Resident": {
+    "$numberInt": "2638"
+  },
+  "age40Resident": {
+    "$numberInt": "2935"
+  },
+  "age50Resident": {
+    "$numberInt": "2929"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4673"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1502"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1110"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1255"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1444"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1390"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2208"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1463"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1226"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1383"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1491"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1539"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2465"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7095"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7095"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002021b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590550"
+  },
+  "adstrdName": "상도3동",
+  "totalResident": {
+    "$numberInt": "23844"
+  },
+  "maleResident": {
+    "$numberInt": "11339"
+  },
+  "femaleResident": {
+    "$numberInt": "12505"
+  },
+  "age10Resident": {
+    "$numberInt": "2273"
+  },
+  "age20Resident": {
+    "$numberInt": "4063"
+  },
+  "age30Resident": {
+    "$numberInt": "3842"
+  },
+  "age40Resident": {
+    "$numberInt": "3224"
+  },
+  "age50Resident": {
+    "$numberInt": "3734"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6708"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1181"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1858"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1972"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1603"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1787"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2938"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1092"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2205"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1870"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1621"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1947"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3770"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12158"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12158"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002021c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710610"
+  },
+  "adstrdName": "삼전동",
+  "totalResident": {
+    "$numberInt": "29062"
+  },
+  "maleResident": {
+    "$numberInt": "13547"
+  },
+  "femaleResident": {
+    "$numberInt": "15515"
+  },
+  "age10Resident": {
+    "$numberInt": "2820"
+  },
+  "age20Resident": {
+    "$numberInt": "4764"
+  },
+  "age30Resident": {
+    "$numberInt": "6320"
+  },
+  "age40Resident": {
+    "$numberInt": "4660"
+  },
+  "age50Resident": {
+    "$numberInt": "4135"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6363"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1461"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2110"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3017"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2246"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1947"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2766"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1359"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2654"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3303"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2414"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2188"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3597"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16117"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16117"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002021d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710532"
+  },
+  "adstrdName": "거여2동",
+  "totalResident": {
+    "$numberInt": "23596"
+  },
+  "maleResident": {
+    "$numberInt": "11502"
+  },
+  "femaleResident": {
+    "$numberInt": "12094"
+  },
+  "age10Resident": {
+    "$numberInt": "3534"
+  },
+  "age20Resident": {
+    "$numberInt": "2477"
+  },
+  "age30Resident": {
+    "$numberInt": "3477"
+  },
+  "age40Resident": {
+    "$numberInt": "3649"
+  },
+  "age50Resident": {
+    "$numberInt": "3992"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6467"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1819"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1260"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1742"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1833"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1933"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2915"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1715"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1217"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1735"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1816"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2059"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3552"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10093"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10093"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002021e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290810"
+  },
+  "adstrdName": "석관동",
+  "totalResident": {
+    "$numberInt": "33768"
+  },
+  "maleResident": {
+    "$numberInt": "16684"
+  },
+  "femaleResident": {
+    "$numberInt": "17084"
+  },
+  "age10Resident": {
+    "$numberInt": "3630"
+  },
+  "age20Resident": {
+    "$numberInt": "4580"
+  },
+  "age30Resident": {
+    "$numberInt": "4600"
+  },
+  "age40Resident": {
+    "$numberInt": "4597"
+  },
+  "age50Resident": {
+    "$numberInt": "5650"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10711"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1912"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2202"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2398"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2389"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2833"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4950"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1718"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2378"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2202"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2208"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2817"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5761"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16597"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16597"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002021f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290705"
+  },
+  "adstrdName": "종암동",
+  "totalResident": {
+    "$numberInt": "37648"
+  },
+  "maleResident": {
+    "$numberInt": "18608"
+  },
+  "femaleResident": {
+    "$numberInt": "19040"
+  },
+  "age10Resident": {
+    "$numberInt": "5498"
+  },
+  "age20Resident": {
+    "$numberInt": "5426"
+  },
+  "age30Resident": {
+    "$numberInt": "4572"
+  },
+  "age40Resident": {
+    "$numberInt": "5812"
+  },
+  "age50Resident": {
+    "$numberInt": "6302"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10038"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2952"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2834"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2411"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2827"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3132"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4452"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2546"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2592"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2161"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2985"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3170"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5586"
+  },
+  "totalHouseholds": {
+    "$numberInt": "17012"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "17012"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020220"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620655"
+  },
+  "adstrdName": "신원동",
+  "totalResident": {
+    "$numberInt": "17484"
+  },
+  "maleResident": {
+    "$numberInt": "8937"
+  },
+  "femaleResident": {
+    "$numberInt": "8547"
+  },
+  "age10Resident": {
+    "$numberInt": "1072"
+  },
+  "age20Resident": {
+    "$numberInt": "4165"
+  },
+  "age30Resident": {
+    "$numberInt": "3321"
+  },
+  "age40Resident": {
+    "$numberInt": "2054"
+  },
+  "age50Resident": {
+    "$numberInt": "2330"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4542"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "516"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2106"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2018"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1100"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1213"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1984"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "556"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2059"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1303"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "954"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1117"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2558"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11158"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11158"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020221"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440585"
+  },
+  "adstrdName": "도화동",
+  "totalResident": {
+    "$numberInt": "20443"
+  },
+  "maleResident": {
+    "$numberInt": "9697"
+  },
+  "femaleResident": {
+    "$numberInt": "10746"
+  },
+  "age10Resident": {
+    "$numberInt": "2696"
+  },
+  "age20Resident": {
+    "$numberInt": "2579"
+  },
+  "age30Resident": {
+    "$numberInt": "3498"
+  },
+  "age40Resident": {
+    "$numberInt": "2876"
+  },
+  "age50Resident": {
+    "$numberInt": "3292"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5502"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1398"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1207"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1717"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1414"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1534"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2427"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1298"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1372"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1781"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1462"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1758"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3075"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9219"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9219"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020222"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260520"
+  },
+  "adstrdName": "면목2동",
+  "totalResident": {
+    "$numberInt": "23580"
+  },
+  "maleResident": {
+    "$numberInt": "11697"
+  },
+  "femaleResident": {
+    "$numberInt": "11883"
+  },
+  "age10Resident": {
+    "$numberInt": "2277"
+  },
+  "age20Resident": {
+    "$numberInt": "2917"
+  },
+  "age30Resident": {
+    "$numberInt": "3417"
+  },
+  "age40Resident": {
+    "$numberInt": "3211"
+  },
+  "age50Resident": {
+    "$numberInt": "4445"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7313"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1165"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1417"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1781"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1707"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2245"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3382"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1112"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1500"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1636"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1504"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2200"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3931"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12221"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12221"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020223"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590560"
+  },
+  "adstrdName": "상도4동",
+  "totalResident": {
+    "$numberInt": "27609"
+  },
+  "maleResident": {
+    "$numberInt": "13396"
+  },
+  "femaleResident": {
+    "$numberInt": "14213"
+  },
+  "age10Resident": {
+    "$numberInt": "2921"
+  },
+  "age20Resident": {
+    "$numberInt": "4191"
+  },
+  "age30Resident": {
+    "$numberInt": "4518"
+  },
+  "age40Resident": {
+    "$numberInt": "3888"
+  },
+  "age50Resident": {
+    "$numberInt": "4345"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7746"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1541"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2011"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2349"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2004"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2068"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3423"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1380"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2180"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2169"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1884"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2277"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4323"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14048"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14048"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020224"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590640"
+  },
+  "adstrdName": "사당3동",
+  "totalResident": {
+    "$numberInt": "23686"
+  },
+  "maleResident": {
+    "$numberInt": "11429"
+  },
+  "femaleResident": {
+    "$numberInt": "12257"
+  },
+  "age10Resident": {
+    "$numberInt": "3299"
+  },
+  "age20Resident": {
+    "$numberInt": "2990"
+  },
+  "age30Resident": {
+    "$numberInt": "3605"
+  },
+  "age40Resident": {
+    "$numberInt": "3634"
+  },
+  "age50Resident": {
+    "$numberInt": "3482"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6676"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1684"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1400"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1713"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1846"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1680"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3106"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1615"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1590"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1892"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1788"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1802"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3570"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10442"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10442"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020225"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620595"
+  },
+  "adstrdName": "청룡동",
+  "totalResident": {
+    "$numberInt": "35627"
+  },
+  "maleResident": {
+    "$numberInt": "17102"
+  },
+  "femaleResident": {
+    "$numberInt": "18525"
+  },
+  "age10Resident": {
+    "$numberInt": "2496"
+  },
+  "age20Resident": {
+    "$numberInt": "11517"
+  },
+  "age30Resident": {
+    "$numberInt": "7376"
+  },
+  "age40Resident": {
+    "$numberInt": "3799"
+  },
+  "age50Resident": {
+    "$numberInt": "3839"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6600"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1205"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "5126"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3882"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1956"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1952"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2981"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1291"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "6391"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3494"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1843"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1887"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3619"
+  },
+  "totalHouseholds": {
+    "$numberInt": "24083"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "24083"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020226"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290660"
+  },
+  "adstrdName": "길음1동",
+  "totalResident": {
+    "$numberInt": "34792"
+  },
+  "maleResident": {
+    "$numberInt": "16426"
+  },
+  "femaleResident": {
+    "$numberInt": "18366"
+  },
+  "age10Resident": {
+    "$numberInt": "7906"
+  },
+  "age20Resident": {
+    "$numberInt": "3417"
+  },
+  "age30Resident": {
+    "$numberInt": "3683"
+  },
+  "age40Resident": {
+    "$numberInt": "7214"
+  },
+  "age50Resident": {
+    "$numberInt": "5810"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6762"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3941"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1638"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1646"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3327"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3045"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2829"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3965"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1779"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2037"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3887"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2765"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3933"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12458"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12458"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020227"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290525"
+  },
+  "adstrdName": "성북동",
+  "totalResident": {
+    "$numberInt": "15875"
+  },
+  "maleResident": {
+    "$numberInt": "7372"
+  },
+  "femaleResident": {
+    "$numberInt": "8503"
+  },
+  "age10Resident": {
+    "$numberInt": "1672"
+  },
+  "age20Resident": {
+    "$numberInt": "2533"
+  },
+  "age30Resident": {
+    "$numberInt": "2486"
+  },
+  "age40Resident": {
+    "$numberInt": "2202"
+  },
+  "age50Resident": {
+    "$numberInt": "2730"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4252"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "852"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1127"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1210"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1036"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1273"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1874"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "820"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1406"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1276"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1166"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1457"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2378"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8108"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8108"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020228"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440720"
+  },
+  "adstrdName": "성산1동",
+  "totalResident": {
+    "$numberInt": "18543"
+  },
+  "maleResident": {
+    "$numberInt": "8632"
+  },
+  "femaleResident": {
+    "$numberInt": "9911"
+  },
+  "age10Resident": {
+    "$numberInt": "1968"
+  },
+  "age20Resident": {
+    "$numberInt": "3017"
+  },
+  "age30Resident": {
+    "$numberInt": "3275"
+  },
+  "age40Resident": {
+    "$numberInt": "2964"
+  },
+  "age50Resident": {
+    "$numberInt": "2958"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4361"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "931"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1402"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1584"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1404"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1444"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1867"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1037"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1615"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1691"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1560"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1514"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2494"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9475"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9475"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020229"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290555"
+  },
+  "adstrdName": "삼선동",
+  "totalResident": {
+    "$numberInt": "22125"
+  },
+  "maleResident": {
+    "$numberInt": "10481"
+  },
+  "femaleResident": {
+    "$numberInt": "11644"
+  },
+  "age10Resident": {
+    "$numberInt": "2473"
+  },
+  "age20Resident": {
+    "$numberInt": "4178"
+  },
+  "age30Resident": {
+    "$numberInt": "3060"
+  },
+  "age40Resident": {
+    "$numberInt": "2974"
+  },
+  "age50Resident": {
+    "$numberInt": "3789"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5651"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1264"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1869"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1503"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1462"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1907"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2476"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1209"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2309"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1557"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1512"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1882"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3175"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11391"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11391"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002022a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620775"
+  },
+  "adstrdName": "난곡동",
+  "totalResident": {
+    "$numberInt": "25257"
+  },
+  "maleResident": {
+    "$numberInt": "12654"
+  },
+  "femaleResident": {
+    "$numberInt": "12603"
+  },
+  "age10Resident": {
+    "$numberInt": "2430"
+  },
+  "age20Resident": {
+    "$numberInt": "3557"
+  },
+  "age30Resident": {
+    "$numberInt": "3407"
+  },
+  "age40Resident": {
+    "$numberInt": "3357"
+  },
+  "age50Resident": {
+    "$numberInt": "4375"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8131"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1236"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1795"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1868"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1836"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2178"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3741"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1194"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1762"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1539"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1521"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2197"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4390"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12782"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12782"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002022b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260610"
+  },
+  "adstrdName": "중화2동",
+  "totalResident": {
+    "$numberInt": "23768"
+  },
+  "maleResident": {
+    "$numberInt": "12182"
+  },
+  "femaleResident": {
+    "$numberInt": "11586"
+  },
+  "age10Resident": {
+    "$numberInt": "1842"
+  },
+  "age20Resident": {
+    "$numberInt": "3254"
+  },
+  "age30Resident": {
+    "$numberInt": "3585"
+  },
+  "age40Resident": {
+    "$numberInt": "3023"
+  },
+  "age50Resident": {
+    "$numberInt": "4241"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7823"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1006"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1588"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1903"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1657"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2228"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3800"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "836"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1666"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1682"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1366"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2013"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4023"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13441"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13441"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002022c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215750"
+  },
+  "adstrdName": "중곡2동",
+  "totalResident": {
+    "$numberInt": "20512"
+  },
+  "maleResident": {
+    "$numberInt": "9636"
+  },
+  "femaleResident": {
+    "$numberInt": "10876"
+  },
+  "age10Resident": {
+    "$numberInt": "2069"
+  },
+  "age20Resident": {
+    "$numberInt": "3304"
+  },
+  "age30Resident": {
+    "$numberInt": "3661"
+  },
+  "age40Resident": {
+    "$numberInt": "2825"
+  },
+  "age50Resident": {
+    "$numberInt": "3343"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5310"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1053"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1474"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1777"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1388"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1528"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2416"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1016"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1830"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1884"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1437"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1815"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2894"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10569"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10569"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002022d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290620"
+  },
+  "adstrdName": "정릉1동",
+  "totalResident": {
+    "$numberInt": "17732"
+  },
+  "maleResident": {
+    "$numberInt": "8501"
+  },
+  "femaleResident": {
+    "$numberInt": "9231"
+  },
+  "age10Resident": {
+    "$numberInt": "2848"
+  },
+  "age20Resident": {
+    "$numberInt": "2228"
+  },
+  "age30Resident": {
+    "$numberInt": "2325"
+  },
+  "age40Resident": {
+    "$numberInt": "2923"
+  },
+  "age50Resident": {
+    "$numberInt": "2859"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4549"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1470"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1082"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1135"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1429"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1389"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1996"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1378"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1146"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1190"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1494"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1470"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2553"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7342"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7342"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002022e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530790"
+  },
+  "adstrdName": "수궁동",
+  "totalResident": {
+    "$numberInt": "22707"
+  },
+  "maleResident": {
+    "$numberInt": "11115"
+  },
+  "femaleResident": {
+    "$numberInt": "11592"
+  },
+  "age10Resident": {
+    "$numberInt": "2938"
+  },
+  "age20Resident": {
+    "$numberInt": "2615"
+  },
+  "age30Resident": {
+    "$numberInt": "2913"
+  },
+  "age40Resident": {
+    "$numberInt": "3392"
+  },
+  "age50Resident": {
+    "$numberInt": "3789"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7060"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1550"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1379"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1474"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1705"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1794"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3213"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1388"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1236"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1439"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1687"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1995"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3847"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9939"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9939"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002022f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560700"
+  },
+  "adstrdName": "대림1동",
+  "totalResident": {
+    "$numberInt": "13711"
+  },
+  "maleResident": {
+    "$numberInt": "6805"
+  },
+  "femaleResident": {
+    "$numberInt": "6906"
+  },
+  "age10Resident": {
+    "$numberInt": "1441"
+  },
+  "age20Resident": {
+    "$numberInt": "1798"
+  },
+  "age30Resident": {
+    "$numberInt": "1785"
+  },
+  "age40Resident": {
+    "$numberInt": "1826"
+  },
+  "age50Resident": {
+    "$numberInt": "2344"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4517"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "792"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "898"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "972"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "983"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1124"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2036"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "649"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "900"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "813"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "843"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1220"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2481"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6855"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6855"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020230"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470560"
+  },
+  "adstrdName": "신월1동",
+  "totalResident": {
+    "$numberInt": "19365"
+  },
+  "maleResident": {
+    "$numberInt": "9957"
+  },
+  "femaleResident": {
+    "$numberInt": "9408"
+  },
+  "age10Resident": {
+    "$numberInt": "1836"
+  },
+  "age20Resident": {
+    "$numberInt": "2238"
+  },
+  "age30Resident": {
+    "$numberInt": "2462"
+  },
+  "age40Resident": {
+    "$numberInt": "2677"
+  },
+  "age50Resident": {
+    "$numberInt": "3485"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6667"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "951"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1132"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1379"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1480"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1803"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3212"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "885"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1106"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1083"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1197"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1682"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3455"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10008"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10008"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020231"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470540"
+  },
+  "adstrdName": "목4동",
+  "totalResident": {
+    "$numberInt": "24428"
+  },
+  "maleResident": {
+    "$numberInt": "11899"
+  },
+  "femaleResident": {
+    "$numberInt": "12529"
+  },
+  "age10Resident": {
+    "$numberInt": "3976"
+  },
+  "age20Resident": {
+    "$numberInt": "3730"
+  },
+  "age30Resident": {
+    "$numberInt": "2695"
+  },
+  "age40Resident": {
+    "$numberInt": "3867"
+  },
+  "age50Resident": {
+    "$numberInt": "4890"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5270"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2049"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1953"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1381"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1723"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2424"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2369"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1927"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1777"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1314"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2144"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2466"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2901"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9964"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9964"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020232"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500590"
+  },
+  "adstrdName": "화곡본동",
+  "totalResident": {
+    "$numberInt": "32956"
+  },
+  "maleResident": {
+    "$numberInt": "15959"
+  },
+  "femaleResident": {
+    "$numberInt": "16997"
+  },
+  "age10Resident": {
+    "$numberInt": "3601"
+  },
+  "age20Resident": {
+    "$numberInt": "5536"
+  },
+  "age30Resident": {
+    "$numberInt": "6108"
+  },
+  "age40Resident": {
+    "$numberInt": "5100"
+  },
+  "age50Resident": {
+    "$numberInt": "4798"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7813"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1889"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2518"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3225"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2627"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2316"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3384"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1712"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3018"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2883"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2473"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2482"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4429"
+  },
+  "totalHouseholds": {
+    "$numberInt": "17412"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "17412"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020233"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530595"
+  },
+  "adstrdName": "가리봉동",
+  "totalResident": {
+    "$numberInt": "8713"
+  },
+  "maleResident": {
+    "$numberInt": "4797"
+  },
+  "femaleResident": {
+    "$numberInt": "3916"
+  },
+  "age10Resident": {
+    "$numberInt": "403"
+  },
+  "age20Resident": {
+    "$numberInt": "1587"
+  },
+  "age30Resident": {
+    "$numberInt": "1426"
+  },
+  "age40Resident": {
+    "$numberInt": "892"
+  },
+  "age50Resident": {
+    "$numberInt": "1567"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2838"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "222"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "812"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "907"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "517"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "913"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1426"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "181"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "775"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "519"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "375"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "654"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1412"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5988"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5988"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020234"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320690"
+  },
+  "adstrdName": "방학1동",
+  "totalResident": {
+    "$numberInt": "27745"
+  },
+  "maleResident": {
+    "$numberInt": "13722"
+  },
+  "femaleResident": {
+    "$numberInt": "14023"
+  },
+  "age10Resident": {
+    "$numberInt": "3234"
+  },
+  "age20Resident": {
+    "$numberInt": "3491"
+  },
+  "age30Resident": {
+    "$numberInt": "3050"
+  },
+  "age40Resident": {
+    "$numberInt": "3788"
+  },
+  "age50Resident": {
+    "$numberInt": "5097"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9085"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1657"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1718"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1592"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1916"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2548"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4291"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1577"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1773"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1458"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1872"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2549"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4794"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12911"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12911"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020235"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530510"
+  },
+  "adstrdName": "신도림동",
+  "totalResident": {
+    "$numberInt": "35977"
+  },
+  "maleResident": {
+    "$numberInt": "17321"
+  },
+  "femaleResident": {
+    "$numberInt": "18656"
+  },
+  "age10Resident": {
+    "$numberInt": "6560"
+  },
+  "age20Resident": {
+    "$numberInt": "4183"
+  },
+  "age30Resident": {
+    "$numberInt": "5844"
+  },
+  "age40Resident": {
+    "$numberInt": "6488"
+  },
+  "age50Resident": {
+    "$numberInt": "5387"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7515"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3327"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1918"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2724"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3130"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2651"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3571"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3233"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2265"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3120"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3358"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2736"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3944"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14249"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14249"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020236"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215740"
+  },
+  "adstrdName": "중곡1동",
+  "totalResident": {
+    "$numberInt": "15218"
+  },
+  "maleResident": {
+    "$numberInt": "7204"
+  },
+  "femaleResident": {
+    "$numberInt": "8014"
+  },
+  "age10Resident": {
+    "$numberInt": "1230"
+  },
+  "age20Resident": {
+    "$numberInt": "2805"
+  },
+  "age30Resident": {
+    "$numberInt": "3048"
+  },
+  "age40Resident": {
+    "$numberInt": "1945"
+  },
+  "age50Resident": {
+    "$numberInt": "2312"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3878"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "632"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1127"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1502"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1038"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1125"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1780"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "598"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1678"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1546"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "907"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1187"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2098"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8644"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8644"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020237"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170510"
+  },
+  "adstrdName": "후암동",
+  "totalResident": {
+    "$numberInt": "16020"
+  },
+  "maleResident": {
+    "$numberInt": "7744"
+  },
+  "femaleResident": {
+    "$numberInt": "8276"
+  },
+  "age10Resident": {
+    "$numberInt": "1795"
+  },
+  "age20Resident": {
+    "$numberInt": "2223"
+  },
+  "age30Resident": {
+    "$numberInt": "2747"
+  },
+  "age40Resident": {
+    "$numberInt": "2311"
+  },
+  "age50Resident": {
+    "$numberInt": "2626"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4318"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "946"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1085"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1439"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1120"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1287"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1867"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "849"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1138"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1308"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1191"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1339"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2451"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8265"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8265"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020238"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215847"
+  },
+  "adstrdName": "자양4동",
+  "totalResident": {
+    "$numberInt": "19815"
+  },
+  "maleResident": {
+    "$numberInt": "9797"
+  },
+  "femaleResident": {
+    "$numberInt": "10018"
+  },
+  "age10Resident": {
+    "$numberInt": "1688"
+  },
+  "age20Resident": {
+    "$numberInt": "3243"
+  },
+  "age30Resident": {
+    "$numberInt": "3332"
+  },
+  "age40Resident": {
+    "$numberInt": "2560"
+  },
+  "age50Resident": {
+    "$numberInt": "3149"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5843"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "842"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1547"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1748"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1331"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1625"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2704"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "846"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1696"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1584"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1229"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1524"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3139"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10929"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10929"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020239"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590651"
+  },
+  "adstrdName": "사당5동",
+  "totalResident": {
+    "$numberInt": "14118"
+  },
+  "maleResident": {
+    "$numberInt": "6733"
+  },
+  "femaleResident": {
+    "$numberInt": "7385"
+  },
+  "age10Resident": {
+    "$numberInt": "1744"
+  },
+  "age20Resident": {
+    "$numberInt": "1987"
+  },
+  "age30Resident": {
+    "$numberInt": "2508"
+  },
+  "age40Resident": {
+    "$numberInt": "2161"
+  },
+  "age50Resident": {
+    "$numberInt": "2141"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3577"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "892"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "903"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1242"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1096"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1027"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1573"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "852"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1084"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1266"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1065"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1114"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2004"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6685"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6685"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002023a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740640"
+  },
+  "adstrdName": "성내1동",
+  "totalResident": {
+    "$numberInt": "19392"
+  },
+  "maleResident": {
+    "$numberInt": "9277"
+  },
+  "femaleResident": {
+    "$numberInt": "10115"
+  },
+  "age10Resident": {
+    "$numberInt": "2902"
+  },
+  "age20Resident": {
+    "$numberInt": "2484"
+  },
+  "age30Resident": {
+    "$numberInt": "2971"
+  },
+  "age40Resident": {
+    "$numberInt": "3248"
+  },
+  "age50Resident": {
+    "$numberInt": "2960"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4827"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1500"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1192"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1407"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1575"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1406"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2197"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1402"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1292"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1564"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1673"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1554"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2630"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8213"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8213"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002023b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680545"
+  },
+  "adstrdName": "압구정동",
+  "totalResident": {
+    "$numberInt": "26119"
+  },
+  "maleResident": {
+    "$numberInt": "12090"
+  },
+  "femaleResident": {
+    "$numberInt": "14029"
+  },
+  "age10Resident": {
+    "$numberInt": "4614"
+  },
+  "age20Resident": {
+    "$numberInt": "2812"
+  },
+  "age30Resident": {
+    "$numberInt": "2812"
+  },
+  "age40Resident": {
+    "$numberInt": "4414"
+  },
+  "age50Resident": {
+    "$numberInt": "4347"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7120"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2227"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1332"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1202"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2000"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2108"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3221"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2387"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1480"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1610"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2414"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2239"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3899"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10177"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10177"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002023c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560670"
+  },
+  "adstrdName": "신길5동",
+  "totalResident": {
+    "$numberInt": "9947"
+  },
+  "maleResident": {
+    "$numberInt": "4806"
+  },
+  "femaleResident": {
+    "$numberInt": "5141"
+  },
+  "age10Resident": {
+    "$numberInt": "1381"
+  },
+  "age20Resident": {
+    "$numberInt": "1074"
+  },
+  "age30Resident": {
+    "$numberInt": "1328"
+  },
+  "age40Resident": {
+    "$numberInt": "1490"
+  },
+  "age50Resident": {
+    "$numberInt": "1623"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3051"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "691"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "523"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "669"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "771"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "795"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1357"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "690"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "551"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "659"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "719"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "828"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1694"
+  },
+  "totalHouseholds": {
+    "$numberInt": "4562"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "4562"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002023d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140615"
+  },
+  "adstrdName": "신당동",
+  "totalResident": {
+    "$numberInt": "7385"
+  },
+  "maleResident": {
+    "$numberInt": "3600"
+  },
+  "femaleResident": {
+    "$numberInt": "3785"
+  },
+  "age10Resident": {
+    "$numberInt": "462"
+  },
+  "age20Resident": {
+    "$numberInt": "1299"
+  },
+  "age30Resident": {
+    "$numberInt": "1301"
+  },
+  "age40Resident": {
+    "$numberInt": "966"
+  },
+  "age50Resident": {
+    "$numberInt": "1192"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2165"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "208"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "548"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "652"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "511"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "647"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1034"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "254"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "751"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "649"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "455"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "545"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1131"
+  },
+  "totalHouseholds": {
+    "$numberInt": "4680"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "4680"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002023e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170650"
+  },
+  "adstrdName": "이태원1동",
+  "totalResident": {
+    "$numberInt": "6015"
+  },
+  "maleResident": {
+    "$numberInt": "3013"
+  },
+  "femaleResident": {
+    "$numberInt": "3002"
+  },
+  "age10Resident": {
+    "$numberInt": "440"
+  },
+  "age20Resident": {
+    "$numberInt": "862"
+  },
+  "age30Resident": {
+    "$numberInt": "1139"
+  },
+  "age40Resident": {
+    "$numberInt": "785"
+  },
+  "age50Resident": {
+    "$numberInt": "893"
+  },
+  "age60PlusResident": {
+    "$numberInt": "1896"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "220"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "475"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "651"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "411"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "416"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "840"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "220"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "387"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "488"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "374"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "477"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1056"
+  },
+  "totalHouseholds": {
+    "$numberInt": "3435"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "3435"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002023f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200660"
+  },
+  "adstrdName": "성수1가2동",
+  "totalResident": {
+    "$numberInt": "11932"
+  },
+  "maleResident": {
+    "$numberInt": "5820"
+  },
+  "femaleResident": {
+    "$numberInt": "6112"
+  },
+  "age10Resident": {
+    "$numberInt": "1337"
+  },
+  "age20Resident": {
+    "$numberInt": "1762"
+  },
+  "age30Resident": {
+    "$numberInt": "2314"
+  },
+  "age40Resident": {
+    "$numberInt": "1721"
+  },
+  "age50Resident": {
+    "$numberInt": "1844"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2954"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "684"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "847"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1142"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "830"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "931"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1386"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "653"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "915"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1172"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "891"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "913"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1568"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5899"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5899"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020240"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710570"
+  },
+  "adstrdName": "오금동",
+  "totalResident": {
+    "$numberInt": "37341"
+  },
+  "maleResident": {
+    "$numberInt": "18034"
+  },
+  "femaleResident": {
+    "$numberInt": "19307"
+  },
+  "age10Resident": {
+    "$numberInt": "5202"
+  },
+  "age20Resident": {
+    "$numberInt": "4669"
+  },
+  "age30Resident": {
+    "$numberInt": "5043"
+  },
+  "age40Resident": {
+    "$numberInt": "5341"
+  },
+  "age50Resident": {
+    "$numberInt": "6555"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10531"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2719"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2407"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2481"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2576"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3006"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4845"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2483"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2262"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2562"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2765"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3549"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5686"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15582"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15582"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020241"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530760"
+  },
+  "adstrdName": "개봉3동",
+  "totalResident": {
+    "$numberInt": "19544"
+  },
+  "maleResident": {
+    "$numberInt": "9486"
+  },
+  "femaleResident": {
+    "$numberInt": "10058"
+  },
+  "age10Resident": {
+    "$numberInt": "2153"
+  },
+  "age20Resident": {
+    "$numberInt": "2163"
+  },
+  "age30Resident": {
+    "$numberInt": "2439"
+  },
+  "age40Resident": {
+    "$numberInt": "2872"
+  },
+  "age50Resident": {
+    "$numberInt": "3410"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6507"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1071"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1131"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1284"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1464"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1636"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2900"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1082"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1032"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1155"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1408"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1774"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3607"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8664"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8664"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020242"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530780"
+  },
+  "adstrdName": "오류2동",
+  "totalResident": {
+    "$numberInt": "37281"
+  },
+  "maleResident": {
+    "$numberInt": "17771"
+  },
+  "femaleResident": {
+    "$numberInt": "19510"
+  },
+  "age10Resident": {
+    "$numberInt": "6048"
+  },
+  "age20Resident": {
+    "$numberInt": "4179"
+  },
+  "age30Resident": {
+    "$numberInt": "4524"
+  },
+  "age40Resident": {
+    "$numberInt": "5966"
+  },
+  "age50Resident": {
+    "$numberInt": "5977"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10587"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3079"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2074"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2193"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2931"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2847"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4647"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2969"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2105"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2331"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3035"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3130"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5940"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15714"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15714"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020243"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680590"
+  },
+  "adstrdName": "삼성2동",
+  "totalResident": {
+    "$numberInt": "30579"
+  },
+  "maleResident": {
+    "$numberInt": "14671"
+  },
+  "femaleResident": {
+    "$numberInt": "15908"
+  },
+  "age10Resident": {
+    "$numberInt": "5521"
+  },
+  "age20Resident": {
+    "$numberInt": "3838"
+  },
+  "age30Resident": {
+    "$numberInt": "4647"
+  },
+  "age40Resident": {
+    "$numberInt": "6146"
+  },
+  "age50Resident": {
+    "$numberInt": "5012"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5415"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3013"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1795"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2086"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2747"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2550"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2480"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2508"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2043"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2561"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3399"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2462"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2935"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13824"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13824"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020244"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410655"
+  },
+  "adstrdName": "홍제2동",
+  "totalResident": {
+    "$numberInt": "13186"
+  },
+  "maleResident": {
+    "$numberInt": "6166"
+  },
+  "femaleResident": {
+    "$numberInt": "7020"
+  },
+  "age10Resident": {
+    "$numberInt": "1523"
+  },
+  "age20Resident": {
+    "$numberInt": "1559"
+  },
+  "age30Resident": {
+    "$numberInt": "1871"
+  },
+  "age40Resident": {
+    "$numberInt": "1680"
+  },
+  "age50Resident": {
+    "$numberInt": "2414"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4139"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "786"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "740"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "927"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "801"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1119"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1793"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "737"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "819"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "944"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "879"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1295"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2346"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5752"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5752"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020245"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710641"
+  },
+  "adstrdName": "문정1동",
+  "totalResident": {
+    "$numberInt": "19502"
+  },
+  "maleResident": {
+    "$numberInt": "9647"
+  },
+  "femaleResident": {
+    "$numberInt": "9855"
+  },
+  "age10Resident": {
+    "$numberInt": "2438"
+  },
+  "age20Resident": {
+    "$numberInt": "2819"
+  },
+  "age30Resident": {
+    "$numberInt": "3305"
+  },
+  "age40Resident": {
+    "$numberInt": "2734"
+  },
+  "age50Resident": {
+    "$numberInt": "3098"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5108"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1269"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1413"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1696"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1389"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1433"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2447"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1169"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1406"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1609"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1345"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1665"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2661"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8497"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8497"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020246"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440660"
+  },
+  "adstrdName": "서교동",
+  "totalResident": {
+    "$numberInt": "24037"
+  },
+  "maleResident": {
+    "$numberInt": "10999"
+  },
+  "femaleResident": {
+    "$numberInt": "13038"
+  },
+  "age10Resident": {
+    "$numberInt": "1635"
+  },
+  "age20Resident": {
+    "$numberInt": "5914"
+  },
+  "age30Resident": {
+    "$numberInt": "5368"
+  },
+  "age40Resident": {
+    "$numberInt": "3403"
+  },
+  "age50Resident": {
+    "$numberInt": "3103"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4614"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "801"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2535"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2555"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1610"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1482"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2016"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "834"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3379"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2813"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1793"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1621"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2598"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15244"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15244"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020247"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200720"
+  },
+  "adstrdName": "송정동",
+  "totalResident": {
+    "$numberInt": "9719"
+  },
+  "maleResident": {
+    "$numberInt": "5095"
+  },
+  "femaleResident": {
+    "$numberInt": "4624"
+  },
+  "age10Resident": {
+    "$numberInt": "857"
+  },
+  "age20Resident": {
+    "$numberInt": "1443"
+  },
+  "age30Resident": {
+    "$numberInt": "1547"
+  },
+  "age40Resident": {
+    "$numberInt": "1314"
+  },
+  "age50Resident": {
+    "$numberInt": "1704"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2854"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "465"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "712"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "854"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "731"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "911"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1422"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "392"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "731"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "693"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "583"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "793"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1432"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5365"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5365"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020248"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230600"
+  },
+  "adstrdName": "답십리1동",
+  "totalResident": {
+    "$numberInt": "27834"
+  },
+  "maleResident": {
+    "$numberInt": "13376"
+  },
+  "femaleResident": {
+    "$numberInt": "14458"
+  },
+  "age10Resident": {
+    "$numberInt": "4184"
+  },
+  "age20Resident": {
+    "$numberInt": "3822"
+  },
+  "age30Resident": {
+    "$numberInt": "4851"
+  },
+  "age40Resident": {
+    "$numberInt": "4651"
+  },
+  "age50Resident": {
+    "$numberInt": "4043"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6283"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2126"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1689"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2278"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2374"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2005"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2904"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2058"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2133"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2573"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2277"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2038"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3379"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12866"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12866"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020249"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200645"
+  },
+  "adstrdName": "옥수동",
+  "totalResident": {
+    "$numberInt": "25399"
+  },
+  "maleResident": {
+    "$numberInt": "11775"
+  },
+  "femaleResident": {
+    "$numberInt": "13624"
+  },
+  "age10Resident": {
+    "$numberInt": "3895"
+  },
+  "age20Resident": {
+    "$numberInt": "2444"
+  },
+  "age30Resident": {
+    "$numberInt": "4547"
+  },
+  "age40Resident": {
+    "$numberInt": "4429"
+  },
+  "age50Resident": {
+    "$numberInt": "3813"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6271"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1930"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1143"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2043"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2163"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1787"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2709"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1965"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1301"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2504"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2266"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2026"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3562"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10753"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10753"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002024a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650660"
+  },
+  "adstrdName": "내곡동",
+  "totalResident": {
+    "$numberInt": "17000"
+  },
+  "maleResident": {
+    "$numberInt": "8222"
+  },
+  "femaleResident": {
+    "$numberInt": "8778"
+  },
+  "age10Resident": {
+    "$numberInt": "2978"
+  },
+  "age20Resident": {
+    "$numberInt": "1636"
+  },
+  "age30Resident": {
+    "$numberInt": "2294"
+  },
+  "age40Resident": {
+    "$numberInt": "2922"
+  },
+  "age50Resident": {
+    "$numberInt": "2424"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4746"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1530"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "839"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1070"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1447"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1169"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2167"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1448"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "797"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1224"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1475"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1255"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2579"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7047"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7047"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002024b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530750"
+  },
+  "adstrdName": "개봉2동",
+  "totalResident": {
+    "$numberInt": "29724"
+  },
+  "maleResident": {
+    "$numberInt": "14398"
+  },
+  "femaleResident": {
+    "$numberInt": "15326"
+  },
+  "age10Resident": {
+    "$numberInt": "3680"
+  },
+  "age20Resident": {
+    "$numberInt": "3251"
+  },
+  "age30Resident": {
+    "$numberInt": "3930"
+  },
+  "age40Resident": {
+    "$numberInt": "4387"
+  },
+  "age50Resident": {
+    "$numberInt": "4747"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9729"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1864"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1598"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1963"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2241"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2295"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4437"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1816"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1653"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1967"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2146"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2452"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5292"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12314"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12314"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002024c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230660"
+  },
+  "adstrdName": "장안2동",
+  "totalResident": {
+    "$numberInt": "32376"
+  },
+  "maleResident": {
+    "$numberInt": "16042"
+  },
+  "femaleResident": {
+    "$numberInt": "16334"
+  },
+  "age10Resident": {
+    "$numberInt": "5322"
+  },
+  "age20Resident": {
+    "$numberInt": "3614"
+  },
+  "age30Resident": {
+    "$numberInt": "4637"
+  },
+  "age40Resident": {
+    "$numberInt": "5737"
+  },
+  "age50Resident": {
+    "$numberInt": "5003"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8063"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2817"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1806"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2321"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2898"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2502"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3698"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2505"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1808"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2316"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2839"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2501"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4365"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14170"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14170"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002024d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650540"
+  },
+  "adstrdName": "잠원동",
+  "totalResident": {
+    "$numberInt": "26800"
+  },
+  "maleResident": {
+    "$numberInt": "12898"
+  },
+  "femaleResident": {
+    "$numberInt": "13902"
+  },
+  "age10Resident": {
+    "$numberInt": "5125"
+  },
+  "age20Resident": {
+    "$numberInt": "3295"
+  },
+  "age30Resident": {
+    "$numberInt": "3328"
+  },
+  "age40Resident": {
+    "$numberInt": "4910"
+  },
+  "age50Resident": {
+    "$numberInt": "4879"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5263"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2649"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1648"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1503"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2236"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2437"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2425"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2476"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1647"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1825"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2674"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2442"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2838"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10729"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10729"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002024e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380632"
+  },
+  "adstrdName": "신사2동",
+  "totalResident": {
+    "$numberInt": "18907"
+  },
+  "maleResident": {
+    "$numberInt": "9370"
+  },
+  "femaleResident": {
+    "$numberInt": "9537"
+  },
+  "age10Resident": {
+    "$numberInt": "2190"
+  },
+  "age20Resident": {
+    "$numberInt": "2440"
+  },
+  "age30Resident": {
+    "$numberInt": "2592"
+  },
+  "age40Resident": {
+    "$numberInt": "2704"
+  },
+  "age50Resident": {
+    "$numberInt": "3220"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5761"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1191"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1269"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1334"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1379"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1573"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2624"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "999"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1171"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1258"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1325"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1647"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3137"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8700"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8700"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002024f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710566"
+  },
+  "adstrdName": "오륜동",
+  "totalResident": {
+    "$numberInt": "17799"
+  },
+  "maleResident": {
+    "$numberInt": "8725"
+  },
+  "femaleResident": {
+    "$numberInt": "9074"
+  },
+  "age10Resident": {
+    "$numberInt": "3619"
+  },
+  "age20Resident": {
+    "$numberInt": "1925"
+  },
+  "age30Resident": {
+    "$numberInt": "1601"
+  },
+  "age40Resident": {
+    "$numberInt": "3036"
+  },
+  "age50Resident": {
+    "$numberInt": "3015"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4603"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1962"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1032"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "698"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1341"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1469"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2223"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1657"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "893"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "903"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1695"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1546"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2380"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5896"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5896"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020250"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350700"
+  },
+  "adstrdName": "상계8동",
+  "totalResident": {
+    "$numberInt": "21848"
+  },
+  "maleResident": {
+    "$numberInt": "10388"
+  },
+  "femaleResident": {
+    "$numberInt": "11460"
+  },
+  "age10Resident": {
+    "$numberInt": "3644"
+  },
+  "age20Resident": {
+    "$numberInt": "2362"
+  },
+  "age30Resident": {
+    "$numberInt": "4739"
+  },
+  "age40Resident": {
+    "$numberInt": "3591"
+  },
+  "age50Resident": {
+    "$numberInt": "3102"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4410"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1839"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1172"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2348"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1737"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1452"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1840"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1805"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1190"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2391"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1854"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1650"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2570"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9129"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9129"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020251"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320522"
+  },
+  "adstrdName": "도봉2동",
+  "totalResident": {
+    "$numberInt": "25990"
+  },
+  "maleResident": {
+    "$numberInt": "12683"
+  },
+  "femaleResident": {
+    "$numberInt": "13307"
+  },
+  "age10Resident": {
+    "$numberInt": "2824"
+  },
+  "age20Resident": {
+    "$numberInt": "2705"
+  },
+  "age30Resident": {
+    "$numberInt": "3335"
+  },
+  "age40Resident": {
+    "$numberInt": "3398"
+  },
+  "age50Resident": {
+    "$numberInt": "4204"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9524"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1447"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1384"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1689"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1779"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2024"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4360"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1377"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1321"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1646"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1619"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2180"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5164"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11766"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11766"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020252"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350720"
+  },
+  "adstrdName": "상계10동",
+  "totalResident": {
+    "$numberInt": "18184"
+  },
+  "maleResident": {
+    "$numberInt": "8356"
+  },
+  "femaleResident": {
+    "$numberInt": "9828"
+  },
+  "age10Resident": {
+    "$numberInt": "2697"
+  },
+  "age20Resident": {
+    "$numberInt": "2279"
+  },
+  "age30Resident": {
+    "$numberInt": "2871"
+  },
+  "age40Resident": {
+    "$numberInt": "2783"
+  },
+  "age50Resident": {
+    "$numberInt": "3188"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4366"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1366"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1065"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1371"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1291"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1420"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1843"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1331"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1214"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1500"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1492"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1768"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2523"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7648"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7648"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020253"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305555"
+  },
+  "adstrdName": "송천동",
+  "totalResident": {
+    "$numberInt": "24748"
+  },
+  "maleResident": {
+    "$numberInt": "12287"
+  },
+  "femaleResident": {
+    "$numberInt": "12461"
+  },
+  "age10Resident": {
+    "$numberInt": "2087"
+  },
+  "age20Resident": {
+    "$numberInt": "2986"
+  },
+  "age30Resident": {
+    "$numberInt": "2909"
+  },
+  "age40Resident": {
+    "$numberInt": "3147"
+  },
+  "age50Resident": {
+    "$numberInt": "4586"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9033"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1058"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1508"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1572"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1654"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2327"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4168"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1029"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1478"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1337"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1493"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2259"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4865"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13030"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13030"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020254"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410640"
+  },
+  "adstrdName": "홍제3동",
+  "totalResident": {
+    "$numberInt": "17665"
+  },
+  "maleResident": {
+    "$numberInt": "8453"
+  },
+  "femaleResident": {
+    "$numberInt": "9212"
+  },
+  "age10Resident": {
+    "$numberInt": "2103"
+  },
+  "age20Resident": {
+    "$numberInt": "2224"
+  },
+  "age30Resident": {
+    "$numberInt": "2424"
+  },
+  "age40Resident": {
+    "$numberInt": "2312"
+  },
+  "age50Resident": {
+    "$numberInt": "3090"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5512"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1077"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1108"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1198"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1173"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1508"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2389"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1026"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1116"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1226"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1139"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1582"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3123"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7996"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7996"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020255"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620735"
+  },
+  "adstrdName": "대학동",
+  "totalResident": {
+    "$numberInt": "24237"
+  },
+  "maleResident": {
+    "$numberInt": "14808"
+  },
+  "femaleResident": {
+    "$numberInt": "9429"
+  },
+  "age10Resident": {
+    "$numberInt": "1459"
+  },
+  "age20Resident": {
+    "$numberInt": "6378"
+  },
+  "age30Resident": {
+    "$numberInt": "5009"
+  },
+  "age40Resident": {
+    "$numberInt": "3401"
+  },
+  "age50Resident": {
+    "$numberInt": "3295"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4695"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "752"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3815"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3441"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2293"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2154"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2353"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "707"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2563"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1568"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1108"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1141"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2342"
+  },
+  "totalHouseholds": {
+    "$numberInt": "17409"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "17409"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020256"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710550"
+  },
+  "adstrdName": "마천2동",
+  "totalResident": {
+    "$numberInt": "17575"
+  },
+  "maleResident": {
+    "$numberInt": "8982"
+  },
+  "femaleResident": {
+    "$numberInt": "8593"
+  },
+  "age10Resident": {
+    "$numberInt": "1634"
+  },
+  "age20Resident": {
+    "$numberInt": "2032"
+  },
+  "age30Resident": {
+    "$numberInt": "1978"
+  },
+  "age40Resident": {
+    "$numberInt": "2304"
+  },
+  "age50Resident": {
+    "$numberInt": "3268"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6359"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "835"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1135"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1114"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1238"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1651"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3009"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "799"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "897"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "864"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1066"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1617"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3350"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8507"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8507"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020257"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710600"
+  },
+  "adstrdName": "석촌동",
+  "totalResident": {
+    "$numberInt": "30682"
+  },
+  "maleResident": {
+    "$numberInt": "14536"
+  },
+  "femaleResident": {
+    "$numberInt": "16146"
+  },
+  "age10Resident": {
+    "$numberInt": "2809"
+  },
+  "age20Resident": {
+    "$numberInt": "5023"
+  },
+  "age30Resident": {
+    "$numberInt": "6745"
+  },
+  "age40Resident": {
+    "$numberInt": "4605"
+  },
+  "age50Resident": {
+    "$numberInt": "4370"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7130"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1419"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2187"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3287"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2285"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2098"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3260"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1390"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2836"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3458"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2320"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2272"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3870"
+  },
+  "totalHouseholds": {
+    "$numberInt": "16996"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "16996"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020258"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650600"
+  },
+  "adstrdName": "방배1동",
+  "totalResident": {
+    "$numberInt": "16479"
+  },
+  "maleResident": {
+    "$numberInt": "7678"
+  },
+  "femaleResident": {
+    "$numberInt": "8801"
+  },
+  "age10Resident": {
+    "$numberInt": "2228"
+  },
+  "age20Resident": {
+    "$numberInt": "2161"
+  },
+  "age30Resident": {
+    "$numberInt": "2666"
+  },
+  "age40Resident": {
+    "$numberInt": "2736"
+  },
+  "age50Resident": {
+    "$numberInt": "2463"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4225"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1150"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1028"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1218"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1238"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1139"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1905"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1078"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1133"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1448"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1498"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1324"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2320"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7461"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7461"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020259"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620645"
+  },
+  "adstrdName": "서원동",
+  "totalResident": {
+    "$numberInt": "22908"
+  },
+  "maleResident": {
+    "$numberInt": "12012"
+  },
+  "femaleResident": {
+    "$numberInt": "10896"
+  },
+  "age10Resident": {
+    "$numberInt": "1251"
+  },
+  "age20Resident": {
+    "$numberInt": "6434"
+  },
+  "age30Resident": {
+    "$numberInt": "5015"
+  },
+  "age40Resident": {
+    "$numberInt": "2651"
+  },
+  "age50Resident": {
+    "$numberInt": "2699"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4858"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "661"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3288"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3009"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1511"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1321"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2222"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "590"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3146"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2006"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1140"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1378"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2636"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15098"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15098"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002025a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620665"
+  },
+  "adstrdName": "서림동",
+  "totalResident": {
+    "$numberInt": "23319"
+  },
+  "maleResident": {
+    "$numberInt": "12975"
+  },
+  "femaleResident": {
+    "$numberInt": "10344"
+  },
+  "age10Resident": {
+    "$numberInt": "1537"
+  },
+  "age20Resident": {
+    "$numberInt": "5561"
+  },
+  "age30Resident": {
+    "$numberInt": "4791"
+  },
+  "age40Resident": {
+    "$numberInt": "3106"
+  },
+  "age50Resident": {
+    "$numberInt": "2996"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5328"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "783"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3141"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3018"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1882"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1636"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2515"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "754"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2420"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1773"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1224"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1360"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2813"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15153"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15153"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002025b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260600"
+  },
+  "adstrdName": "중화1동",
+  "totalResident": {
+    "$numberInt": "18698"
+  },
+  "maleResident": {
+    "$numberInt": "9211"
+  },
+  "femaleResident": {
+    "$numberInt": "9487"
+  },
+  "age10Resident": {
+    "$numberInt": "2064"
+  },
+  "age20Resident": {
+    "$numberInt": "2332"
+  },
+  "age30Resident": {
+    "$numberInt": "2956"
+  },
+  "age40Resident": {
+    "$numberInt": "2591"
+  },
+  "age50Resident": {
+    "$numberInt": "3007"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5748"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1042"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1146"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1536"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1390"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1439"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2658"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1022"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1186"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1420"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1201"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1568"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3090"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8901"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8901"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002025c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680640"
+  },
+  "adstrdName": "역삼1동",
+  "totalResident": {
+    "$numberInt": "34082"
+  },
+  "maleResident": {
+    "$numberInt": "16650"
+  },
+  "femaleResident": {
+    "$numberInt": "17432"
+  },
+  "age10Resident": {
+    "$numberInt": "2143"
+  },
+  "age20Resident": {
+    "$numberInt": "6658"
+  },
+  "age30Resident": {
+    "$numberInt": "9612"
+  },
+  "age40Resident": {
+    "$numberInt": "6069"
+  },
+  "age50Resident": {
+    "$numberInt": "4191"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5409"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1080"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2810"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "4834"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3106"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2237"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2583"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1063"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3848"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "4778"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2963"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1954"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2826"
+  },
+  "totalHouseholds": {
+    "$numberInt": "23535"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "23535"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002025d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260655"
+  },
+  "adstrdName": "망우본동",
+  "totalResident": {
+    "$numberInt": "36438"
+  },
+  "maleResident": {
+    "$numberInt": "17968"
+  },
+  "femaleResident": {
+    "$numberInt": "18470"
+  },
+  "age10Resident": {
+    "$numberInt": "4656"
+  },
+  "age20Resident": {
+    "$numberInt": "4442"
+  },
+  "age30Resident": {
+    "$numberInt": "6133"
+  },
+  "age40Resident": {
+    "$numberInt": "5059"
+  },
+  "age50Resident": {
+    "$numberInt": "5632"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10516"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2315"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2037"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3128"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2666"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2835"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4987"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2341"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2405"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3005"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2393"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2797"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5529"
+  },
+  "totalHouseholds": {
+    "$numberInt": "18113"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "18113"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002025e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380520"
+  },
+  "adstrdName": "불광1동",
+  "totalResident": {
+    "$numberInt": "37509"
+  },
+  "maleResident": {
+    "$numberInt": "17625"
+  },
+  "femaleResident": {
+    "$numberInt": "19884"
+  },
+  "age10Resident": {
+    "$numberInt": "4225"
+  },
+  "age20Resident": {
+    "$numberInt": "4651"
+  },
+  "age30Resident": {
+    "$numberInt": "5222"
+  },
+  "age40Resident": {
+    "$numberInt": "5340"
+  },
+  "age50Resident": {
+    "$numberInt": "6443"
+  },
+  "age60PlusResident": {
+    "$numberInt": "11628"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2198"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2193"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2571"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2609"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3033"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "5021"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2027"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2458"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2651"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2731"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3410"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "6607"
+  },
+  "totalHouseholds": {
+    "$numberInt": "17726"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "17726"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002025f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710561"
+  },
+  "adstrdName": "방이1동",
+  "totalResident": {
+    "$numberInt": "15091"
+  },
+  "maleResident": {
+    "$numberInt": "7264"
+  },
+  "femaleResident": {
+    "$numberInt": "7827"
+  },
+  "age10Resident": {
+    "$numberInt": "2333"
+  },
+  "age20Resident": {
+    "$numberInt": "2083"
+  },
+  "age30Resident": {
+    "$numberInt": "2125"
+  },
+  "age40Resident": {
+    "$numberInt": "2358"
+  },
+  "age50Resident": {
+    "$numberInt": "2580"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3612"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1158"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1043"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1064"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1096"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1206"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1697"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1175"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1040"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1061"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1262"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1374"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1915"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6092"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6092"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020260"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470600"
+  },
+  "adstrdName": "신월5동",
+  "totalResident": {
+    "$numberInt": "13979"
+  },
+  "maleResident": {
+    "$numberInt": "6915"
+  },
+  "femaleResident": {
+    "$numberInt": "7064"
+  },
+  "age10Resident": {
+    "$numberInt": "1821"
+  },
+  "age20Resident": {
+    "$numberInt": "1815"
+  },
+  "age30Resident": {
+    "$numberInt": "1906"
+  },
+  "age40Resident": {
+    "$numberInt": "2083"
+  },
+  "age50Resident": {
+    "$numberInt": "2344"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4010"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "958"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "900"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1031"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1043"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1134"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1849"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "863"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "915"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "875"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1040"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1210"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2161"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6352"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6352"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020261"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560710"
+  },
+  "adstrdName": "대림2동",
+  "totalResident": {
+    "$numberInt": "11730"
+  },
+  "maleResident": {
+    "$numberInt": "5740"
+  },
+  "femaleResident": {
+    "$numberInt": "5990"
+  },
+  "age10Resident": {
+    "$numberInt": "829"
+  },
+  "age20Resident": {
+    "$numberInt": "1815"
+  },
+  "age30Resident": {
+    "$numberInt": "1841"
+  },
+  "age40Resident": {
+    "$numberInt": "1392"
+  },
+  "age50Resident": {
+    "$numberInt": "1933"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3920"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "414"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "895"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "987"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "743"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "979"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1722"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "415"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "920"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "854"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "649"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "954"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2198"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6886"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6886"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020262"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680690"
+  },
+  "adstrdName": "개포4동",
+  "totalResident": {
+    "$numberInt": "23151"
+  },
+  "maleResident": {
+    "$numberInt": "11149"
+  },
+  "femaleResident": {
+    "$numberInt": "12002"
+  },
+  "age10Resident": {
+    "$numberInt": "3687"
+  },
+  "age20Resident": {
+    "$numberInt": "2869"
+  },
+  "age30Resident": {
+    "$numberInt": "3580"
+  },
+  "age40Resident": {
+    "$numberInt": "3762"
+  },
+  "age50Resident": {
+    "$numberInt": "3942"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5311"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1824"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1445"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1725"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1797"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1880"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2478"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1863"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1424"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1855"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1965"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2062"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2833"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10010"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10010"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020263"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215770"
+  },
+  "adstrdName": "중곡4동",
+  "totalResident": {
+    "$numberInt": "27499"
+  },
+  "maleResident": {
+    "$numberInt": "13389"
+  },
+  "femaleResident": {
+    "$numberInt": "14110"
+  },
+  "age10Resident": {
+    "$numberInt": "2662"
+  },
+  "age20Resident": {
+    "$numberInt": "3932"
+  },
+  "age30Resident": {
+    "$numberInt": "4025"
+  },
+  "age40Resident": {
+    "$numberInt": "3552"
+  },
+  "age50Resident": {
+    "$numberInt": "5090"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8238"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1386"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1967"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2097"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1782"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2372"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3785"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1276"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1965"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1928"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1770"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2718"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4453"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13022"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13022"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020264"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500540"
+  },
+  "adstrdName": "화곡1동",
+  "totalResident": {
+    "$numberInt": "50743"
+  },
+  "maleResident": {
+    "$numberInt": "24632"
+  },
+  "femaleResident": {
+    "$numberInt": "26111"
+  },
+  "age10Resident": {
+    "$numberInt": "4171"
+  },
+  "age20Resident": {
+    "$numberInt": "8918"
+  },
+  "age30Resident": {
+    "$numberInt": "10251"
+  },
+  "age40Resident": {
+    "$numberInt": "7286"
+  },
+  "age50Resident": {
+    "$numberInt": "7176"
+  },
+  "age60PlusResident": {
+    "$numberInt": "12941"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2107"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3937"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "5501"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3794"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3489"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "5804"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2064"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "4981"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "4750"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3492"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3687"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "7137"
+  },
+  "totalHouseholds": {
+    "$numberInt": "28118"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "28118"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020265"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110515"
+  },
+  "adstrdName": "청운효자동",
+  "totalResident": {
+    "$numberInt": "11328"
+  },
+  "maleResident": {
+    "$numberInt": "5174"
+  },
+  "femaleResident": {
+    "$numberInt": "6154"
+  },
+  "age10Resident": {
+    "$numberInt": "1676"
+  },
+  "age20Resident": {
+    "$numberInt": "1401"
+  },
+  "age30Resident": {
+    "$numberInt": "1510"
+  },
+  "age40Resident": {
+    "$numberInt": "1884"
+  },
+  "age50Resident": {
+    "$numberInt": "1911"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2946"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "865"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "685"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "676"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "823"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "867"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1258"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "811"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "716"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "834"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1061"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1044"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1688"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5040"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5040"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020266"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110690"
+  },
+  "adstrdName": "창신3동",
+  "totalResident": {
+    "$numberInt": "6338"
+  },
+  "maleResident": {
+    "$numberInt": "3119"
+  },
+  "femaleResident": {
+    "$numberInt": "3219"
+  },
+  "age10Resident": {
+    "$numberInt": "706"
+  },
+  "age20Resident": {
+    "$numberInt": "826"
+  },
+  "age30Resident": {
+    "$numberInt": "903"
+  },
+  "age40Resident": {
+    "$numberInt": "799"
+  },
+  "age50Resident": {
+    "$numberInt": "1177"
+  },
+  "age60PlusResident": {
+    "$numberInt": "1927"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "366"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "430"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "457"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "403"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "570"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "893"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "340"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "396"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "446"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "396"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "607"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1034"
+  },
+  "totalHouseholds": {
+    "$numberInt": "2767"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "2767"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020267"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560540"
+  },
+  "adstrdName": "여의동",
+  "totalResident": {
+    "$numberInt": "33346"
+  },
+  "maleResident": {
+    "$numberInt": "15644"
+  },
+  "femaleResident": {
+    "$numberInt": "17702"
+  },
+  "age10Resident": {
+    "$numberInt": "5267"
+  },
+  "age20Resident": {
+    "$numberInt": "3636"
+  },
+  "age30Resident": {
+    "$numberInt": "4891"
+  },
+  "age40Resident": {
+    "$numberInt": "5320"
+  },
+  "age50Resident": {
+    "$numberInt": "5307"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8925"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2653"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1669"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2225"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2487"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2546"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4064"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2614"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1967"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2666"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2833"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2761"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4861"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13895"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13895"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020268"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530530"
+  },
+  "adstrdName": "구로2동",
+  "totalResident": {
+    "$numberInt": "22380"
+  },
+  "maleResident": {
+    "$numberInt": "11215"
+  },
+  "femaleResident": {
+    "$numberInt": "11165"
+  },
+  "age10Resident": {
+    "$numberInt": "1783"
+  },
+  "age20Resident": {
+    "$numberInt": "2819"
+  },
+  "age30Resident": {
+    "$numberInt": "2668"
+  },
+  "age40Resident": {
+    "$numberInt": "2758"
+  },
+  "age50Resident": {
+    "$numberInt": "4223"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8129"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "906"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1417"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1492"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1479"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2190"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3731"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "877"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1402"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1176"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1279"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2033"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4398"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12099"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12099"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020269"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680521"
+  },
+  "adstrdName": "논현1동",
+  "totalResident": {
+    "$numberInt": "20996"
+  },
+  "maleResident": {
+    "$numberInt": "9908"
+  },
+  "femaleResident": {
+    "$numberInt": "11088"
+  },
+  "age10Resident": {
+    "$numberInt": "1371"
+  },
+  "age20Resident": {
+    "$numberInt": "3852"
+  },
+  "age30Resident": {
+    "$numberInt": "5204"
+  },
+  "age40Resident": {
+    "$numberInt": "3624"
+  },
+  "age50Resident": {
+    "$numberInt": "2772"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4173"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "675"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1714"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2576"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1695"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1366"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1882"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "696"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2138"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2628"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1929"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1406"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2291"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13524"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13524"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002026a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680730"
+  },
+  "adstrdName": "일원1동",
+  "totalResident": {
+    "$numberInt": "14550"
+  },
+  "maleResident": {
+    "$numberInt": "7048"
+  },
+  "femaleResident": {
+    "$numberInt": "7502"
+  },
+  "age10Resident": {
+    "$numberInt": "1576"
+  },
+  "age20Resident": {
+    "$numberInt": "1946"
+  },
+  "age30Resident": {
+    "$numberInt": "2115"
+  },
+  "age40Resident": {
+    "$numberInt": "2008"
+  },
+  "age50Resident": {
+    "$numberInt": "2140"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4765"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "858"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "954"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1080"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1058"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1028"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2070"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "718"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "992"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1035"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "950"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1112"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2695"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7432"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7432"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002026b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500630"
+  },
+  "adstrdName": "방화1동",
+  "totalResident": {
+    "$numberInt": "41828"
+  },
+  "maleResident": {
+    "$numberInt": "20397"
+  },
+  "femaleResident": {
+    "$numberInt": "21431"
+  },
+  "age10Resident": {
+    "$numberInt": "7374"
+  },
+  "age20Resident": {
+    "$numberInt": "4497"
+  },
+  "age30Resident": {
+    "$numberInt": "5808"
+  },
+  "age40Resident": {
+    "$numberInt": "7134"
+  },
+  "age50Resident": {
+    "$numberInt": "6376"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10639"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3681"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2218"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2826"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3561"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3204"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4907"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3693"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2279"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2982"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3573"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3172"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5732"
+  },
+  "totalHouseholds": {
+    "$numberInt": "17118"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "17118"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002026c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200615"
+  },
+  "adstrdName": "금호2?3가동",
+  "totalResident": {
+    "$numberInt": "21946"
+  },
+  "maleResident": {
+    "$numberInt": "10443"
+  },
+  "femaleResident": {
+    "$numberInt": "11503"
+  },
+  "age10Resident": {
+    "$numberInt": "2829"
+  },
+  "age20Resident": {
+    "$numberInt": "2463"
+  },
+  "age30Resident": {
+    "$numberInt": "3779"
+  },
+  "age40Resident": {
+    "$numberInt": "3570"
+  },
+  "age50Resident": {
+    "$numberInt": "3530"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5775"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1450"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1223"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1831"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1765"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1676"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2498"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1379"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1240"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1948"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1805"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1854"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3277"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9888"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9888"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002026d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140550"
+  },
+  "adstrdName": "명동",
+  "totalResident": {
+    "$numberInt": "2392"
+  },
+  "maleResident": {
+    "$numberInt": "988"
+  },
+  "femaleResident": {
+    "$numberInt": "1404"
+  },
+  "age10Resident": {
+    "$numberInt": "162"
+  },
+  "age20Resident": {
+    "$numberInt": "233"
+  },
+  "age30Resident": {
+    "$numberInt": "286"
+  },
+  "age40Resident": {
+    "$numberInt": "339"
+  },
+  "age50Resident": {
+    "$numberInt": "437"
+  },
+  "age60PlusResident": {
+    "$numberInt": "935"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "83"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "102"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "141"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "139"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "187"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "336"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "79"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "131"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "145"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "200"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "250"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "599"
+  },
+  "totalHouseholds": {
+    "$numberInt": "1191"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "1191"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002026e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470590"
+  },
+  "adstrdName": "신월4동",
+  "totalResident": {
+    "$numberInt": "17445"
+  },
+  "maleResident": {
+    "$numberInt": "8478"
+  },
+  "femaleResident": {
+    "$numberInt": "8967"
+  },
+  "age10Resident": {
+    "$numberInt": "2650"
+  },
+  "age20Resident": {
+    "$numberInt": "1940"
+  },
+  "age30Resident": {
+    "$numberInt": "2047"
+  },
+  "age40Resident": {
+    "$numberInt": "2818"
+  },
+  "age50Resident": {
+    "$numberInt": "2796"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5194"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1353"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1035"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1017"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1420"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1316"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2337"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1297"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "905"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1030"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1398"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1480"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2857"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6839"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6839"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002026f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230545"
+  },
+  "adstrdName": "제기동",
+  "totalResident": {
+    "$numberInt": "22962"
+  },
+  "maleResident": {
+    "$numberInt": "11776"
+  },
+  "femaleResident": {
+    "$numberInt": "11186"
+  },
+  "age10Resident": {
+    "$numberInt": "1961"
+  },
+  "age20Resident": {
+    "$numberInt": "4356"
+  },
+  "age30Resident": {
+    "$numberInt": "2975"
+  },
+  "age40Resident": {
+    "$numberInt": "2601"
+  },
+  "age50Resident": {
+    "$numberInt": "3464"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7605"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1013"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2305"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1676"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1434"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1851"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3497"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "948"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2051"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1299"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1167"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1613"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4108"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12981"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12981"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020270"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380551"
+  },
+  "adstrdName": "갈현1동",
+  "totalResident": {
+    "$numberInt": "14470"
+  },
+  "maleResident": {
+    "$numberInt": "7022"
+  },
+  "femaleResident": {
+    "$numberInt": "7448"
+  },
+  "age10Resident": {
+    "$numberInt": "1417"
+  },
+  "age20Resident": {
+    "$numberInt": "2099"
+  },
+  "age30Resident": {
+    "$numberInt": "2044"
+  },
+  "age40Resident": {
+    "$numberInt": "1968"
+  },
+  "age50Resident": {
+    "$numberInt": "2507"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4435"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "780"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1002"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1088"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "993"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1198"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1961"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "637"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1097"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "956"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "975"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1309"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2474"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7340"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7340"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020271"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260550"
+  },
+  "adstrdName": "면목5동",
+  "totalResident": {
+    "$numberInt": "14564"
+  },
+  "maleResident": {
+    "$numberInt": "7254"
+  },
+  "femaleResident": {
+    "$numberInt": "7310"
+  },
+  "age10Resident": {
+    "$numberInt": "2166"
+  },
+  "age20Resident": {
+    "$numberInt": "1503"
+  },
+  "age30Resident": {
+    "$numberInt": "2461"
+  },
+  "age40Resident": {
+    "$numberInt": "2370"
+  },
+  "age50Resident": {
+    "$numberInt": "2359"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3705"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1092"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "770"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1239"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1261"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1172"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1720"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1074"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "733"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1222"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1109"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1187"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1985"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6400"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6400"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020272"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11620725"
+  },
+  "adstrdName": "조원동",
+  "totalResident": {
+    "$numberInt": "19598"
+  },
+  "maleResident": {
+    "$numberInt": "9785"
+  },
+  "femaleResident": {
+    "$numberInt": "9813"
+  },
+  "age10Resident": {
+    "$numberInt": "1498"
+  },
+  "age20Resident": {
+    "$numberInt": "4367"
+  },
+  "age30Resident": {
+    "$numberInt": "4401"
+  },
+  "age40Resident": {
+    "$numberInt": "2410"
+  },
+  "age50Resident": {
+    "$numberInt": "2461"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4461"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "760"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1921"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2348"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1302"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1299"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2155"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "738"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2446"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2053"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1108"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1162"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2306"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12203"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12203"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020273"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500611"
+  },
+  "adstrdName": "발산1동",
+  "totalResident": {
+    "$numberInt": "35643"
+  },
+  "maleResident": {
+    "$numberInt": "16815"
+  },
+  "femaleResident": {
+    "$numberInt": "18828"
+  },
+  "age10Resident": {
+    "$numberInt": "7192"
+  },
+  "age20Resident": {
+    "$numberInt": "4277"
+  },
+  "age30Resident": {
+    "$numberInt": "3772"
+  },
+  "age40Resident": {
+    "$numberInt": "6448"
+  },
+  "age50Resident": {
+    "$numberInt": "6052"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7902"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3577"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2108"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1789"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3013"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2922"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3406"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3615"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2169"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1983"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3435"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3130"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4496"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13557"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13557"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020274"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140590"
+  },
+  "adstrdName": "광희동",
+  "totalResident": {
+    "$numberInt": "5676"
+  },
+  "maleResident": {
+    "$numberInt": "2808"
+  },
+  "femaleResident": {
+    "$numberInt": "2868"
+  },
+  "age10Resident": {
+    "$numberInt": "307"
+  },
+  "age20Resident": {
+    "$numberInt": "1154"
+  },
+  "age30Resident": {
+    "$numberInt": "1222"
+  },
+  "age40Resident": {
+    "$numberInt": "673"
+  },
+  "age50Resident": {
+    "$numberInt": "758"
+  },
+  "age60PlusResident": {
+    "$numberInt": "1562"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "159"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "454"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "650"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "345"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "416"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "784"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "148"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "700"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "572"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "328"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "342"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "778"
+  },
+  "totalHouseholds": {
+    "$numberInt": "3859"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "3859"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020275"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290600"
+  },
+  "adstrdName": "안암동",
+  "totalResident": {
+    "$numberInt": "14869"
+  },
+  "maleResident": {
+    "$numberInt": "7492"
+  },
+  "femaleResident": {
+    "$numberInt": "7377"
+  },
+  "age10Resident": {
+    "$numberInt": "1094"
+  },
+  "age20Resident": {
+    "$numberInt": "5477"
+  },
+  "age30Resident": {
+    "$numberInt": "2031"
+  },
+  "age40Resident": {
+    "$numberInt": "1398"
+  },
+  "age50Resident": {
+    "$numberInt": "1902"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2967"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "576"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2817"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1147"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "710"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "931"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1311"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "518"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2660"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "884"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "688"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "971"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1656"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9778"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9778"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020276"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320670"
+  },
+  "adstrdName": "쌍문2동",
+  "totalResident": {
+    "$numberInt": "17905"
+  },
+  "maleResident": {
+    "$numberInt": "8522"
+  },
+  "femaleResident": {
+    "$numberInt": "9383"
+  },
+  "age10Resident": {
+    "$numberInt": "1919"
+  },
+  "age20Resident": {
+    "$numberInt": "2161"
+  },
+  "age30Resident": {
+    "$numberInt": "2304"
+  },
+  "age40Resident": {
+    "$numberInt": "2455"
+  },
+  "age50Resident": {
+    "$numberInt": "3145"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5921"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1019"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1072"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1206"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1250"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1458"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2517"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "900"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1089"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1098"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1205"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1687"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3404"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8451"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8451"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020277"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170640"
+  },
+  "adstrdName": "이촌2동",
+  "totalResident": {
+    "$numberInt": "7870"
+  },
+  "maleResident": {
+    "$numberInt": "3699"
+  },
+  "femaleResident": {
+    "$numberInt": "4171"
+  },
+  "age10Resident": {
+    "$numberInt": "869"
+  },
+  "age20Resident": {
+    "$numberInt": "833"
+  },
+  "age30Resident": {
+    "$numberInt": "1272"
+  },
+  "age40Resident": {
+    "$numberInt": "1131"
+  },
+  "age50Resident": {
+    "$numberInt": "1294"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2471"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "425"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "418"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "640"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "551"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "626"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1039"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "444"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "415"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "632"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "580"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "668"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1432"
+  },
+  "totalHouseholds": {
+    "$numberInt": "3591"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "3591"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020278"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470610"
+  },
+  "adstrdName": "신월6동",
+  "totalResident": {
+    "$numberInt": "13867"
+  },
+  "maleResident": {
+    "$numberInt": "6764"
+  },
+  "femaleResident": {
+    "$numberInt": "7103"
+  },
+  "age10Resident": {
+    "$numberInt": "2649"
+  },
+  "age20Resident": {
+    "$numberInt": "1421"
+  },
+  "age30Resident": {
+    "$numberInt": "2209"
+  },
+  "age40Resident": {
+    "$numberInt": "2369"
+  },
+  "age50Resident": {
+    "$numberInt": "2064"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3155"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1333"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "712"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1050"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1222"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "997"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1450"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1316"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "709"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1159"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1147"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1067"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1705"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5367"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5367"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020279"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710642"
+  },
+  "adstrdName": "문정2동",
+  "totalResident": {
+    "$numberInt": "28782"
+  },
+  "maleResident": {
+    "$numberInt": "13195"
+  },
+  "femaleResident": {
+    "$numberInt": "15587"
+  },
+  "age10Resident": {
+    "$numberInt": "2904"
+  },
+  "age20Resident": {
+    "$numberInt": "4676"
+  },
+  "age30Resident": {
+    "$numberInt": "7307"
+  },
+  "age40Resident": {
+    "$numberInt": "4456"
+  },
+  "age50Resident": {
+    "$numberInt": "3472"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5967"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1440"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1801"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3302"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2126"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1668"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2858"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1464"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2875"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "4005"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2330"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1804"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3109"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15844"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15844"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002027a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11350580"
+  },
+  "adstrdName": "월계3동",
+  "totalResident": {
+    "$numberInt": "28721"
+  },
+  "maleResident": {
+    "$numberInt": "13754"
+  },
+  "femaleResident": {
+    "$numberInt": "14967"
+  },
+  "age10Resident": {
+    "$numberInt": "3604"
+  },
+  "age20Resident": {
+    "$numberInt": "3167"
+  },
+  "age30Resident": {
+    "$numberInt": "4255"
+  },
+  "age40Resident": {
+    "$numberInt": "4140"
+  },
+  "age50Resident": {
+    "$numberInt": "4550"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9005"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1901"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1564"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2158"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2094"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2172"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3865"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1703"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1603"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2097"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2046"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2378"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5140"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12872"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12872"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002027b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500604"
+  },
+  "adstrdName": "가양2동",
+  "totalResident": {
+    "$numberInt": "13460"
+  },
+  "maleResident": {
+    "$numberInt": "6313"
+  },
+  "femaleResident": {
+    "$numberInt": "7147"
+  },
+  "age10Resident": {
+    "$numberInt": "815"
+  },
+  "age20Resident": {
+    "$numberInt": "1307"
+  },
+  "age30Resident": {
+    "$numberInt": "2213"
+  },
+  "age40Resident": {
+    "$numberInt": "1362"
+  },
+  "age50Resident": {
+    "$numberInt": "1635"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6128"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "434"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "570"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1093"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "677"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "784"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2755"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "381"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "737"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1120"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "685"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "851"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3373"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8004"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8004"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002027c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11710680"
+  },
+  "adstrdName": "잠실3동",
+  "totalResident": {
+    "$numberInt": "33805"
+  },
+  "maleResident": {
+    "$numberInt": "15960"
+  },
+  "femaleResident": {
+    "$numberInt": "17845"
+  },
+  "age10Resident": {
+    "$numberInt": "6578"
+  },
+  "age20Resident": {
+    "$numberInt": "3530"
+  },
+  "age30Resident": {
+    "$numberInt": "3519"
+  },
+  "age40Resident": {
+    "$numberInt": "6057"
+  },
+  "age50Resident": {
+    "$numberInt": "5459"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8662"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3272"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1716"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1492"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2781"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2674"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4025"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3306"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1814"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2027"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3276"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2785"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4637"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11814"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11814"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002027d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410710"
+  },
+  "adstrdName": "북가좌1동",
+  "totalResident": {
+    "$numberInt": "17563"
+  },
+  "maleResident": {
+    "$numberInt": "8389"
+  },
+  "femaleResident": {
+    "$numberInt": "9174"
+  },
+  "age10Resident": {
+    "$numberInt": "3067"
+  },
+  "age20Resident": {
+    "$numberInt": "1862"
+  },
+  "age30Resident": {
+    "$numberInt": "2117"
+  },
+  "age40Resident": {
+    "$numberInt": "2988"
+  },
+  "age50Resident": {
+    "$numberInt": "3001"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4528"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1608"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "899"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "980"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1408"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1495"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1999"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1459"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "963"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1137"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1580"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1506"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2529"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6782"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6782"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002027e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290770"
+  },
+  "adstrdName": "장위2동",
+  "totalResident": {
+    "$numberInt": "13080"
+  },
+  "maleResident": {
+    "$numberInt": "6397"
+  },
+  "femaleResident": {
+    "$numberInt": "6683"
+  },
+  "age10Resident": {
+    "$numberInt": "1253"
+  },
+  "age20Resident": {
+    "$numberInt": "1748"
+  },
+  "age30Resident": {
+    "$numberInt": "1781"
+  },
+  "age40Resident": {
+    "$numberInt": "1629"
+  },
+  "age50Resident": {
+    "$numberInt": "2262"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4407"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "650"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "854"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "919"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "876"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1143"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1955"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "603"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "894"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "862"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "753"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1119"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2452"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6575"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6575"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002027f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11230536"
+  },
+  "adstrdName": "용신동",
+  "totalResident": {
+    "$numberInt": "38362"
+  },
+  "maleResident": {
+    "$numberInt": "18958"
+  },
+  "femaleResident": {
+    "$numberInt": "19404"
+  },
+  "age10Resident": {
+    "$numberInt": "3880"
+  },
+  "age20Resident": {
+    "$numberInt": "6996"
+  },
+  "age30Resident": {
+    "$numberInt": "7010"
+  },
+  "age40Resident": {
+    "$numberInt": "5542"
+  },
+  "age50Resident": {
+    "$numberInt": "5577"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9357"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1971"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3141"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3504"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2942"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2924"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4476"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1909"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3855"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3506"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2600"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2653"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4881"
+  },
+  "totalHouseholds": {
+    "$numberInt": "21655"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "21655"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020280"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650530"
+  },
+  "adstrdName": "서초3동",
+  "totalResident": {
+    "$numberInt": "31862"
+  },
+  "maleResident": {
+    "$numberInt": "15138"
+  },
+  "femaleResident": {
+    "$numberInt": "16724"
+  },
+  "age10Resident": {
+    "$numberInt": "4233"
+  },
+  "age20Resident": {
+    "$numberInt": "5226"
+  },
+  "age30Resident": {
+    "$numberInt": "5306"
+  },
+  "age40Resident": {
+    "$numberInt": "4770"
+  },
+  "age50Resident": {
+    "$numberInt": "5156"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7171"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2285"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2321"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2452"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2166"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2550"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3364"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1948"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2905"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2854"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2604"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2606"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3807"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15194"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15194"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020281"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740610"
+  },
+  "adstrdName": "천호2동",
+  "totalResident": {
+    "$numberInt": "32694"
+  },
+  "maleResident": {
+    "$numberInt": "15924"
+  },
+  "femaleResident": {
+    "$numberInt": "16770"
+  },
+  "age10Resident": {
+    "$numberInt": "3070"
+  },
+  "age20Resident": {
+    "$numberInt": "4613"
+  },
+  "age30Resident": {
+    "$numberInt": "6011"
+  },
+  "age40Resident": {
+    "$numberInt": "4701"
+  },
+  "age50Resident": {
+    "$numberInt": "5084"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9215"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1569"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2099"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "3053"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2408"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2498"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4297"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1501"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2514"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2958"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2293"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2586"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4918"
+  },
+  "totalHouseholds": {
+    "$numberInt": "17419"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "17419"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020282"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380510"
+  },
+  "adstrdName": "녹번동",
+  "totalResident": {
+    "$numberInt": "36092"
+  },
+  "maleResident": {
+    "$numberInt": "16943"
+  },
+  "femaleResident": {
+    "$numberInt": "19149"
+  },
+  "age10Resident": {
+    "$numberInt": "4214"
+  },
+  "age20Resident": {
+    "$numberInt": "4495"
+  },
+  "age30Resident": {
+    "$numberInt": "5670"
+  },
+  "age40Resident": {
+    "$numberInt": "5379"
+  },
+  "age50Resident": {
+    "$numberInt": "5807"
+  },
+  "age60PlusResident": {
+    "$numberInt": "10527"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2055"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2091"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2752"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2745"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2767"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4533"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2159"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2404"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2918"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2634"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3040"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5994"
+  },
+  "totalHouseholds": {
+    "$numberInt": "17617"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "17617"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020283"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260660"
+  },
+  "adstrdName": "망우3동",
+  "totalResident": {
+    "$numberInt": "15615"
+  },
+  "maleResident": {
+    "$numberInt": "7869"
+  },
+  "femaleResident": {
+    "$numberInt": "7746"
+  },
+  "age10Resident": {
+    "$numberInt": "1418"
+  },
+  "age20Resident": {
+    "$numberInt": "1977"
+  },
+  "age30Resident": {
+    "$numberInt": "1954"
+  },
+  "age40Resident": {
+    "$numberInt": "1959"
+  },
+  "age50Resident": {
+    "$numberInt": "3002"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5305"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "686"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "992"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1066"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1044"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1503"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2578"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "732"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "985"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "888"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "915"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1499"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2727"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8150"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8150"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020284"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440630"
+  },
+  "adstrdName": "신수동",
+  "totalResident": {
+    "$numberInt": "22046"
+  },
+  "maleResident": {
+    "$numberInt": "10753"
+  },
+  "femaleResident": {
+    "$numberInt": "11293"
+  },
+  "age10Resident": {
+    "$numberInt": "3231"
+  },
+  "age20Resident": {
+    "$numberInt": "3303"
+  },
+  "age30Resident": {
+    "$numberInt": "3353"
+  },
+  "age40Resident": {
+    "$numberInt": "3486"
+  },
+  "age50Resident": {
+    "$numberInt": "3769"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4904"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1676"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1715"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1632"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1655"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1871"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2204"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1555"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1588"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1721"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1831"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1898"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2700"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9989"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9989"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020285"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290715"
+  },
+  "adstrdName": "월곡1동",
+  "totalResident": {
+    "$numberInt": "25580"
+  },
+  "maleResident": {
+    "$numberInt": "12324"
+  },
+  "femaleResident": {
+    "$numberInt": "13256"
+  },
+  "age10Resident": {
+    "$numberInt": "4029"
+  },
+  "age20Resident": {
+    "$numberInt": "2818"
+  },
+  "age30Resident": {
+    "$numberInt": "3214"
+  },
+  "age40Resident": {
+    "$numberInt": "4144"
+  },
+  "age50Resident": {
+    "$numberInt": "4342"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7033"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2015"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1322"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1595"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2052"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2170"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3170"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2014"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1496"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1619"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2092"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2172"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3863"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10775"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10775"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020286"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590680"
+  },
+  "adstrdName": "신대방2동",
+  "totalResident": {
+    "$numberInt": "22684"
+  },
+  "maleResident": {
+    "$numberInt": "10857"
+  },
+  "femaleResident": {
+    "$numberInt": "11827"
+  },
+  "age10Resident": {
+    "$numberInt": "3307"
+  },
+  "age20Resident": {
+    "$numberInt": "3677"
+  },
+  "age30Resident": {
+    "$numberInt": "3873"
+  },
+  "age40Resident": {
+    "$numberInt": "3490"
+  },
+  "age50Resident": {
+    "$numberInt": "3231"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5106"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1680"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1686"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1885"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1710"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1580"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2316"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1627"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1991"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1988"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1780"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1651"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2790"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10901"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10901"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020287"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11290780"
+  },
+  "adstrdName": "장위3동",
+  "totalResident": {
+    "$numberInt": "15519"
+  },
+  "maleResident": {
+    "$numberInt": "7611"
+  },
+  "femaleResident": {
+    "$numberInt": "7908"
+  },
+  "age10Resident": {
+    "$numberInt": "2784"
+  },
+  "age20Resident": {
+    "$numberInt": "1948"
+  },
+  "age30Resident": {
+    "$numberInt": "2233"
+  },
+  "age40Resident": {
+    "$numberInt": "2635"
+  },
+  "age50Resident": {
+    "$numberInt": "2529"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3390"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1405"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "947"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1076"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1350"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1245"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1588"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1379"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1001"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1157"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1285"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1284"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1802"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6445"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6445"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020288"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380690"
+  },
+  "adstrdName": "진관동",
+  "totalResident": {
+    "$numberInt": "54368"
+  },
+  "maleResident": {
+    "$numberInt": "25288"
+  },
+  "femaleResident": {
+    "$numberInt": "29080"
+  },
+  "age10Resident": {
+    "$numberInt": "10415"
+  },
+  "age20Resident": {
+    "$numberInt": "6706"
+  },
+  "age30Resident": {
+    "$numberInt": "6109"
+  },
+  "age40Resident": {
+    "$numberInt": "9196"
+  },
+  "age50Resident": {
+    "$numberInt": "9113"
+  },
+  "age60PlusResident": {
+    "$numberInt": "12829"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "5374"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2925"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2553"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "4158"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "4500"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "5778"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "5041"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3781"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3556"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "5038"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "4613"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "7051"
+  },
+  "totalHouseholds": {
+    "$numberInt": "21360"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "21360"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020289"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11380625"
+  },
+  "adstrdName": "역촌동",
+  "totalResident": {
+    "$numberInt": "43767"
+  },
+  "maleResident": {
+    "$numberInt": "20483"
+  },
+  "femaleResident": {
+    "$numberInt": "23284"
+  },
+  "age10Resident": {
+    "$numberInt": "4868"
+  },
+  "age20Resident": {
+    "$numberInt": "5864"
+  },
+  "age30Resident": {
+    "$numberInt": "5966"
+  },
+  "age40Resident": {
+    "$numberInt": "6675"
+  },
+  "age50Resident": {
+    "$numberInt": "7550"
+  },
+  "age60PlusResident": {
+    "$numberInt": "12844"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2439"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2804"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2897"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3284"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3534"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "5525"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2429"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3060"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3069"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3391"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "4016"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "7319"
+  },
+  "totalHouseholds": {
+    "$numberInt": "20617"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "20617"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002028a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740620"
+  },
+  "adstrdName": "천호3동",
+  "totalResident": {
+    "$numberInt": "25969"
+  },
+  "maleResident": {
+    "$numberInt": "12529"
+  },
+  "femaleResident": {
+    "$numberInt": "13440"
+  },
+  "age10Resident": {
+    "$numberInt": "2197"
+  },
+  "age20Resident": {
+    "$numberInt": "4210"
+  },
+  "age30Resident": {
+    "$numberInt": "5030"
+  },
+  "age40Resident": {
+    "$numberInt": "3486"
+  },
+  "age50Resident": {
+    "$numberInt": "3867"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7179"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1133"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1782"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2441"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1810"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1966"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3397"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1064"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2428"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2589"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1676"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1901"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3782"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14368"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14368"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002028b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440700"
+  },
+  "adstrdName": "망원2동",
+  "totalResident": {
+    "$numberInt": "17917"
+  },
+  "maleResident": {
+    "$numberInt": "8341"
+  },
+  "femaleResident": {
+    "$numberInt": "9576"
+  },
+  "age10Resident": {
+    "$numberInt": "2213"
+  },
+  "age20Resident": {
+    "$numberInt": "2552"
+  },
+  "age30Resident": {
+    "$numberInt": "2870"
+  },
+  "age40Resident": {
+    "$numberInt": "2842"
+  },
+  "age50Resident": {
+    "$numberInt": "2916"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4524"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1135"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1123"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1346"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1365"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1413"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1959"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1078"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1429"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1524"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1477"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1503"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2565"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8348"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8348"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002028c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305595"
+  },
+  "adstrdName": "번1동",
+  "totalResident": {
+    "$numberInt": "17358"
+  },
+  "maleResident": {
+    "$numberInt": "8652"
+  },
+  "femaleResident": {
+    "$numberInt": "8706"
+  },
+  "age10Resident": {
+    "$numberInt": "1339"
+  },
+  "age20Resident": {
+    "$numberInt": "2827"
+  },
+  "age30Resident": {
+    "$numberInt": "2519"
+  },
+  "age40Resident": {
+    "$numberInt": "2518"
+  },
+  "age50Resident": {
+    "$numberInt": "2901"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5254"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "672"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1323"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1359"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1386"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1510"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2402"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "667"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1504"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1160"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1132"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1391"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2852"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10159"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10159"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002028d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11470530"
+  },
+  "adstrdName": "목3동",
+  "totalResident": {
+    "$numberInt": "21206"
+  },
+  "maleResident": {
+    "$numberInt": "10060"
+  },
+  "femaleResident": {
+    "$numberInt": "11146"
+  },
+  "age10Resident": {
+    "$numberInt": "2379"
+  },
+  "age20Resident": {
+    "$numberInt": "3090"
+  },
+  "age30Resident": {
+    "$numberInt": "3786"
+  },
+  "age40Resident": {
+    "$numberInt": "2997"
+  },
+  "age50Resident": {
+    "$numberInt": "3368"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5586"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1265"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1485"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1845"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1444"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1519"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2502"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1114"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1605"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1941"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1553"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1849"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3084"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10074"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10074"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002028e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530770"
+  },
+  "adstrdName": "오류1동",
+  "totalResident": {
+    "$numberInt": "22559"
+  },
+  "maleResident": {
+    "$numberInt": "10732"
+  },
+  "femaleResident": {
+    "$numberInt": "11827"
+  },
+  "age10Resident": {
+    "$numberInt": "2051"
+  },
+  "age20Resident": {
+    "$numberInt": "4022"
+  },
+  "age30Resident": {
+    "$numberInt": "4550"
+  },
+  "age40Resident": {
+    "$numberInt": "2980"
+  },
+  "age50Resident": {
+    "$numberInt": "3031"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5925"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1022"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1640"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2288"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1531"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1516"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2735"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1029"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2382"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2262"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1449"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1515"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3190"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12645"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12645"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002028f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740650"
+  },
+  "adstrdName": "성내2동",
+  "totalResident": {
+    "$numberInt": "23452"
+  },
+  "maleResident": {
+    "$numberInt": "11433"
+  },
+  "femaleResident": {
+    "$numberInt": "12019"
+  },
+  "age10Resident": {
+    "$numberInt": "1873"
+  },
+  "age20Resident": {
+    "$numberInt": "3921"
+  },
+  "age30Resident": {
+    "$numberInt": "4390"
+  },
+  "age40Resident": {
+    "$numberInt": "3062"
+  },
+  "age50Resident": {
+    "$numberInt": "3447"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6759"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "986"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1657"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2269"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1606"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1749"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3166"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "887"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2264"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2121"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1456"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1698"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3593"
+  },
+  "totalHouseholds": {
+    "$numberInt": "13395"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "13395"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020290"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11545630"
+  },
+  "adstrdName": "독산3동",
+  "totalResident": {
+    "$numberInt": "23433"
+  },
+  "maleResident": {
+    "$numberInt": "11747"
+  },
+  "femaleResident": {
+    "$numberInt": "11686"
+  },
+  "age10Resident": {
+    "$numberInt": "1819"
+  },
+  "age20Resident": {
+    "$numberInt": "3579"
+  },
+  "age30Resident": {
+    "$numberInt": "3643"
+  },
+  "age40Resident": {
+    "$numberInt": "2766"
+  },
+  "age50Resident": {
+    "$numberInt": "4214"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7412"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "910"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1751"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2030"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1501"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2044"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3511"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "909"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1828"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1613"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1265"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2170"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3901"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12776"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12776"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020291"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170560"
+  },
+  "adstrdName": "원효로1동",
+  "totalResident": {
+    "$numberInt": "16956"
+  },
+  "maleResident": {
+    "$numberInt": "7874"
+  },
+  "femaleResident": {
+    "$numberInt": "9082"
+  },
+  "age10Resident": {
+    "$numberInt": "2035"
+  },
+  "age20Resident": {
+    "$numberInt": "2849"
+  },
+  "age30Resident": {
+    "$numberInt": "4187"
+  },
+  "age40Resident": {
+    "$numberInt": "2648"
+  },
+  "age50Resident": {
+    "$numberInt": "2178"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3059"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1053"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1083"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1956"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1293"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1079"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1410"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "982"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1766"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2231"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1355"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1099"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1649"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9246"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9246"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020292"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530560"
+  },
+  "adstrdName": "구로5동",
+  "totalResident": {
+    "$numberInt": "28952"
+  },
+  "maleResident": {
+    "$numberInt": "14052"
+  },
+  "femaleResident": {
+    "$numberInt": "14900"
+  },
+  "age10Resident": {
+    "$numberInt": "2914"
+  },
+  "age20Resident": {
+    "$numberInt": "4871"
+  },
+  "age30Resident": {
+    "$numberInt": "5547"
+  },
+  "age40Resident": {
+    "$numberInt": "3904"
+  },
+  "age50Resident": {
+    "$numberInt": "4379"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7337"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1488"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2093"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2812"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2039"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2188"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3432"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1426"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2778"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2735"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1865"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2191"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3905"
+  },
+  "totalHouseholds": {
+    "$numberInt": "15519"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "15519"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020293"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11500593"
+  },
+  "adstrdName": "화곡8동",
+  "totalResident": {
+    "$numberInt": "23468"
+  },
+  "maleResident": {
+    "$numberInt": "11313"
+  },
+  "femaleResident": {
+    "$numberInt": "12155"
+  },
+  "age10Resident": {
+    "$numberInt": "2351"
+  },
+  "age20Resident": {
+    "$numberInt": "3535"
+  },
+  "age30Resident": {
+    "$numberInt": "3798"
+  },
+  "age40Resident": {
+    "$numberInt": "3576"
+  },
+  "age50Resident": {
+    "$numberInt": "3586"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6622"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1204"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1690"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2003"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1867"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1684"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2865"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1147"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1845"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1795"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1709"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1902"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3757"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11692"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11692"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020294"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170555"
+  },
+  "adstrdName": "청파동",
+  "totalResident": {
+    "$numberInt": "18842"
+  },
+  "maleResident": {
+    "$numberInt": "8750"
+  },
+  "femaleResident": {
+    "$numberInt": "10092"
+  },
+  "age10Resident": {
+    "$numberInt": "1460"
+  },
+  "age20Resident": {
+    "$numberInt": "4040"
+  },
+  "age30Resident": {
+    "$numberInt": "3339"
+  },
+  "age40Resident": {
+    "$numberInt": "2305"
+  },
+  "age50Resident": {
+    "$numberInt": "2991"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4707"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "717"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1526"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1783"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1168"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1491"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2065"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "743"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2514"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1556"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1137"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1500"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2642"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11116"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11116"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020295"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560620"
+  },
+  "adstrdName": "양평2동",
+  "totalResident": {
+    "$numberInt": "22288"
+  },
+  "maleResident": {
+    "$numberInt": "10893"
+  },
+  "femaleResident": {
+    "$numberInt": "11395"
+  },
+  "age10Resident": {
+    "$numberInt": "2856"
+  },
+  "age20Resident": {
+    "$numberInt": "3622"
+  },
+  "age30Resident": {
+    "$numberInt": "5349"
+  },
+  "age40Resident": {
+    "$numberInt": "3276"
+  },
+  "age50Resident": {
+    "$numberInt": "3043"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4142"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1460"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1610"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2673"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1636"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1565"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1949"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1396"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2012"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2676"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1640"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1478"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2193"
+  },
+  "totalHouseholds": {
+    "$numberInt": "10913"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "10913"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020296"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410720"
+  },
+  "adstrdName": "북가좌2동",
+  "totalResident": {
+    "$numberInt": "30673"
+  },
+  "maleResident": {
+    "$numberInt": "14859"
+  },
+  "femaleResident": {
+    "$numberInt": "15814"
+  },
+  "age10Resident": {
+    "$numberInt": "3326"
+  },
+  "age20Resident": {
+    "$numberInt": "4272"
+  },
+  "age30Resident": {
+    "$numberInt": "4121"
+  },
+  "age40Resident": {
+    "$numberInt": "4325"
+  },
+  "age50Resident": {
+    "$numberInt": "5190"
+  },
+  "age60PlusResident": {
+    "$numberInt": "9439"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1717"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "2125"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2161"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2184"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2476"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "4196"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1609"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2147"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1960"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2141"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2714"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "5243"
+  },
+  "totalHouseholds": {
+    "$numberInt": "14579"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "14579"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020297"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11545640"
+  },
+  "adstrdName": "독산4동",
+  "totalResident": {
+    "$numberInt": "14511"
+  },
+  "maleResident": {
+    "$numberInt": "7266"
+  },
+  "femaleResident": {
+    "$numberInt": "7245"
+  },
+  "age10Resident": {
+    "$numberInt": "1272"
+  },
+  "age20Resident": {
+    "$numberInt": "1921"
+  },
+  "age30Resident": {
+    "$numberInt": "2009"
+  },
+  "age40Resident": {
+    "$numberInt": "1717"
+  },
+  "age50Resident": {
+    "$numberInt": "2876"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4716"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "622"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "974"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1076"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "906"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1443"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2245"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "650"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "947"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "933"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "811"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1433"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2471"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7557"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7557"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020298"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110640"
+  },
+  "adstrdName": "이화동",
+  "totalResident": {
+    "$numberInt": "6891"
+  },
+  "maleResident": {
+    "$numberInt": "3277"
+  },
+  "femaleResident": {
+    "$numberInt": "3614"
+  },
+  "age10Resident": {
+    "$numberInt": "487"
+  },
+  "age20Resident": {
+    "$numberInt": "1496"
+  },
+  "age30Resident": {
+    "$numberInt": "1219"
+  },
+  "age40Resident": {
+    "$numberInt": "792"
+  },
+  "age50Resident": {
+    "$numberInt": "1000"
+  },
+  "age60PlusResident": {
+    "$numberInt": "1897"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "254"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "686"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "604"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "402"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "490"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "841"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "233"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "810"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "615"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "390"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "510"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1056"
+  },
+  "totalHouseholds": {
+    "$numberInt": "4206"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "4206"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc0020299"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110615"
+  },
+  "adstrdName": "종로1?2?3?4가동",
+  "totalResident": {
+    "$numberInt": "6658"
+  },
+  "maleResident": {
+    "$numberInt": "4029"
+  },
+  "femaleResident": {
+    "$numberInt": "2629"
+  },
+  "age10Resident": {
+    "$numberInt": "369"
+  },
+  "age20Resident": {
+    "$numberInt": "944"
+  },
+  "age30Resident": {
+    "$numberInt": "974"
+  },
+  "age40Resident": {
+    "$numberInt": "835"
+  },
+  "age50Resident": {
+    "$numberInt": "1117"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2419"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "197"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "456"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "574"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "512"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "761"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1529"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "172"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "488"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "400"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "323"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "356"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "890"
+  },
+  "totalHouseholds": {
+    "$numberInt": "4883"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "4883"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002029a"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560535"
+  },
+  "adstrdName": "영등포동",
+  "totalResident": {
+    "$numberInt": "29839"
+  },
+  "maleResident": {
+    "$numberInt": "15326"
+  },
+  "femaleResident": {
+    "$numberInt": "14513"
+  },
+  "age10Resident": {
+    "$numberInt": "1900"
+  },
+  "age20Resident": {
+    "$numberInt": "7604"
+  },
+  "age30Resident": {
+    "$numberInt": "8392"
+  },
+  "age40Resident": {
+    "$numberInt": "3528"
+  },
+  "age50Resident": {
+    "$numberInt": "3320"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5095"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "952"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3066"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "4449"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1993"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2021"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2845"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "948"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "4538"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3943"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1535"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1299"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2250"
+  },
+  "totalHouseholds": {
+    "$numberInt": "21204"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "21204"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002029b"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11260690"
+  },
+  "adstrdName": "신내2동",
+  "totalResident": {
+    "$numberInt": "19675"
+  },
+  "maleResident": {
+    "$numberInt": "9292"
+  },
+  "femaleResident": {
+    "$numberInt": "10383"
+  },
+  "age10Resident": {
+    "$numberInt": "2434"
+  },
+  "age20Resident": {
+    "$numberInt": "2125"
+  },
+  "age30Resident": {
+    "$numberInt": "2704"
+  },
+  "age40Resident": {
+    "$numberInt": "2785"
+  },
+  "age50Resident": {
+    "$numberInt": "3320"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6307"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1225"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1062"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1331"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1400"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1545"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2729"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1209"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1063"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1373"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1385"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1775"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3578"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8897"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8897"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002029c"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11560680"
+  },
+  "adstrdName": "신길6동",
+  "totalResident": {
+    "$numberInt": "19493"
+  },
+  "maleResident": {
+    "$numberInt": "9518"
+  },
+  "femaleResident": {
+    "$numberInt": "9975"
+  },
+  "age10Resident": {
+    "$numberInt": "2487"
+  },
+  "age20Resident": {
+    "$numberInt": "2892"
+  },
+  "age30Resident": {
+    "$numberInt": "3304"
+  },
+  "age40Resident": {
+    "$numberInt": "2786"
+  },
+  "age50Resident": {
+    "$numberInt": "2955"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5069"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1352"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1351"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1622"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1452"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1432"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2309"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1135"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1541"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1682"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1334"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1523"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2760"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9265"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9265"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002029d"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140665"
+  },
+  "adstrdName": "동화동",
+  "totalResident": {
+    "$numberInt": "9941"
+  },
+  "maleResident": {
+    "$numberInt": "4786"
+  },
+  "femaleResident": {
+    "$numberInt": "5155"
+  },
+  "age10Resident": {
+    "$numberInt": "1332"
+  },
+  "age20Resident": {
+    "$numberInt": "1138"
+  },
+  "age30Resident": {
+    "$numberInt": "1278"
+  },
+  "age40Resident": {
+    "$numberInt": "1416"
+  },
+  "age50Resident": {
+    "$numberInt": "1801"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2976"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "687"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "556"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "634"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "690"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "853"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1366"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "645"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "582"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "644"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "726"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "948"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1610"
+  },
+  "totalHouseholds": {
+    "$numberInt": "3987"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "3987"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002029e"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410520"
+  },
+  "adstrdName": "천연동",
+  "totalResident": {
+    "$numberInt": "16547"
+  },
+  "maleResident": {
+    "$numberInt": "7796"
+  },
+  "femaleResident": {
+    "$numberInt": "8751"
+  },
+  "age10Resident": {
+    "$numberInt": "2273"
+  },
+  "age20Resident": {
+    "$numberInt": "1936"
+  },
+  "age30Resident": {
+    "$numberInt": "2301"
+  },
+  "age40Resident": {
+    "$numberInt": "2399"
+  },
+  "age50Resident": {
+    "$numberInt": "2915"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4723"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1130"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "932"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1103"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1149"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1427"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2055"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1143"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1004"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1198"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1250"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1488"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2668"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7609"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7609"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc002029f"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440680"
+  },
+  "adstrdName": "합정동",
+  "totalResident": {
+    "$numberInt": "16310"
+  },
+  "maleResident": {
+    "$numberInt": "7512"
+  },
+  "femaleResident": {
+    "$numberInt": "8798"
+  },
+  "age10Resident": {
+    "$numberInt": "1356"
+  },
+  "age20Resident": {
+    "$numberInt": "3011"
+  },
+  "age30Resident": {
+    "$numberInt": "3574"
+  },
+  "age40Resident": {
+    "$numberInt": "2448"
+  },
+  "age50Resident": {
+    "$numberInt": "2205"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3716"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "668"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1309"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1701"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1195"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1002"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1637"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "688"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1702"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1873"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1253"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1203"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2079"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9188"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9188"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202a0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140680"
+  },
+  "adstrdName": "중림동",
+  "totalResident": {
+    "$numberInt": "12142"
+  },
+  "maleResident": {
+    "$numberInt": "5940"
+  },
+  "femaleResident": {
+    "$numberInt": "6202"
+  },
+  "age10Resident": {
+    "$numberInt": "1646"
+  },
+  "age20Resident": {
+    "$numberInt": "1368"
+  },
+  "age30Resident": {
+    "$numberInt": "2109"
+  },
+  "age40Resident": {
+    "$numberInt": "2066"
+  },
+  "age50Resident": {
+    "$numberInt": "1828"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3125"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "866"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "587"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "958"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1102"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "940"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1487"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "780"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "781"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1151"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "964"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "888"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1638"
+  },
+  "totalHouseholds": {
+    "$numberInt": "5937"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "5937"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202a1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440740"
+  },
+  "adstrdName": "상암동",
+  "totalResident": {
+    "$numberInt": "29662"
+  },
+  "maleResident": {
+    "$numberInt": "13937"
+  },
+  "femaleResident": {
+    "$numberInt": "15725"
+  },
+  "age10Resident": {
+    "$numberInt": "5608"
+  },
+  "age20Resident": {
+    "$numberInt": "4228"
+  },
+  "age30Resident": {
+    "$numberInt": "3533"
+  },
+  "age40Resident": {
+    "$numberInt": "5087"
+  },
+  "age50Resident": {
+    "$numberInt": "5046"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6160"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2865"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1834"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1629"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2369"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2534"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2706"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2743"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2394"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1904"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2718"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2512"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3454"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12700"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12700"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202a2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740580"
+  },
+  "adstrdName": "암사2동",
+  "totalResident": {
+    "$numberInt": "14825"
+  },
+  "maleResident": {
+    "$numberInt": "7158"
+  },
+  "femaleResident": {
+    "$numberInt": "7667"
+  },
+  "age10Resident": {
+    "$numberInt": "2123"
+  },
+  "age20Resident": {
+    "$numberInt": "1760"
+  },
+  "age30Resident": {
+    "$numberInt": "2621"
+  },
+  "age40Resident": {
+    "$numberInt": "2306"
+  },
+  "age50Resident": {
+    "$numberInt": "2266"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3749"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1094"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "823"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1282"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1167"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1082"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1710"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1029"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "937"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1339"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1139"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1184"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2039"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6375"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6375"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202a3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215870"
+  },
+  "adstrdName": "구의3동",
+  "totalResident": {
+    "$numberInt": "27836"
+  },
+  "maleResident": {
+    "$numberInt": "13145"
+  },
+  "femaleResident": {
+    "$numberInt": "14691"
+  },
+  "age10Resident": {
+    "$numberInt": "3858"
+  },
+  "age20Resident": {
+    "$numberInt": "4079"
+  },
+  "age30Resident": {
+    "$numberInt": "4489"
+  },
+  "age40Resident": {
+    "$numberInt": "4065"
+  },
+  "age50Resident": {
+    "$numberInt": "4687"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6658"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1909"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1868"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2168"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1909"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2228"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3063"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1949"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "2211"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2321"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2156"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2459"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3595"
+  },
+  "totalHouseholds": {
+    "$numberInt": "12048"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "12048"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202a4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11650580"
+  },
+  "adstrdName": "반포3동",
+  "totalResident": {
+    "$numberInt": "23761"
+  },
+  "maleResident": {
+    "$numberInt": "11271"
+  },
+  "femaleResident": {
+    "$numberInt": "12490"
+  },
+  "age10Resident": {
+    "$numberInt": "5151"
+  },
+  "age20Resident": {
+    "$numberInt": "2582"
+  },
+  "age30Resident": {
+    "$numberInt": "2533"
+  },
+  "age40Resident": {
+    "$numberInt": "4499"
+  },
+  "age50Resident": {
+    "$numberInt": "4268"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4728"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2632"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1260"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1128"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1973"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2176"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2102"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2519"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1322"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1405"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2526"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2092"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2626"
+  },
+  "totalHouseholds": {
+    "$numberInt": "8199"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "8199"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202a5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11215810"
+  },
+  "adstrdName": "광장동",
+  "totalResident": {
+    "$numberInt": "33964"
+  },
+  "maleResident": {
+    "$numberInt": "16438"
+  },
+  "femaleResident": {
+    "$numberInt": "17526"
+  },
+  "age10Resident": {
+    "$numberInt": "7792"
+  },
+  "age20Resident": {
+    "$numberInt": "3846"
+  },
+  "age30Resident": {
+    "$numberInt": "3310"
+  },
+  "age40Resident": {
+    "$numberInt": "6841"
+  },
+  "age50Resident": {
+    "$numberInt": "6054"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6121"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "4000"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1911"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1494"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "3076"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "3054"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2903"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3792"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1935"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1816"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3765"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "3000"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3218"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11851"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11851"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202a6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680600"
+  },
+  "adstrdName": "대치1동",
+  "totalResident": {
+    "$numberInt": "23878"
+  },
+  "maleResident": {
+    "$numberInt": "11957"
+  },
+  "femaleResident": {
+    "$numberInt": "11921"
+  },
+  "age10Resident": {
+    "$numberInt": "6872"
+  },
+  "age20Resident": {
+    "$numberInt": "2275"
+  },
+  "age30Resident": {
+    "$numberInt": "1337"
+  },
+  "age40Resident": {
+    "$numberInt": "5333"
+  },
+  "age50Resident": {
+    "$numberInt": "4121"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3940"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3792"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1172"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "563"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2262"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2256"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1912"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3080"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1103"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "774"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3071"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1865"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2028"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7218"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7218"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202a7"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530730"
+  },
+  "adstrdName": "고척2동",
+  "totalResident": {
+    "$numberInt": "25749"
+  },
+  "maleResident": {
+    "$numberInt": "12684"
+  },
+  "femaleResident": {
+    "$numberInt": "13065"
+  },
+  "age10Resident": {
+    "$numberInt": "3300"
+  },
+  "age20Resident": {
+    "$numberInt": "3084"
+  },
+  "age30Resident": {
+    "$numberInt": "3007"
+  },
+  "age40Resident": {
+    "$numberInt": "3629"
+  },
+  "age50Resident": {
+    "$numberInt": "4710"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8019"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1693"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1564"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1543"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1802"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2352"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3730"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1607"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1520"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1464"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1827"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2358"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4289"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11447"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11447"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202a8"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11200590"
+  },
+  "adstrdName": "금호1가동",
+  "totalResident": {
+    "$numberInt": "14750"
+  },
+  "maleResident": {
+    "$numberInt": "7024"
+  },
+  "femaleResident": {
+    "$numberInt": "7726"
+  },
+  "age10Resident": {
+    "$numberInt": "2106"
+  },
+  "age20Resident": {
+    "$numberInt": "1524"
+  },
+  "age30Resident": {
+    "$numberInt": "2315"
+  },
+  "age40Resident": {
+    "$numberInt": "2474"
+  },
+  "age50Resident": {
+    "$numberInt": "2321"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4010"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1088"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "737"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1083"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1276"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1104"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1736"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1018"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "787"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1232"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1198"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1217"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2274"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6503"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6503"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202a9"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11410615"
+  },
+  "adstrdName": "연희동",
+  "totalResident": {
+    "$numberInt": "33724"
+  },
+  "maleResident": {
+    "$numberInt": "16100"
+  },
+  "femaleResident": {
+    "$numberInt": "17624"
+  },
+  "age10Resident": {
+    "$numberInt": "3331"
+  },
+  "age20Resident": {
+    "$numberInt": "7365"
+  },
+  "age30Resident": {
+    "$numberInt": "5355"
+  },
+  "age40Resident": {
+    "$numberInt": "4424"
+  },
+  "age50Resident": {
+    "$numberInt": "4927"
+  },
+  "age60PlusResident": {
+    "$numberInt": "8322"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1671"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "3700"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2674"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2130"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2314"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3611"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1660"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "3665"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "2681"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2294"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2613"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "4711"
+  },
+  "totalHouseholds": {
+    "$numberInt": "18420"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "18420"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202aa"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11140570"
+  },
+  "adstrdName": "필동",
+  "totalResident": {
+    "$numberInt": "4012"
+  },
+  "maleResident": {
+    "$numberInt": "2085"
+  },
+  "femaleResident": {
+    "$numberInt": "1927"
+  },
+  "age10Resident": {
+    "$numberInt": "336"
+  },
+  "age20Resident": {
+    "$numberInt": "748"
+  },
+  "age30Resident": {
+    "$numberInt": "697"
+  },
+  "age40Resident": {
+    "$numberInt": "476"
+  },
+  "age50Resident": {
+    "$numberInt": "567"
+  },
+  "age60PlusResident": {
+    "$numberInt": "1188"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "176"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "371"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "378"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "257"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "328"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "575"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "160"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "377"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "319"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "219"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "239"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "613"
+  },
+  "totalHouseholds": {
+    "$numberInt": "2495"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "2495"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202ab"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440590"
+  },
+  "adstrdName": "용강동",
+  "totalResident": {
+    "$numberInt": "21098"
+  },
+  "maleResident": {
+    "$numberInt": "9951"
+  },
+  "femaleResident": {
+    "$numberInt": "11147"
+  },
+  "age10Resident": {
+    "$numberInt": "3985"
+  },
+  "age20Resident": {
+    "$numberInt": "1997"
+  },
+  "age30Resident": {
+    "$numberInt": "3386"
+  },
+  "age40Resident": {
+    "$numberInt": "4218"
+  },
+  "age50Resident": {
+    "$numberInt": "3157"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4355"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1980"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "909"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1533"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1990"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1605"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1934"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2005"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1088"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1853"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2228"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1552"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2421"
+  },
+  "totalHouseholds": {
+    "$numberInt": "9236"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "9236"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202ac"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11440555"
+  },
+  "adstrdName": "아현동",
+  "totalResident": {
+    "$numberInt": "28335"
+  },
+  "maleResident": {
+    "$numberInt": "13175"
+  },
+  "femaleResident": {
+    "$numberInt": "15160"
+  },
+  "age10Resident": {
+    "$numberInt": "4932"
+  },
+  "age20Resident": {
+    "$numberInt": "3170"
+  },
+  "age30Resident": {
+    "$numberInt": "5561"
+  },
+  "age40Resident": {
+    "$numberInt": "4986"
+  },
+  "age50Resident": {
+    "$numberInt": "4207"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5479"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2368"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1350"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "2486"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2506"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2003"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2462"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2564"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1820"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "3075"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2480"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2204"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3017"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11924"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11924"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202ad"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11320681"
+  },
+  "adstrdName": "쌍문4동",
+  "totalResident": {
+    "$numberInt": "18061"
+  },
+  "maleResident": {
+    "$numberInt": "8536"
+  },
+  "femaleResident": {
+    "$numberInt": "9525"
+  },
+  "age10Resident": {
+    "$numberInt": "2733"
+  },
+  "age20Resident": {
+    "$numberInt": "2180"
+  },
+  "age30Resident": {
+    "$numberInt": "2113"
+  },
+  "age40Resident": {
+    "$numberInt": "2651"
+  },
+  "age50Resident": {
+    "$numberInt": "3212"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5172"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1440"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1107"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "996"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1249"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1435"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2309"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1293"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1073"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1117"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1402"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1777"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2863"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7093"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7093"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202ae"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11170530"
+  },
+  "adstrdName": "남영동",
+  "totalResident": {
+    "$numberInt": "6819"
+  },
+  "maleResident": {
+    "$numberInt": "4160"
+  },
+  "femaleResident": {
+    "$numberInt": "2659"
+  },
+  "age10Resident": {
+    "$numberInt": "353"
+  },
+  "age20Resident": {
+    "$numberInt": "767"
+  },
+  "age30Resident": {
+    "$numberInt": "1006"
+  },
+  "age40Resident": {
+    "$numberInt": "842"
+  },
+  "age50Resident": {
+    "$numberInt": "1451"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2400"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "194"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "339"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "550"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "513"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "994"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1570"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "159"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "428"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "456"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "329"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "457"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "830"
+  },
+  "totalHouseholds": {
+    "$numberInt": "4845"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "4845"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202af"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11530800"
+  },
+  "adstrdName": "항동",
+  "totalResident": {
+    "$numberInt": "16335"
+  },
+  "maleResident": {
+    "$numberInt": "7906"
+  },
+  "femaleResident": {
+    "$numberInt": "8429"
+  },
+  "age10Resident": {
+    "$numberInt": "3938"
+  },
+  "age20Resident": {
+    "$numberInt": "1379"
+  },
+  "age30Resident": {
+    "$numberInt": "3015"
+  },
+  "age40Resident": {
+    "$numberInt": "3308"
+  },
+  "age50Resident": {
+    "$numberInt": "1830"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2865"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1988"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "670"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1336"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1748"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "864"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1300"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1950"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "709"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1679"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1560"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "966"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1565"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6252"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6252"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202b0"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11590650"
+  },
+  "adstrdName": "사당4동",
+  "totalResident": {
+    "$numberInt": "13771"
+  },
+  "maleResident": {
+    "$numberInt": "6587"
+  },
+  "femaleResident": {
+    "$numberInt": "7184"
+  },
+  "age10Resident": {
+    "$numberInt": "1226"
+  },
+  "age20Resident": {
+    "$numberInt": "2307"
+  },
+  "age30Resident": {
+    "$numberInt": "2363"
+  },
+  "age40Resident": {
+    "$numberInt": "1912"
+  },
+  "age50Resident": {
+    "$numberInt": "1984"
+  },
+  "age60PlusResident": {
+    "$numberInt": "3979"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "635"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1053"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1227"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "986"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "954"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "1732"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "591"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1254"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1136"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "926"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1030"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2247"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7233"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7233"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202b1"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11110570"
+  },
+  "adstrdName": "무악동",
+  "totalResident": {
+    "$numberInt": "7963"
+  },
+  "maleResident": {
+    "$numberInt": "3652"
+  },
+  "femaleResident": {
+    "$numberInt": "4311"
+  },
+  "age10Resident": {
+    "$numberInt": "1473"
+  },
+  "age20Resident": {
+    "$numberInt": "823"
+  },
+  "age30Resident": {
+    "$numberInt": "813"
+  },
+  "age40Resident": {
+    "$numberInt": "1301"
+  },
+  "age50Resident": {
+    "$numberInt": "1434"
+  },
+  "age60PlusResident": {
+    "$numberInt": "2119"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "630"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "387"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "379"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "610"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "716"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "930"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "843"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "436"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "434"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "691"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "718"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "1189"
+  },
+  "totalHouseholds": {
+    "$numberInt": "3007"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "3007"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202b2"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680656"
+  },
+  "adstrdName": "도곡2동",
+  "totalResident": {
+    "$numberInt": "32648"
+  },
+  "maleResident": {
+    "$numberInt": "15135"
+  },
+  "femaleResident": {
+    "$numberInt": "17513"
+  },
+  "age10Resident": {
+    "$numberInt": "7204"
+  },
+  "age20Resident": {
+    "$numberInt": "3520"
+  },
+  "age30Resident": {
+    "$numberInt": "3007"
+  },
+  "age40Resident": {
+    "$numberInt": "6127"
+  },
+  "age50Resident": {
+    "$numberInt": "5568"
+  },
+  "age60PlusResident": {
+    "$numberInt": "7222"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3363"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1568"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1279"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2682"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2771"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "3472"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "3841"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1952"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1728"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "3445"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2797"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3750"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11471"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11471"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202b3"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680750"
+  },
+  "adstrdName": "수서동",
+  "totalResident": {
+    "$numberInt": "14026"
+  },
+  "maleResident": {
+    "$numberInt": "6312"
+  },
+  "femaleResident": {
+    "$numberInt": "7714"
+  },
+  "age10Resident": {
+    "$numberInt": "1011"
+  },
+  "age20Resident": {
+    "$numberInt": "1134"
+  },
+  "age30Resident": {
+    "$numberInt": "1895"
+  },
+  "age40Resident": {
+    "$numberInt": "1573"
+  },
+  "age50Resident": {
+    "$numberInt": "1854"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6559"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "494"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "578"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "951"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "798"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "843"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2648"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "517"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "556"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "944"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "775"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1011"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3911"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7719"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7719"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202b4"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11680720"
+  },
+  "adstrdName": "일원본동",
+  "totalResident": {
+    "$numberInt": "22796"
+  },
+  "maleResident": {
+    "$numberInt": "11239"
+  },
+  "femaleResident": {
+    "$numberInt": "11557"
+  },
+  "age10Resident": {
+    "$numberInt": "5022"
+  },
+  "age20Resident": {
+    "$numberInt": "2258"
+  },
+  "age30Resident": {
+    "$numberInt": "2549"
+  },
+  "age40Resident": {
+    "$numberInt": "4257"
+  },
+  "age50Resident": {
+    "$numberInt": "3663"
+  },
+  "age60PlusResident": {
+    "$numberInt": "5047"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "2895"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1173"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1177"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1911"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1777"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2306"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2127"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1085"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1372"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2346"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1886"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2741"
+  },
+  "totalHouseholds": {
+    "$numberInt": "7994"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "7994"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202b5"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11305575"
+  },
+  "adstrdName": "삼각산동",
+  "totalResident": {
+    "$numberInt": "30604"
+  },
+  "maleResident": {
+    "$numberInt": "14688"
+  },
+  "femaleResident": {
+    "$numberInt": "15916"
+  },
+  "age10Resident": {
+    "$numberInt": "6040"
+  },
+  "age20Resident": {
+    "$numberInt": "3295"
+  },
+  "age30Resident": {
+    "$numberInt": "3197"
+  },
+  "age40Resident": {
+    "$numberInt": "5643"
+  },
+  "age50Resident": {
+    "$numberInt": "5510"
+  },
+  "age60PlusResident": {
+    "$numberInt": "6919"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "3112"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1629"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "1510"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "2687"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "2762"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2988"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "2928"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1666"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "1687"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "2956"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "2748"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "3931"
+  },
+  "totalHouseholds": {
+    "$numberInt": "11515"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "11515"
+  }
+},
+{
+  "_id": {
+    "$oid": "68a81c699631f01cc00202b6"
+  },
+  "period": {
+    "$numberInt": "20251"
+  },
+  "adstrdCode": {
+    "$numberInt": "11740540"
+  },
+  "adstrdName": "명일2동",
+  "totalResident": {
+    "$numberInt": "17034"
+  },
+  "maleResident": {
+    "$numberInt": "8298"
+  },
+  "femaleResident": {
+    "$numberInt": "8736"
+  },
+  "age10Resident": {
+    "$numberInt": "3313"
+  },
+  "age20Resident": {
+    "$numberInt": "2117"
+  },
+  "age30Resident": {
+    "$numberInt": "1797"
+  },
+  "age40Resident": {
+    "$numberInt": "2939"
+  },
+  "age50Resident": {
+    "$numberInt": "2672"
+  },
+  "age60PlusResident": {
+    "$numberInt": "4196"
+  },
+  "maleAge10Resident": {
+    "$numberInt": "1797"
+  },
+  "maleAge20Resident": {
+    "$numberInt": "1015"
+  },
+  "maleAge30Resident": {
+    "$numberInt": "850"
+  },
+  "maleAge40Resident": {
+    "$numberInt": "1299"
+  },
+  "maleAge50Resident": {
+    "$numberInt": "1332"
+  },
+  "maleAge60PlusResident": {
+    "$numberInt": "2005"
+  },
+  "femaleAge10Resident": {
+    "$numberInt": "1516"
+  },
+  "femaleAge20Resident": {
+    "$numberInt": "1102"
+  },
+  "femaleAge30Resident": {
+    "$numberInt": "947"
+  },
+  "femaleAge40Resident": {
+    "$numberInt": "1640"
+  },
+  "femaleAge50Resident": {
+    "$numberInt": "1340"
+  },
+  "femaleAge60PlusResident": {
+    "$numberInt": "2191"
+  },
+  "totalHouseholds": {
+    "$numberInt": "6424"
+  },
+  "apartmentHouseholds": {
+    "$numberInt": "0"
+  },
+  "nonApartmentHouseholds": {
+    "$numberInt": "6424"
+  }
+}]

--- a/src/main/java/com/likelion/cleopatra/domain/incomeConsumption/service/IncomeConsumptionService.java
+++ b/src/main/java/com/likelion/cleopatra/domain/incomeConsumption/service/IncomeConsumptionService.java
@@ -3,12 +3,13 @@ package com.likelion.cleopatra.domain.incomeConsumption.service;
 import com.likelion.cleopatra.domain.incomeConsumption.document.IncomeConsumptionDoc;
 import com.likelion.cleopatra.domain.incomeConsumption.dto.IncomeConsumptionRes;
 import com.likelion.cleopatra.domain.incomeConsumption.dto.consumption.Consumption;
-import com.likelion.cleopatra.domain.incomeConsumption.dto.description.DescriptionIncomeConsumption;
 import com.likelion.cleopatra.domain.incomeConsumption.dto.income.Income;
 import com.likelion.cleopatra.domain.incomeConsumption.repository.IncomeConsumptionRepository;
 import com.likelion.cleopatra.domain.report.dto.report.ReportReq;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.text.Normalizer;
 
 @RequiredArgsConstructor
 @Service
@@ -18,11 +19,21 @@ public class IncomeConsumptionService {
 
     public IncomeConsumptionRes getIncomeConsumptionData(ReportReq req) {
 
-        IncomeConsumptionDoc doc = incomeConsumptionRepository.findByAdstrdName(req.getSub_neighborhood())
-                .orElseThrow(() -> new IllegalArgumentException("population not found: " + req.getSub_neighborhood()));
+        String key = normalizeDong(req.getSub_neighborhood());
+
+        IncomeConsumptionDoc doc = incomeConsumptionRepository.findByAdstrdName(key)
+                .orElseThrow(() -> new IllegalArgumentException("income/consumption not found: " + key));
 
         Income income = Income.from(doc);
         Consumption consumption = Consumption.from(doc);
         return IncomeConsumptionRes.from(income, consumption);
+    }
+
+    /** "공릉 1동", 전각숫자, NBSP 등 → "공릉1동" 으로 정규화 */
+    private String normalizeDong(String s) {
+        if (s == null) throw new IllegalArgumentException("sub_neighborhood is null");
+        String t = Normalizer.normalize(s, Normalizer.Form.NFKC);
+        t = t.replace('\u00A0', ' ').trim();
+        return t.replaceAll("\\s+", "");
     }
 }

--- a/src/main/java/com/likelion/cleopatra/domain/population/service/PopulationService.java
+++ b/src/main/java/com/likelion/cleopatra/domain/population/service/PopulationService.java
@@ -3,13 +3,14 @@ package com.likelion.cleopatra.domain.population.service;
 import com.likelion.cleopatra.domain.population.document.PopulationDoc;
 import com.likelion.cleopatra.domain.population.dto.PopulationRes;
 import com.likelion.cleopatra.domain.population.dto.age.Ages;
-import com.likelion.cleopatra.domain.population.dto.description.DescriptionPopulation;
 import com.likelion.cleopatra.domain.population.dto.gender.Gender;
 import com.likelion.cleopatra.domain.population.repository.PopulationRepository;
 import com.likelion.cleopatra.domain.report.dto.report.ReportReq;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.text.Normalizer;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -19,15 +20,25 @@ public class PopulationService {
     private final PopulationRepository populationRepository;
 
     public PopulationRes getPopulationData(ReportReq req) {
+        final String raw = req.getSub_neighborhood();
+        final String key = normalizeDong(raw); // ==> "공릉1동" 으로 고정
 
-        PopulationDoc doc = populationRepository.findByAdstrdName(req.getSub_neighborhood())
-                .orElseThrow(() -> new IllegalArgumentException("population not found: " + req.getSub_neighborhood()));
+        PopulationDoc doc = populationRepository.findByAdstrdName(key)
+                .orElseThrow(() -> new IllegalArgumentException("population not found: " + key));
 
-        Ages ages = Ages.from(doc);
-        Gender gender = Gender.from(doc);
-        PopulationRes res = PopulationRes.from(ages, gender);
-        log.debug("[Population] population data created: populationRes = {}", res.toString());
-        return res;
+        return PopulationRes.from(Ages.from(doc), Gender.from(doc));
     }
 
+    /** "공릉 1 동", 전각숫자, NBSP 등을 모두 "공릉1동"으로 정규화 */
+    private String normalizeDong(String s) {
+        if (s == null) throw new IllegalArgumentException("sub_neighborhood is null");
+        // 전각 -> 반각, 조합문자 정규화
+        String t = Normalizer.normalize(s, Normalizer.Form.NFKC);
+        // NBSP 제거 후 트림
+        t = t.replace('\u00A0', ' ').trim();
+        // 내부 공백 전부 제거 (공릉 1 동 -> 공릉1동)
+        t = t.replaceAll("\\s+", "");
+        // 접미사 "동"은 그대로 두되 불필요한 마침표 등 제거 필요시 추가
+        return t;
+    }
 }


### PR DESCRIPTION
prod 환경에서 IncomeConsumptionService, PopulationService에서 sub_neighborhood가 "공릉 1동"처럼 내부 공백/NBSP/전각숫자 등으로 들어오는 케이스 해결

# ✒️ 관련 이슈번호
> - #18 


   
# 🔑 Key Changes
> prod에선 sub_neighborhood가 "공릉 1동"처럼 내부 공백/NBSP/전각숫자 등으로 들어오는 케이스

요구대로 “항상 공릉1동 포맷으로만 조회”하도록 입력을 정규화

   
# 📢 To Reviewers

